### PR TITLE
Fix fallback gnome shell version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,7 +43,7 @@ if [[ "$(command -v gnome-shell)" ]]; then
   fi
   else
     echo "'gnome-shell' not found, using styles for last gnome-shell version available."
-    GS_VERSION="42"
+    GS_VERSION="42-0"
 fi
 
 usage() {


### PR DESCRIPTION
Set the correct default gnome shell version in the install script to prevent a file not found error.