### PR TITLE
Fixed: 'standard' color shell has light-themed activities button now

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -82,6 +82,7 @@ install() {
 
   [[ "$color" == '-dark' ]] && local ELSE_DARK="$color"
   [[ "$color" == '-light' ]] && local ELSE_LIGHT="$color"
+  [[ "$color" == '-dark' ]] || [[ "$color" == '' ]] && local ACTIVITIES_ASSETS_SUFFIX="-dark"
 
   if [[ "$window" == 'round' ]]; then
     round='-round'
@@ -133,7 +134,7 @@ install() {
   cp -r "${SRC_DIR}/gnome-shell/common-assets"                                  "$THEME_DIR/gnome-shell/assets"
   cp -r "${SRC_DIR}/gnome-shell/assets${ELSE_DARK:-}/"*.svg                     "$THEME_DIR/gnome-shell/assets"
   cp -r "${SRC_DIR}/gnome-shell/theme$theme/"*.svg                              "$THEME_DIR/gnome-shell/assets"
-  cp -r "${SRC_DIR}/gnome-shell/assets${ELSE_DARK:-}/activities/activities${icon}.svg" "$THEME_DIR/gnome-shell/assets/activities.svg"
+  cp -r "${SRC_DIR}/gnome-shell/assets${ACTIVITIES_ASSETS_SUFFIX:-}/activities/activities${icon}.svg" "$THEME_DIR/gnome-shell/assets/activities.svg"
 
   if [[ "$window" = "round" ]] ; then
     cp -r "${SRC_DIR}/gnome-shell/assets${ELSE_DARK:-}/buttons-round/"*.svg     "$THEME_DIR/gnome-shell/assets"


### PR DESCRIPTION
Light theme by default has a dark activities button, where dark does have light one.
But the standard is kinda mixture of both of them - The panel is dark, where the dropdowns and everything else is light.

This PR aims to solve the issue where the standard theme uses black activities button on top of black panel.

Result:
![Screenshot from 2021-11-24 16-32-10](https://user-images.githubusercontent.com/91674633/143267729-da9797df-ec43-40f2-9bb5-178b8c6b3653.png)