### PR TITLE
cinnamon.css: fix calendar applet scaled text bug

### DIFF
--- a/src/_sass/cinnamon/_common.scss
+++ b/src/_sass/cinnamon/_common.scss
@@ -756,6 +756,7 @@ StScrollBar {
 
 .calendar-day-base {
   text-align: center;
+  min-width: 28px;
   height: 28px;
   padding: 0;
   margin: 2px;
@@ -815,6 +816,7 @@ StScrollBar {
 }
 
 .calendar-week-number {
+  min-width: 20px;
   height: 20px;
   margin: 6px 0;
   color: $track;

--- a/src/_sass/cinnamon/_common.scss
+++ b/src/_sass/cinnamon/_common.scss
@@ -756,7 +756,6 @@ StScrollBar {
 
 .calendar-day-base {
   text-align: center;
-  width: 28px;
   height: 28px;
   padding: 0;
   margin: 2px;
@@ -816,7 +815,6 @@ StScrollBar {
 }
 
 .calendar-week-number {
-  width: 20px;
   height: 20px;
   margin: 6px 0;
   color: $track;


### PR DESCRIPTION
Cinnamon calendar applet: remove width limit to allow for larger font sizes or cinnamon text scaling.

cf. https://github.com/vinceliuice/Orchis-theme/pull/446