### PR TITLE
Fix lock-dialog background colors

### DIFF
--- a/src/_sass/gtk/apps/_mate.scss
+++ b/src/_sass/gtk/apps/_mate.scss
@@ -464,7 +464,10 @@ na-tray-applet widget box widget {
   box-shadow: $shadow-z6, inset 0 1px highlight($surface); // not sure if box-shadow works here
   background-color: $surface;
 
-  frame > border { border-style: none; }
+  frame > border { 
+    border-style: none; 
+    background-color: transparent;
+  }
 
   button {
     @extend %button-flat;

--- a/src/_sass/gtk/apps/_mate.scss
+++ b/src/_sass/gtk/apps/_mate.scss
@@ -460,15 +460,14 @@ na-tray-applet widget box widget {
 /* mate-screensaver lock dialog */
 .lock-dialog {
   border: 1px solid $frame;
-  border-radius: $corner-radius + 1px;
-  box-shadow: $shadow-z6, inset 0 1px highlight($surface); // not sure if box-shadow works here
+  border-radius: 0; // Using rounded corners will reveal a black background
   background-color: $surface;
 
   notebook { 
     background-color: $surface;
   }
 
-  frame > border { border-style: none; margin: 0; }
+  frame > border { border-style: none; border-color: transparent; }
 
   button {
     @extend %button-flat;

--- a/src/_sass/gtk/apps/_mate.scss
+++ b/src/_sass/gtk/apps/_mate.scss
@@ -464,10 +464,11 @@ na-tray-applet widget box widget {
   box-shadow: $shadow-z6, inset 0 1px highlight($surface); // not sure if box-shadow works here
   background-color: $surface;
 
-  frame > border { 
-    border-style: none; 
-    background-color: transparent;
+  notebook { 
+    background-color: $surface;
   }
+
+  frame > border { border-style: none; margin: 0; }
 
   button {
     @extend %button-flat;


### PR DESCRIPTION
Ref #100 

- Fix background color not fully applied to MATE screensaver and Budgie screensaver

Remove incompatible code:
- Box shadow does not work
- Border radius will reveal a black background ([see here](https://user-images.githubusercontent.com/2727095/164174036-26027f08-9006-43f3-81bc-1498a3911507.jpg)) this is because of the way Screensaver renders

![PXL_20220421_014339765 MP](https://user-images.githubusercontent.com/2727095/164355050-be829e11-4848-4e35-824b-e0ad9457bef6.jpg)
