### PR TITLE
fix hint-text and caret color

### DIFF
--- a/src/gnome-shell/sass/_drawing.scss
+++ b/src/gnome-shell/sass/_drawing.scss
@@ -151,7 +151,7 @@
 //
 
   @if $t == normal {
-    caret-color: rgba(black, 0.75);
+    caret-color: rgba(white, 0.75);
     color: rgba(black, 0.75);
     background-color: rgba(white, 0.75);
     border-color: transparent;

--- a/src/gnome-shell/sass/widgets/_search-entry.scss
+++ b/src/gnome-shell/sass/widgets/_search-entry.scss
@@ -34,7 +34,7 @@ $search_entry_width: 320px;
 
   StLabel.hint-text {
     margin-left: 2px;
-    color: rgba(black, 0.35);
+    color: rgba(white, 0.35);
   }
 }
 


### PR DESCRIPTION
Related issue: https://github.com/vinceliuice/Fluent-gtk-theme/issues/122

Before:
![image](https://user-images.githubusercontent.com/26806995/187064853-7d3c9731-7e8c-4c9a-8e58-5180c7a52698.png)

After:
![image](https://user-images.githubusercontent.com/26806995/187066526-b7969c94-d94f-4bdd-bca0-1d0602874913.png)
