### PR TITLE
KindaFix: Make activities button text font-size to 0

### DIFF
--- a/src/gnome-shell/sass/widgets/_panel.scss
+++ b/src/gnome-shell/sass/widgets/_panel.scss
@@ -128,6 +128,7 @@ $panel_transition_duration: 250ms; // same as the overview transition duration
       background-repeat: no-repeat;
       background-size: auto;
       color: transparent !important;
+      font-size: 0;
       box-shadow: none;
 
       > * { width: $medium_size; }


### PR DESCRIPTION
The activities text is hidden by default using the css `color` property, which makes it transparent.
Some of the extensions (i.e. Transparent Top Bar) are applying shadows to text, which makes it visible again, overlapping with the icon.

This PR is a more-permament way of hiding the "Activities" text, making this theme compatible with extensions managing top-bar transparency.