### PR TITLE
Fix for GTK4 DING

### DIFF
--- a/src/_sass/gtk/_common-4.0.scss
+++ b/src/_sass/gtk/_common-4.0.scss
@@ -15,6 +15,10 @@
   }
 }
 
+#desktopwindow.background {
+  background-color: transparent;
+}
+
 dnd {
   color: on($background);
 }


### PR DESCRIPTION
Quick fix to make the Gtk4 DING extension for GNOME Shell work properly with Fluent.