### PR TITLE
Fixes button overlapping issues on GNOME 48

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -38,7 +38,9 @@ SIZE_VARIANTS=('' '-compact')
 if [[ "$(command -v gnome-shell)" ]]; then
   gnome-shell --version
   SHELL_VERSION="$(gnome-shell --version | cut -d ' ' -f 3 | cut -d . -f -1)"
-  if [[ "${SHELL_VERSION:-}" -ge "47" ]]; then
+  if [[ "${SHELL_VERSION:-}" -ge "48" ]]; then
+    GS_VERSION="48-0"
+  elif [[ "${SHELL_VERSION:-}" -ge "47" ]]; then
     GS_VERSION="47-0"
   elif [[ "${SHELL_VERSION:-}" -ge "46" ]]; then
     GS_VERSION="46-0"

--- a/parse-sass.sh
+++ b/parse-sass.sh
@@ -60,6 +60,7 @@ for color in "${_COLOR_VARIANTS[@]}"; do
     sassc "${SASSC_OPT[@]}" "src/gnome-shell/shell-44-0/gnome-shell$color$size."{scss,css}
     sassc "${SASSC_OPT[@]}" "src/gnome-shell/shell-46-0/gnome-shell$color$size."{scss,css}
     sassc "${SASSC_OPT[@]}" "src/gnome-shell/shell-47-0/gnome-shell$color$size."{scss,css}
+    sassc "${SASSC_OPT[@]}" "src/gnome-shell/shell-48-0/gnome-shell$color$size."{scss,css}
     sassc "${SASSC_OPT[@]}" "src/cinnamon/cinnamon$color$size."{scss,css}
   done
 done

--- a/src/gnome-shell/sass/_widgets-48-0.scss
+++ b/src/gnome-shell/sass/_widgets-48-0.scss
@@ -1,0 +1,53 @@
+//
+// Shell widgets stylesheets are placed in separate .scss files
+// in 'widgets' and imported into the main stylesheet in this file.
+// To create or update a widget for the shell modify the list below.
+//
+
+/* WIDGETS */
+
+// Primary widgets
+@import 'widgets/base';
+@import 'widgets/entries';
+@import 'widgets/buttons';
+@import 'widgets/check-box-47';
+@import 'widgets/switches-47';
+@import 'widgets/slider-47';
+@import 'widgets/scrollbars';
+// Popovers
+@import 'widgets/popovers-47';
+@import 'widgets/calendar-46';
+@import 'widgets/message-list-48';
+@import 'widgets/ibus-popup';
+// Notifications
+@import 'widgets/notifications-47';
+@import 'widgets/hotplug';
+// Dialogs
+@import 'widgets/dialogs-47';
+@import 'widgets/network-dialog';
+// OSDs
+@import 'widgets/osd-42';
+@import 'widgets/switcher-popup';
+@import 'widgets/workspace-switcher';
+// Panel
+@import 'widgets/panel';
+@import 'widgets/corner-ripple';
+// Overview
+@import 'widgets/overview';
+@import 'widgets/window-picker';
+@import 'widgets/search-entry';
+@import 'widgets/search-results-46';
+@import 'widgets/dash-46';
+@import 'widgets/app-grid-46';
+@import 'widgets/workspace-thumbnails';
+// A11y / misc
+@import 'widgets/a11y';
+@import 'widgets/misc';
+@import 'widgets/tiled-previews';
+@import 'widgets/keyboard';
+@import 'widgets/looking-glass';
+@import 'widgets/quick-settings-48';
+@import 'widgets/screenshot';
+// Lock / login screens
+@import 'widgets/login-dialog';
+@import 'widgets/screen-shield';

--- a/src/gnome-shell/sass/widgets/_message-list-48.scss
+++ b/src/gnome-shell/sass/widgets/_message-list-48.scss
@@ -1,0 +1,269 @@
+/* Message List */
+// a.k.a. notifications in the menu
+
+// main list
+.message-list {
+  width: 29em;
+  padding: 0;
+  color: $secondary_fg_color;
+  text-shadow: none;
+  box-shadow: none;
+  border: 0 solid $border_color;
+
+  // padding and margins to account for scrollbar
+  &:ltr {
+    margin-left: $container_padding;
+    margin-right: 0;
+    padding-right: $container_padding * 2;
+    border-right-width: 1px;
+  }
+
+  &:rtl {
+    margin-right: $container_padding;
+    margin-left: 0;
+    padding-left: $container_padding * 2;
+    border-left-width: 1px;
+  }
+
+  .message-list-placeholder {
+    @extend %title_2;
+    color: $disabled_secondary_fg_color;
+
+    // icon size and color
+    > StIcon {
+      icon-size: 96px; // 48px
+      margin-bottom: $container_margin * 3;
+      -st-icon-style: symbolic;
+    }
+  }
+}
+
+.message-view {
+  // to account for scrollbar
+  &:ltr { margin-right: 0; }
+  &:rtl { margin-left: 0; }
+
+  -st-vfade-offset: 68px;
+
+  .message {
+    margin-bottom: $container_padding * 2 !important;
+  }
+}
+
+// do-not-disturb + clear button
+.message-list-controls {
+  // NOTE: remove the padding if notification_bubble could remove margin for drop shadow
+  padding: $container_padding * 2;
+  padding-bottom: $container_padding;
+  spacing: $container_padding;
+  @extend %heading;
+    .dnd-button {
+    // We need this because the focus outline isn't inset like for the buttons
+    // so the dnd button would grow when it gets focus if we didn't change only
+    // its color when focusing.
+    border-width: 2px;
+    border-color: transparent;
+    border-radius: 32px;
+    border-style: solid;
+
+    &:focus {
+      border-color: transparentize($primary_color, 0.4);
+    }
+  }
+}
+
+// message notification group
+.message-notification-group {
+  spacing: $container_padding * 2;
+
+  .message-group-header {
+    padding: $container_padding;
+    .message-group-title {
+      @extend %title_2;
+      margin: 0 $container_margin;
+    }
+  }
+
+  // close button
+  .message-collapse-button {
+    @extend .icon-button;
+    color: $fg_color;
+    background-color: transparentize($fg_color, 0.8);
+    padding: 4px;
+    &:hover { background-color: transparentize($fg_color, 0.7); }
+    &:active { background-color: transparentize($fg_color, 0.8); }
+  }
+}
+
+// message bubbles
+.message {
+  background-color: $popover_button_bg;
+  border-radius: $buttons_radius;
+  color: $secondary_fg_color;
+  text-shadow: none;
+  padding: 0;
+  margin: $container_margin;
+  box-shadow: 0 3px 8px -2px rgba(black, 0.15);
+  background-color: rgba($base_color, 0.95);
+  border: 1px solid transparent;
+  border-left: none;
+  border-bottom: none;
+
+  &:hover, &:focus, &:active { background-color: $base_color; }
+
+  .popup-menu & {
+    margin: 0 0 $container_margin;
+    box-shadow: none;
+    background-color: $popover_button_bg;
+    border-radius: $buttons_radius;
+    color: $secondary_fg_color;
+    border: 1px solid $popover_button_border;
+
+    &:hover, &:focus {
+      background-color: $popover_button_hover;
+      border-color: if($variant == 'light', rgba(black, 0.15), rgba(white, 0.08));
+    }
+  
+    &:active { background-color: $popover_button_active; }
+  }
+
+  &:second-in-stack {
+    box-shadow: 0 1px 3px rgba(black, 0.05);
+  }
+
+  &:lower-in-stack {
+    box-shadow: none;
+    // border-color: if($variant == 'light', darken($card_bg_color, 10%), transparent); // a not ideal workaround for light theme
+  }
+
+  // message header
+  .message-header {
+    padding: 0 $scaled_padding;
+    spacing: $container_padding;
+    color: $disabled_fg_color;
+
+    // remove side padding to accommodate the close button
+    &:ltr { padding-right: 0; }
+    &:rtl { padding-left: 0; }
+
+    // header source icon
+    .message-source-icon {
+      icon-size: $scalable_icon_size; // 16px
+      -st-icon-style: symbolic;
+    }
+
+    // box that contains the source icon, source name and timestamp of the message
+    .message-header-content {
+      spacing: $container_padding;
+      min-height: to_em(24px);
+      padding-bottom: $container_padding;
+
+      // header source title
+      .message-source-title {
+        font-weight: bold;
+      }
+
+      // Time label
+      .event-time {
+        @extend %caption;
+        color: $disabled_fg_color;
+        // Add bottom padding to align the app name with the time horizontally
+        padding-bottom: to_em(1px);
+
+        &:ltr { text-align: right; }
+        &:rtl { text-align: left; }
+      }
+    }
+
+    // buttons in the message header
+    .message-expand-button,
+    .message-close-button {
+      @extend .icon-button;
+      color: $fg_color;
+      background-color: transparentize($fg_color, .9);
+      padding: 4px;
+      &:hover { background-color: transparentize($fg_color, .81);}
+      &:active,
+      &:active:hover { background-color: transparentize($fg_color, .76);}
+      &:insensitive { background-color: transparentize($fg_color, .93);}
+    }
+
+    .message-expand-button {
+      padding: 6px;
+      &:ltr { margin-right: $container_padding; }
+      &:rtl { margin-left: $container_padding; }
+    }
+  }
+
+  // container for message contents
+  .message-box {
+    padding: $container_padding;
+    margin: $container_padding;
+    margin-top: 0;
+    spacing: $container_padding;
+
+    // icon of the message
+    .message-icon {
+      &:ltr { margin-right:$container_padding; }
+      &:rtl { margin-left:$container_padding; }
+
+      // icon size and color
+      icon-size: $base_icon_size * 3; // 48px
+      -st-icon-style: symbolic;
+
+      &.message-themed-icon {
+        border-radius: $circular_radius; // is circular
+        background-color: transparentize($fg_color, 0.8);
+        icon-size: $base_icon_size;
+        min-width: $base_icon_size * 3;
+        min-height: $base_icon_size * 3;
+      }
+    }
+
+    // If the header isn't displayed we need more top margin
+    &:first-child {
+      margin-top: $container_padding * 2;
+    }
+
+    // text of the message
+    .message-content {
+      spacing: $container_margin;
+
+      // message title
+      .message-title {
+        font-weight: bold;
+      }
+    }
+  }
+}
+
+// URLs in messages
+.url-highlighter {
+  link-color: $link_color;
+}
+
+/* Media Controls */
+.message-media-control {
+  margin: 4px 0;
+  padding: 0 $container_padding * 2;
+  border-radius: $circular_radius;
+  color: $secondary_fg_color;
+  border: none;
+
+  &:hover, &:focus { color: $fg_color; background-color: $divider_color; }
+  &:active { color: $fg_color; background-color: $track_color; }
+  &:insensitive { color: $disabled_secondary_fg_color; }
+
+  & StIcon { icon-size: $base_icon_size; }
+}
+
+.media-message {
+  // album-art
+  .message-icon {
+    border-radius: $buttons_radius !important;
+
+    &.message-themed-icon {
+      icon-size: $large_icon_size !important; // 32px
+    }
+  }
+}

--- a/src/gnome-shell/sass/widgets/_quick-settings-48.scss
+++ b/src/gnome-shell/sass/widgets/_quick-settings-48.scss
@@ -1,0 +1,307 @@
+.quick-settings {
+  border-radius: $menu_radius !important;
+  margin: $container_padding !important;
+
+  @if $laptop == 'false' {
+    padding: 10px 6px + $container_padding 14px !important;
+  } @else {
+    padding: 8px 6px + $container_padding 12px !important;
+  }
+
+  .icon-button, .button {
+    padding: $container_padding * 1.5;
+
+    > StIcon {
+      icon-size: 16px;
+    }
+  }
+}
+  
+  .quick-settings-grid {
+    spacing-rows: $container_padding * 2;
+    spacing-columns: $container_padding * 2;
+  }
+  
+  .quick-toggle, .quick-menu-toggle {
+    border-radius: $buttons_radius;
+    min-width: 12em;
+    max-width: 12em;
+    min-height: $container_padding * 3 + 26px;
+    padding: 0;
+    border: none;
+  }
+  
+  .quick-toggle {
+    background-color: rgba($fg_color, 0.06) !important;
+    
+    &:hover {
+      background-color: rgba($fg_color, 0.12) !important;
+    }
+    
+    &:active {
+      background-color: rgba($fg_color, 0.15) !important;
+    }
+    
+    &:checked {
+      background-color: $primary_color !important;
+      color: white;
+      
+      &:hover {
+        background-color: mix($fg_color, $primary_color, 6%) !important;
+        color: white;
+      }
+      
+      &:active {
+        background-color: mix($fg_color, $primary_color, 15%) !important;
+        color: white;
+      }
+    }
+  
+    & > StBoxLayout { spacing: $container_padding * 1.5; }
+  
+    /* Move padding into the box; this is to allow menu arrows
+       to extend to the border */
+    &.button { padding: 0; }
+    & > StBoxLayout { padding: 0 $container_padding * 2; }
+    &:ltr > StBoxLayout { padding-left: $container_padding * 4; }
+    &:rtl > StBoxLayout { padding-right: $container_padding * 4; }
+  
+    .quick-toggle-title {
+      font-weight: bold;
+    }
+  
+    & StBoxLayout > .quick-toggle-subtitle {
+      font-weight: normal;
+      font-size: 12px;
+    }
+  
+    .quick-toggle-icon { icon-size: 16px; }
+  }
+  
+  .quick-toggle-has-menu {
+    & .quick-toggle {
+      min-width: auto;
+      max-width: auto;
+  
+      &:ltr { border-radius: $buttons_radius 0 0 $buttons_radius; }
+      &:ltr > StBoxLayout { padding-right: $container_padding * 2; }
+      &:rtl { border-radius: 0 $buttons_radius $buttons_radius 0; }
+      &:rtr > StBoxLayout { padding-left: $container_padding * 2; }
+  
+      &:ltr:last-child { border-radius: $buttons_radius; }
+      &:rtl:last-child { border-radius: $buttons_radius; }
+    }
+  
+    & .quick-toggle-menu-button {
+      padding: $container_padding $container_padding * 2;
+      border: none;
+      background-color: rgba($fg_color, 0.06) !important;
+  
+      &:hover {
+        background-color: rgba($fg_color, 0.12) !important;
+      }
+    
+      &:active {
+        background-color: rgba($fg_color, 0.15) !important;
+      }
+    
+      &:checked {
+        background-color: $primary_color !important;
+        color: white;
+    
+        &:hover {
+          color: white;
+          background-color: st-mix($fg_color, $primary_color, 6%) !important;
+        }
+    
+        &:active {
+          color: white;
+          background-color: st-mix($fg_color, $primary_color, 15%) !important;
+        }
+      }
+  
+      &:ltr {
+        border-radius: 0 $buttons_radius $buttons_radius 0;
+        border-left-width: 0;
+      }
+  
+      &:rtl {
+        border-radius: $buttons_radius 0 0 $buttons_radius;
+        border-right-width: 0;
+      }
+    }
+  
+    & .quick-toggle-separator {
+      width: 0;
+    }
+  }
+  
+  .quick-slider {
+    & > StBoxLayout { spacing: $container_padding; }
+  
+    .slider-bin {
+      &:focus { @include button(focus); }
+      min-height: 16px; // slider size
+      padding: $container_padding;
+      border-radius: $circular_radius;
+    }
+  
+    .quick-toggle-icon {
+      icon-size: 16px;
+    }
+  
+    .icon-button {
+      min-width: 22px;
+      min-height: 22px;
+      background-color: transparent;
+      color: $fg_color !important;
+  
+      &:hover {
+        background-color: rgba($fg_color, 0.06);
+      }
+  
+      &:active {
+        background-color: rgba($fg_color, 0.12);
+      }
+    }
+  }
+  
+  .quick-toggle-menu {
+    background-color: lighten($base_color, 5%) !important;
+    color: $fg_color !important;
+    border-radius: $menu_radius !important;
+    padding: $container_padding * 3;
+    margin: $container_padding * 2 $container_padding * 6 0;
+    border: none !important;
+  
+    .popup-menu-item {
+      border-radius: $buttons_radius !important;
+      min-height: 20px;
+  
+      &:focus, &:hover, &.selected {
+        color: $fg_color !important;
+        background-color: rgba($fg_color, 0.1) !important;
+      }
+  
+      &:active {
+        color: $fg_color !important;
+        background-color: rgba($fg_color, 0.2) !important;
+      }
+  
+      > StIcon { -st-icon-style: symbolic; }
+    }
+  
+    & .header {
+      spacing-rows: 0.5 * $container_padding;
+      spacing-columns: $container_padding * 2;
+      padding-bottom: 2 * $container_padding;
+  
+      & .icon {
+        icon-size: 16px * 1.5; // a non-standard symbolic size but ok
+        border-radius: $buttons_radius;
+        padding: 1.5 * $container_padding;
+        background-color: rgba($fg_color, 0.06) !important;
+  
+        &.active {
+          background-color: $primary_color !important;
+          color: white;
+        }
+      }
+  
+      & .title {
+        @extend %title_3;
+      }
+  
+      & .subtitle {
+        @extend %caption_heading;
+      }
+    }
+  }
+  
+  .quick-settings-system-item {
+    & > StBoxLayout { spacing: 2 * $container_padding; }
+  
+    .icon-button {
+      background-color: $divider_color;
+      color: $fg_color;
+      border-radius: $buttons_radius;
+      min-height: 22px;
+      min-width: 22px !important;
+      // padding: $container_padding;
+  
+      &:hover {
+        background-color: $visit_color;
+      }
+  
+      &:active {
+        background-color: $track_color;
+      }
+  
+      > StIcon {
+       -st-icon-style: symbolic;
+       icon-size: 16px;
+      }
+    }
+  
+    & .power-item {
+      min-height: 0;
+      min-width: 0;
+  
+      &:insensitive {
+        @include button(normal);
+        background-color: transparent;
+      }
+    }
+  }
+  
+  .nm-network-item {
+    .wireless-secure-icon { icon-size: 0.5 * 16px; }
+  }
+  
+  .bt-device-item {
+    .popup-menu-icon { -st-icon-style: symbolic; }
+  }
+  
+  .bt-menu-placeholder.popup-menu-item {
+    @extend %title_4;
+    text-align: center;
+  
+    padding: 2em 4em;
+  }
+  
+  .device-subtitle { color: $disabled_fg_color; }
+  
+  .keyboard-brightness-level {
+    spacing: $container_padding;
+  
+    .button:checked { @extend %default_button; }
+  }
+  
+  // background apps
+  
+  .background-apps-quick-toggle {
+    min-height: 40px;
+    background-color: transparent;
+  
+    & StIcon { icon-size: 16px !important; }
+  }
+  
+  .background-app-item {
+    & .title { @extend %heading; }
+    & .subtitle { @extend %caption; }
+    & .popup-menu-icon {
+      icon-size: 24px !important;
+      -st-icon-style: regular !important;
+    }
+  
+    & .icon-button {
+      @extend .icon-button;
+      padding: $container_padding;
+    }
+  
+    & .spinner {
+      padding: $container_padding;
+    }
+  
+    &.popup-inactive-menu-item { color: $fg_color; }
+  }

--- a/src/gnome-shell/shell-48-0/gnome-shell-Dark-compact.css
+++ b/src/gnome-shell/shell-48-0/gnome-shell-Dark-compact.css
@@ -1,0 +1,4945 @@
+/* This stylesheet is generated, DO NOT EDIT */
+stage {
+  font-size: 9.75pt;
+  font-weight: 400;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+/* Common Stylings */
+#dash .dash-item-container .show-apps,
+#dash .dash-item-container .overview-tile,
+#dash .dash-item-container .grid-search-result,
+#dash .dash-item-container .search-provider-icon,
+#dash .dash-item-container .list-search-result {
+  background: none;
+  box-shadow: none;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  margin: 0;
+}
+
+#dash .dash-item-container .show-apps .overview-icon,
+#dash .dash-item-container .overview-tile .overview-icon,
+#dash .dash-item-container .grid-search-result .overview-icon,
+#dash .dash-item-container .search-provider-icon .overview-icon,
+#dash .dash-item-container .list-search-result .overview-icon {
+  border-radius: 6px;
+  padding: 4px;
+  spacing: 4px;
+  text-align: center;
+  transition-duration: 100ms;
+}
+
+.search-statustext {
+  font-size: 45px;
+  font-weight: 400;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.popup-menu-content {
+  background: rgba(32, 32, 32, 0.97);
+  color: rgba(255, 255, 255, 0.9);
+  border-radius: 3px;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.1);
+}
+
+.modal-dialog {
+  background: rgba(32, 32, 32, 0.97);
+  color: rgba(255, 255, 255, 0.9);
+  border-radius: 6px;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2);
+}
+
+/* General Typography */
+.message-notification-group .message-group-header .message-group-title, .message-list .message-list-placeholder {
+  font-weight: 800;
+  font-size: 1.364em;
+}
+
+.quick-toggle-menu .header .title {
+  font-weight: 700;
+  font-size: 1.364em;
+}
+
+.bt-menu-placeholder.popup-menu-item {
+  font-weight: 700;
+  font-size: 1.182em;
+}
+
+.background-app-item .title, .message-list-controls, .calendar .calendar-month-header .calendar-month-label {
+  font-weight: 700;
+  font-size: 1em;
+}
+
+.quick-toggle-menu .header .subtitle {
+  font-weight: 700;
+  font-size: 0.818em;
+}
+
+.background-app-item .subtitle, .message .message-header .message-header-content .event-time {
+  font-weight: 400;
+  font-size: 0.818em;
+}
+
+/* WIDGETS */
+.shell-link {
+  border-radius: 3px;
+  color: #3281ea;
+  background-color: transparent;
+}
+
+.shell-link:hover {
+  color: #3281ea;
+  background-color: rgba(50, 129, 234, 0.15);
+}
+
+.shell-link:active {
+  color: #3281ea;
+  background-color: rgba(50, 129, 234, 0.3);
+}
+
+.lowres-icon {
+  icon-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+}
+
+.icon-dropshadow {
+  icon-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+}
+
+/* Entries */
+StEntry {
+  min-height: 24px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  border-width: 0;
+  caret-color: rgba(255, 255, 255, 0.7);
+  selection-background-color: #3281ea;
+  selected-color: #FFFFFF !important;
+  font-size: 11.25pt;
+  font-weight: 400;
+  caret-color: rgba(255, 255, 255, 0.7);
+  color: rgba(255, 255, 255, 0.7);
+  background-color: rgba(255, 255, 255, 0.15);
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+StEntry:hover {
+  border: 2px solid rgba(255, 255, 255, 0.15) !important;
+}
+
+StEntry:focus {
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #3281ea !important;
+}
+
+StEntry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+StEntry StIcon.capslock-warning {
+  icon-size: 16px;
+  warning-color: #FF6D00;
+  padding: 0 0;
+}
+
+StEntry StIcon.peek-password {
+  icon-size: 16px;
+  padding: 0 4px;
+}
+
+StEntry StLabel.hint-text {
+  margin-left: 2px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+/* Buttons */
+.screenshot-ui-show-pointer-button, .screenshot-ui-type-button {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:focus, .screenshot-ui-type-button:focus {
+  color: rgba(255, 255, 255, 0.85);
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:hover, .screenshot-ui-type-button:hover {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.15);
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:active, .screenshot-ui-type-button:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.3);
+  box-shadow: 0 0 transparent;
+}
+
+.screenshot-ui-show-pointer-button:checked, .screenshot-ui-type-button:checked {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #3281ea;
+  border-color: #3281ea;
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:checked:hover, .screenshot-ui-type-button:checked:hover, .screenshot-ui-show-pointer-button:checked:focus, .screenshot-ui-type-button:checked:focus {
+  background-color: #3281ea;
+}
+
+.screenshot-ui-show-pointer-button:insensitive, .screenshot-ui-type-button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.icon-button.flat, .message .message-header .flat.message-expand-button,
+.message .message-header .flat.message-close-button, .message-notification-group .flat.message-collapse-button, .button.flat {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.icon-button.flat:focus, .message .message-header .flat.message-expand-button:focus,
+.message .message-header .flat.message-close-button:focus, .message-notification-group .flat.message-collapse-button:focus, .button.flat:focus {
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: none;
+}
+
+.icon-button.flat:hover, .message .message-header .flat.message-expand-button:hover,
+.message .message-header .flat.message-close-button:hover, .message-notification-group .flat.message-collapse-button:hover, .button.flat:hover {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.06);
+  box-shadow: none;
+}
+
+.icon-button.flat:selected, .message .message-header .flat.message-expand-button:selected,
+.message .message-header .flat.message-close-button:selected, .message-notification-group .flat.message-collapse-button:selected, .button.flat:selected, .icon-button.flat:active, .message .message-header .flat.message-expand-button:active,
+.message .message-header .flat.message-close-button:active, .message-notification-group .flat.message-collapse-button:active, .button.flat:active {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.15);
+  box-shadow: 0 0 transparent;
+}
+
+.icon-button.flat:checked, .message .message-header .flat.message-expand-button:checked,
+.message .message-header .flat.message-close-button:checked, .message-notification-group .flat.message-collapse-button:checked, .button.flat:checked {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.15);
+  box-shadow: 0 0 transparent;
+}
+
+.icon-button.flat:insensitive, .message .message-header .flat.message-expand-button:insensitive,
+.message .message-header .flat.message-close-button:insensitive, .message-notification-group .flat.message-collapse-button:insensitive, .button.flat:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:checked, .icon-button.default, .message .message-header .default.message-expand-button,
+.message .message-header .default.message-close-button, .message-notification-group .default.message-collapse-button, .button.default {
+  color: #FFFFFF;
+  background-color: #3281ea;
+  border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:focus:checked, .icon-button.default:focus, .message .message-header .default.message-expand-button:focus,
+.message .message-header .default.message-close-button:focus, .message-notification-group .default.message-collapse-button:focus, .button.default:focus {
+  color: #3281ea;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.keyboard-brightness-level .button:focus:hover:checked, .icon-button.default:focus:hover, .message .message-header .default.message-expand-button:focus:hover,
+.message .message-header .default.message-close-button:focus:hover, .message-notification-group .default.message-collapse-button:focus:hover, .button.default:focus:hover, .keyboard-brightness-level .button:focus:active:checked, .icon-button.default:focus:active, .message .message-header .default.message-expand-button:focus:active,
+.message .message-header .default.message-close-button:focus:active, .message-notification-group .default.message-collapse-button:focus:active, .button.default:focus:active {
+  color: #3281ea;
+}
+
+.keyboard-brightness-level .button:hover:checked, .icon-button.default:hover, .message .message-header .default.message-expand-button:hover,
+.message .message-header .default.message-close-button:hover, .message-notification-group .default.message-collapse-button:hover, .button.default:hover {
+  color: #FFFFFF;
+  background-color: #3281ea;
+  border-color: rgba(255, 255, 255, 0.15);
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:insensitive:checked, .icon-button.default:insensitive, .message .message-header .default.message-expand-button:insensitive,
+.message .message-header .default.message-close-button:insensitive, .message-notification-group .default.message-collapse-button:insensitive, .button.default:insensitive {
+  color: #FFFFFF;
+  background-color: #3281ea;
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:active:checked, .icon-button.default:active, .message .message-header .default.message-expand-button:active,
+.message .message-header .default.message-close-button:active, .message-notification-group .default.message-collapse-button:active, .button.default:active {
+  color: #FFFFFF;
+  background-color: #498fec;
+  border-color: rgba(255, 255, 255, 0.15);
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:active:hover:checked, .icon-button.default:active:hover, .message .message-header .default.message-expand-button:active:hover,
+.message .message-header .default.message-close-button:active:hover, .message-notification-group .default.message-collapse-button:active:hover, .button.default:active:hover, .keyboard-brightness-level .button:active:focus:checked, .icon-button.default:active:focus, .message .message-header .default.message-expand-button:active:focus,
+.message .message-header .default.message-close-button:active:focus, .message-notification-group .default.message-collapse-button:active:focus, .button.default:active:focus {
+  background-color: #498fec;
+}
+
+.icon-button, .background-app-item .icon-button, .background-app-item .message-notification-group .message-collapse-button, .message-notification-group .background-app-item .message-collapse-button, .background-app-item .message .message-header .message-expand-button, .message .message-header .background-app-item .message-expand-button,
+.background-app-item .message .message-header .message-close-button,
+.message .message-header .background-app-item .message-close-button, .message .message-header .message-expand-button,
+.message .message-header .message-close-button, .message-notification-group .message-collapse-button, .button {
+  padding: 4px 8px;
+  border-width: 0;
+  border-radius: 3px;
+  font-size: 9.75pt;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.icon-button:focus, .message .message-header .message-expand-button:focus,
+.message .message-header .message-close-button:focus, .message-notification-group .message-collapse-button:focus, .button:focus {
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: none;
+}
+
+.icon-button:hover, .message .message-header .message-expand-button:hover,
+.message .message-header .message-close-button:hover, .message-notification-group .message-collapse-button:hover, .button:hover {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.06);
+  box-shadow: none;
+}
+
+.icon-button:selected, .message .message-header .message-expand-button:selected,
+.message .message-header .message-close-button:selected, .message-notification-group .message-collapse-button:selected, .button:selected, .icon-button:active, .message .message-header .message-expand-button:active,
+.message .message-header .message-close-button:active, .message-notification-group .message-collapse-button:active, .button:active {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.15);
+  box-shadow: 0 0 transparent;
+}
+
+.icon-button:checked, .message .message-header .message-expand-button:checked,
+.message .message-header .message-close-button:checked, .message-notification-group .message-collapse-button:checked, .button:checked {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #3281ea;
+  border-color: #3281ea;
+  box-shadow: none;
+}
+
+.icon-button:checked:hover, .message .message-header .message-expand-button:checked:hover,
+.message .message-header .message-close-button:checked:hover, .message-notification-group .message-collapse-button:checked:hover, .button:checked:hover, .icon-button:checked:focus, .message .message-header .message-expand-button:checked:focus,
+.message .message-header .message-close-button:checked:focus, .message-notification-group .message-collapse-button:checked:focus, .button:checked:focus {
+  background-color: #3281ea;
+}
+
+.icon-button:insensitive, .message .message-header .message-expand-button:insensitive,
+.message .message-header .message-close-button:insensitive, .message-notification-group .message-collapse-button:insensitive, .button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button, .notification-button {
+  border-radius: 3px;
+  border: 1px solid;
+  color: rgba(255, 255, 255, 0.8);
+  background-color: #343434;
+  border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button:focus, .notification-button:focus {
+  color: #3281ea;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.modal-dialog .modal-dialog-button:focus:hover, .notification-button:focus:hover, .modal-dialog .modal-dialog-button:focus:active, .notification-button:focus:active {
+  color: #3281ea;
+}
+
+.modal-dialog .modal-dialog-button:hover, .notification-button:hover {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: #343434;
+  border-color: rgba(255, 255, 255, 0.15);
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button:selected, .notification-button:selected, .modal-dialog .modal-dialog-button:active, .notification-button:active {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: #414141;
+  border-color: rgba(255, 255, 255, 0.15);
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button:selected:hover, .notification-button:selected:hover, .modal-dialog .modal-dialog-button:selected:focus, .notification-button:selected:focus, .modal-dialog .modal-dialog-button:active:hover, .notification-button:active:hover, .modal-dialog .modal-dialog-button:active:focus, .notification-button:active:focus {
+  background-color: #414141;
+}
+
+.modal-dialog .modal-dialog-button:checked, .notification-button:checked {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #3281ea;
+  border-color: #3281ea;
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button:checked:hover, .notification-button:checked:hover, .modal-dialog .modal-dialog-button:checked:focus, .notification-button:checked:focus {
+  background-color: #3281ea;
+}
+
+.modal-dialog .modal-dialog-button:insensitive, .notification-button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: #343434;
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.button {
+  min-height: 1.5em;
+}
+
+.icon-button, .background-app-item .icon-button, .background-app-item .message-notification-group .message-collapse-button, .message-notification-group .background-app-item .message-collapse-button, .background-app-item .message .message-header .message-expand-button, .message .message-header .background-app-item .message-expand-button,
+.background-app-item .message .message-header .message-close-button,
+.message .message-header .background-app-item .message-close-button, .message .message-header .message-expand-button,
+.message .message-header .message-close-button, .message-notification-group .message-collapse-button {
+  border-radius: 9999px;
+  padding: 0.818em;
+  min-height: 1.091em;
+}
+
+.icon-button StIcon, .background-app-item .icon-button StIcon, .background-app-item .message-notification-group .message-collapse-button StIcon, .message-notification-group .background-app-item .message-collapse-button StIcon, .background-app-item .message .message-header .message-expand-button StIcon, .message .message-header .background-app-item .message-expand-button StIcon,
+.background-app-item .message .message-header .message-close-button StIcon,
+.message .message-header .background-app-item .message-close-button StIcon, .message .message-header .message-expand-button StIcon,
+.message .message-header .message-close-button StIcon, .message-notification-group .message-collapse-button StIcon {
+  icon-size: 1.091em;
+  -st-icon-style: symbolic;
+}
+
+/* Check Boxes */
+.check-box StBoxLayout {
+  spacing: .8em;
+}
+
+.check-box StBin {
+  width: 24px;
+  height: 24px;
+  padding: 4px;
+  border-radius: 100px;
+  background-image: url("assets/checkbox-off.svg");
+}
+
+.check-box:focus StBin {
+  background-image: url("assets/checkbox-off.svg");
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.check-box:hover StBin {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.check-box:active StBin {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.check-box:checked StBin {
+  background-image: url("assets/checkbox.svg");
+}
+
+.check-box:focus:checked StBin {
+  background-image: url("assets/checkbox.svg");
+}
+
+.check-box:hover:checked StBin {
+  background-color: rgba(64, 138, 235, 0.15);
+}
+
+.check-box:active:checked StBin {
+  background-color: rgba(64, 138, 235, 0.3);
+}
+
+.check-box StIcon {
+  icon-size: 0;
+  padding: 0;
+  border: none;
+  background-color: transparent;
+  color: transparent;
+}
+
+.check-box:checked StIcon {
+  background-color: transparent;
+  color: transparent;
+}
+
+.check-box:checked:hover StIcon {
+  background-color: transparent;
+  color: transparent;
+}
+
+.check-box:checked:active StIcon {
+  background-color: transparent;
+  color: transparent;
+}
+
+/* Switches */
+.toggle-switch {
+  width: 36px;
+  height: 18px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+}
+
+.toggle-switch:hover {
+  background: transparent;
+  color: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.7);
+}
+
+.toggle-switch StIcon {
+  icon-size: 10px;
+}
+
+.toggle-switch .handle {
+  margin: 4px;
+  width: 10px;
+  height: 10px;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.7);
+  box-shadow: none;
+  transition-duration: 100ms;
+}
+
+.toggle-switch:checked {
+  background: #3281ea;
+  color: white;
+  border-color: #3281ea;
+}
+
+.toggle-switch:checked:hover {
+  background-color: #498fec;
+  color: white;
+  border-color: #498fec;
+}
+
+.toggle-switch:checked .handle {
+  background: white;
+}
+
+/* Slider */
+.slider {
+  height: 12px;
+  color: white;
+  -barlevel-height: 2px;
+  -barlevel-background-color: rgba(255, 255, 255, 0.15);
+  -barlevel-active-background-color: #408aeb;
+  -barlevel-overdrive-color: #FF5252;
+  -barlevel-overdrive-separator-width: 2px;
+  -slider-handle-radius: 6px;
+}
+
+.slider:hover {
+  color: white;
+}
+
+.slider:active {
+  color: #f2f2f2;
+}
+
+/* Scrollbars */
+StScrollView.vfade {
+  -st-vfade-offset: 32px;
+}
+
+StScrollView.hfade {
+  -st-hfade-offset: 32px;
+}
+
+StScrollBar {
+  padding: 0;
+}
+
+StScrollView StScrollBar {
+  min-width: 8px;
+  min-height: 8px;
+}
+
+StScrollBar StBin#trough {
+  border-radius: 9999px;
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+StScrollBar StButton#vhandle, StScrollBar StButton#hhandle {
+  border-radius: 9999px;
+  background-color: rgba(255, 255, 255, 0.5);
+  border: 4px solid transparent;
+}
+
+StScrollBar StButton#vhandle:hover, StScrollBar StButton#hhandle:hover {
+  background-color: rgba(255, 255, 255, 0.7);
+}
+
+StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
+  background-color: rgba(255, 255, 255, 0.9);
+}
+
+/* Popovers/Menus */
+.popup-menu-boxpointer, .candidate-popup-boxpointer {
+  -arrow-border-radius: 3px;
+  -arrow-background-color: transparent;
+  -arrow-border-width: 0;
+  -arrow-border-color: transparent;
+  -arrow-base: 27px;
+  -arrow-rise: 0;
+  -arrow-box-shadow: none;
+}
+
+.popup-menu {
+  min-width: 15em;
+  color: rgba(255, 255, 255, 0.9);
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+.popup-menu.panel-menu {
+  -boxpointer-gap: 2px;
+  margin-bottom: 1.75em;
+}
+
+.popup-menu-content {
+  padding: 4px;
+  margin: 2px 4px 10px;
+  border: none;
+}
+
+.popup-menu-item {
+  spacing: 4px;
+  padding: 4px 8px;
+  margin: 0;
+  color: rgba(255, 255, 255, 0.9);
+  transition-duration: 100ms;
+  border-radius: 3px;
+  background-image: none;
+  background-gradient-direction: none !important;
+}
+
+.popup-menu-item:ltr {
+  padding-right: 8px;
+  padding-left: 8px;
+}
+
+.popup-menu-item:rtl {
+  padding-right: 8px;
+  padding-left: 8px;
+}
+
+.popup-menu-item:checked {
+  background-color: rgba(255, 255, 255, 0.06) !important;
+  font-weight: normal;
+  border-radius: 3px 3px 0 0 !important;
+  border: none;
+  box-shadow: none;
+  color: rgba(255, 255, 255, 0.9) !important;
+  background-gradient-direction: none !important;
+}
+
+.popup-menu-item:checked.selected, .popup-menu-item:checked:hover, .popup-menu-item:checked:focus {
+  background-color: rgba(255, 255, 255, 0.08) !important;
+  color: rgba(255, 255, 255, 0.9) !important;
+}
+
+.popup-menu-item:checked:active, .popup-menu-item:checked.selected:active {
+  background-color: rgba(255, 255, 255, 0.06) !important;
+  color: rgba(255, 255, 255, 0.9) !important;
+}
+
+.popup-menu-item:checked:insensitive {
+  color: rgba(255, 255, 255, 0.5) !important;
+}
+
+.popup-menu-item.selected, .popup-menu-item:hover, .popup-menu-item:focus {
+  background-color: rgba(255, 255, 255, 0.06) !important;
+  color: rgba(255, 255, 255, 0.9) !important;
+  transition-duration: 0ms;
+  background-gradient-direction: none !important;
+}
+
+.popup-menu-item:active {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+  color: rgba(255, 255, 255, 0.9) !important;
+  transition-duration: 150ms;
+  background-gradient-direction: none !important;
+}
+
+.popup-menu-item.selected:active {
+  color: rgba(255, 255, 255, 0.9) !important;
+}
+
+.popup-menu-item:insensitive {
+  color: rgba(255, 255, 255, 0.5) !important;
+}
+
+.popup-inactive-menu-item {
+  color: rgba(255, 255, 255, 0.9) !important;
+}
+
+.popup-inactive-menu-item:insensitive {
+  color: rgba(255, 255, 255, 0.5) !important;
+}
+
+.popup-menu-arrow,
+.popup-menu-icon {
+  icon-size: 16px;
+}
+
+.popup-sub-menu {
+  margin: 0;
+  background-color: rgba(255, 255, 255, 0.06) !important;
+  border-radius: 0 0 3px 3px !important;
+  border: none;
+  box-shadow: none;
+  background-image: none !important;
+}
+
+.popup-sub-menu .popup-menu-item {
+  margin: 0;
+  border-radius: 0;
+  background-image: none !important;
+  background-color: transparent !important;
+}
+
+.popup-sub-menu .popup-menu-item.selected, .popup-sub-menu .popup-menu-item:hover, .popup-sub-menu .popup-menu-item:focus {
+  background-color: rgba(255, 255, 255, 0.06) !important;
+}
+
+.popup-sub-menu .popup-menu-item:active {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+.popup-sub-menu .popup-menu-item:last-child {
+  border-radius: 0 0 3px 3px !important;
+  border-bottom-width: 0;
+}
+
+.popup-sub-menu .popup-menu-section .popup-menu-item:last-child:hover, .popup-sub-menu .popup-menu-section .popup-menu-item:last-child:focus {
+  border-radius: 0;
+}
+
+.popup-sub-menu .popup-menu-section:last-child .popup-menu-item:last-child {
+  border-radius: 0 0 3px 3px !important;
+}
+
+.popup-menu-ornament {
+  width: 1.2em;
+}
+
+.popup-menu-ornament:ltr {
+  text-align: right;
+}
+
+.popup-menu-ornament:rtl {
+  text-align: left;
+}
+
+.popup-separator-menu-item {
+  background: none;
+  border: none;
+  padding: 0 0;
+  margin: 0 0;
+  height: 2px;
+}
+
+.popup-separator-menu-item .popup-separator-menu-item-separator {
+  height: 1px;
+  margin: 0 0;
+  padding: 0 0;
+  background: none;
+}
+
+.popup-sub-menu .popup-separator-menu-item .popup-separator-menu-item-separator {
+  margin: 0 0;
+  padding: 0 0;
+  background: none;
+}
+
+.background-menu {
+  -boxpointer-gap: 2px;
+  -arrow-rise: 0px;
+}
+
+.aggregate-menu {
+  min-width: 19em;
+}
+
+.aggregate-menu .popup-menu-icon {
+  padding: 0;
+  margin: 0;
+  -st-icon-style: symbolic;
+}
+
+.aggregate-menu .popup-menu-icon:ltr {
+  margin-right: 2px;
+}
+
+.aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
+  padding-left: 8px !important;
+  margin-left: 0 !important;
+}
+
+.aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
+  padding-right: 8px !important;
+  margin-right: 0 !important;
+}
+
+/* Date/Time Menu */
+#calendarArea {
+  padding: 4px 0;
+}
+
+.datemenu-popover {
+  border-radius: 7px !important;
+}
+
+.calendar {
+  padding: 0;
+  margin: 0 6px;
+  border: none;
+  box-shadow: none;
+  background: none;
+  text-shadow: none;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.calendar .calendar-month-header .calendar-change-month-back StIcon,
+.calendar .calendar-month-header .calendar-change-month-forward StIcon {
+  icon-size: 1.091em;
+}
+
+.calendar .calendar-month-header .calendar-month-label {
+  background-color: transparent !important;
+  color: rgba(255, 255, 255, 0.9) !important;
+  padding: 8px 0;
+  width: 10em;
+  text-align: center;
+}
+
+.calendar .calendar-day-heading {
+  width: 28px;
+  height: 21px;
+  margin-top: 2px;
+  padding: 7px 0 0;
+  border-radius: 9999px;
+  background-color: transparent !important;
+  color: rgba(255, 255, 255, 0.5) !important;
+  font-size: 9pt;
+  font-weight: 400;
+  font-weight: bold;
+  text-align: center;
+}
+
+.datemenu-calendar-column {
+  spacing: 4px;
+  border: none;
+  padding: 0;
+  margin: 0;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.datemenu-calendar-column:hover, .datemenu-calendar-column:focus {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.datemenu-calendar-column:active {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.datemenu-calendar-column:ltr {
+  margin-right: 2px;
+  margin-left: 6px;
+  border-left-width: 0;
+}
+
+.datemenu-calendar-column:rtl {
+  margin-left: 2px;
+  margin-right: 6px;
+  border-right-width: 0;
+}
+
+.datemenu-calendar-column .datemenu-displays-section {
+  padding-bottom: 0;
+}
+
+.datemenu-calendar-column .datemenu-displays-box {
+  spacing: 4px;
+}
+
+.datemenu-today-button {
+  min-height: 48px;
+  padding: 4px;
+  border-radius: 3px;
+  border: none;
+  box-shadow: none;
+  text-shadow: none;
+  background: none;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.datemenu-today-button .day-label {
+  font-size: 15pt;
+  font-weight: 500;
+  font-weight: bold;
+}
+
+.datemenu-today-button .date-label {
+  font-size: 18pt;
+  font-weight: 400;
+}
+
+.datemenu-today-button:hover, .datemenu-today-button:focus {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.datemenu-today-button:active {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.pager-button {
+  width: 28px;
+  height: 28px;
+  margin: 2px !important;
+  padding: 0 !important;
+  border-radius: 9999px;
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.pager-button:hover, .pager-button:focus {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.pager-button:active {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.calendar-change-month-back {
+  padding: 2px !important;
+  background-image: url("assets/calendar-arrow-left.svg");
+}
+
+.calendar-change-month-back:rtl {
+  background-image: url("assets/calendar-arrow-right.svg");
+}
+
+.calendar-change-month-forward {
+  padding: 2px !important;
+  background-image: url("assets/calendar-arrow-right.svg");
+}
+
+.calendar-change-month-forward:rtl {
+  background-image: url("assets/calendar-arrow-left.svg");
+}
+
+.calendar-day {
+  font-size: 9pt;
+  font-weight: 400;
+  text-align: center;
+  width: 28px !important;
+  height: 28px !important;
+  padding: 2px !important;
+  margin: 2px !important;
+  border-radius: 9999px;
+  color: rgba(255, 255, 255, 0.7) !important;
+  background-color: transparent !important;
+  border: none;
+  font-feature-settings: "tnum";
+  text-shadow: none;
+}
+
+.calendar-day:hover, .calendar-day:focus {
+  background-color: rgba(255, 255, 255, 0.06) !important;
+  box-shadow: none !important;
+}
+
+.calendar-day:active {
+  color: rgba(255, 255, 255, 0.7) !important;
+  background-color: rgba(255, 255, 255, 0.15) !important;
+  border-color: transparent;
+}
+
+.calendar-day:selected {
+  color: rgba(255, 255, 255, 0.9) !important;
+  background-color: rgba(255, 255, 255, 0.15) !important;
+  border-color: transparent;
+  box-shadow: none !important;
+}
+
+.calendar-day {
+  border-width: 0;
+}
+
+.calendar-day-top {
+  border-top-width: 0;
+}
+
+.calendar-day-left {
+  border-left-width: 0;
+}
+
+.calendar-nonwork-day {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.calendar-today {
+  font-weight: bold !important;
+  color: white !important;
+  background-color: #3281ea !important;
+  border: none;
+}
+
+.calendar-today:hover, .calendar-today:focus {
+  background-color: #408aeb !important;
+  color: white !important;
+  box-shadow: none !important;
+}
+
+.calendar-today:active, .calendar-today:selected {
+  background-color: #3281ea !important;
+  color: white !important;
+  box-shadow: none !important;
+}
+
+.calendar-today:active:hover, .calendar-today:active:focus, .calendar-today:selected:hover, .calendar-today:selected:focus {
+  background-color: #408aeb !important;
+  color: white !important;
+}
+
+.calendar-day-with-events {
+  color: rgba(255, 255, 255, 0.5);
+  background-image: url("assets/calendar-today.svg");
+}
+
+.calendar-day-with-events.calendar-work-day {
+  color: rgba(255, 255, 255, 0.5);
+  font-weight: bold;
+}
+
+.calendar-weekend {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.calendar-other-month {
+  color: rgba(255, 255, 255, 0.3) !important;
+  opacity: 1;
+  font-weight: normal;
+}
+
+.calendar-other-month.calendar-weekend {
+  color: rgba(255, 255, 255, 0.3) !important;
+}
+
+.calendar-week-number {
+  height: 1.8em !important;
+  width: 2.6em !important;
+  padding: 0px 0 !important;
+  margin: 4px 0 !important;
+  border-radius: 9999px;
+  background-color: rgba(255, 255, 255, 0.03);
+  color: rgba(255, 255, 255, 0.5);
+  font-size: inherit;
+  font-weight: bold;
+  text-align: center;
+  text-shadow: none;
+}
+
+.world-clocks-button,
+.weather-button,
+.events-button {
+  padding: 4px 8px;
+  border-radius: 3px;
+  box-shadow: none;
+  text-shadow: none;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: rgba(255, 255, 255, 0.03) !important;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.world-clocks-button:hover, .world-clocks-button:focus,
+.weather-button:hover,
+.weather-button:focus,
+.events-button:hover,
+.events-button:focus {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.08) !important;
+  border-color: rgba(255, 255, 255, 0.06);
+  box-shadow: none;
+}
+
+.world-clocks-button:active,
+.weather-button:active,
+.events-button:active {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.12) !important;
+  box-shadow: none;
+}
+
+.world-clocks-header,
+.weather-header,
+.message-list-section-title,
+.events-section-title,
+.events-title {
+  color: rgba(255, 255, 255, 0.5);
+  font-weight: bold;
+  margin-bottom: 4px;
+  text-shadow: none;
+}
+
+.weather-grid,
+.world-clocks-grid {
+  spacing-rows: 8px;
+  spacing-columns: 16px;
+}
+
+.world-clocks-header,
+.weather-header,
+.events-section-title {
+  color: rgba(255, 255, 255, 0.5);
+  font-weight: bold;
+}
+
+.events-button .events-box {
+  spacing: 4px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.events-button .events-list {
+  spacing: 8px;
+  text-shadow: none;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.events-button .event-time {
+  color: rgba(255, 255, 255, 0.3);
+  font-feature-settings: "tnum";
+}
+
+.world-clocks-button .world-clocks-city {
+  color: rgba(255, 255, 255, 0.5);
+  font-weight: normal;
+  font-size: 1em;
+}
+
+.world-clocks-button .world-clocks-time {
+  color: rgba(255, 255, 255, 0.5);
+  font-feature-settings: "tnum";
+  font-weight: bold;
+  font-size: 1em;
+}
+
+.world-clocks-button .world-clocks-time:ltr {
+  text-align: right;
+}
+
+.world-clocks-button .world-clocks-time:rtl {
+  text-align: left;
+}
+
+.world-clocks-button .world-clocks-timezone {
+  color: rgba(255, 255, 255, 0.5);
+  font-feature-settings: "tnum";
+  font-size: 1em;
+}
+
+.weather-button .weather-box {
+  spacing: 4px;
+}
+
+.weather-button .weather-header-box {
+  spacing: 4px;
+}
+
+.weather-button .weather-header.location {
+  font-weight: normal;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.weather-button .weather-forecast-icon {
+  icon-size: 24px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.weather-button .weather-forecast-time {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.8em;
+  font-feature-settings: "tnum";
+  font-weight: normal;
+  padding-top: 0.2em;
+  padding-bottom: 0.4em;
+}
+
+.weather-button .weather-forecast-temp {
+  font-weight: bold;
+  color: rgba(255, 255, 255, 0.55);
+  text-shadow: none;
+}
+
+/* Message List */
+.message-list {
+  width: 29em;
+  padding: 0;
+  color: rgba(255, 255, 255, 0.7);
+  text-shadow: none;
+  box-shadow: none;
+  border: 0 solid rgba(255, 255, 255, 0.1);
+}
+
+.message-list:ltr {
+  margin-left: 4px;
+  margin-right: 0;
+  padding-right: 8px;
+  border-right-width: 1px;
+}
+
+.message-list:rtl {
+  margin-right: 4px;
+  margin-left: 0;
+  padding-left: 8px;
+  border-left-width: 1px;
+}
+
+.message-list .message-list-placeholder {
+  color: rgba(255, 255, 255, 0.3);
+}
+
+.message-list .message-list-placeholder > StIcon {
+  icon-size: 96px;
+  margin-bottom: 6px;
+  -st-icon-style: symbolic;
+}
+
+.message-view {
+  -st-vfade-offset: 68px;
+}
+
+.message-view:ltr {
+  margin-right: 0;
+}
+
+.message-view:rtl {
+  margin-left: 0;
+}
+
+.message-view .message {
+  margin-bottom: 8px !important;
+}
+
+.message-list-controls {
+  padding: 8px;
+  padding-bottom: 4px;
+  spacing: 4px;
+}
+
+.message-list-controls .dnd-button {
+  border-width: 2px;
+  border-color: transparent;
+  border-radius: 32px;
+  border-style: solid;
+}
+
+.message-list-controls .dnd-button:focus {
+  border-color: rgba(50, 129, 234, 0.6);
+}
+
+.message-notification-group {
+  spacing: 8px;
+}
+
+.message-notification-group .message-group-header {
+  padding: 4px;
+}
+
+.message-notification-group .message-group-header .message-group-title {
+  margin: 0 2px;
+}
+
+.message-notification-group .message-collapse-button {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.1);
+  padding: 4px;
+}
+
+.message-notification-group .message-collapse-button:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+.message-notification-group .message-collapse-button:active {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.message {
+  background-color: rgba(255, 255, 255, 0.03);
+  border-radius: 3px;
+  color: rgba(255, 255, 255, 0.7);
+  text-shadow: none;
+  padding: 0;
+  margin: 2px;
+  box-shadow: 0 3px 8px -2px rgba(0, 0, 0, 0.15);
+  background-color: rgba(32, 32, 32, 0.95);
+  border: 1px solid transparent;
+  border-left: none;
+  border-bottom: none;
+}
+
+.message:hover, .message:focus, .message:active {
+  background-color: #202020;
+}
+
+.popup-menu .message {
+  margin: 0 0 2px;
+  box-shadow: none;
+  background-color: rgba(255, 255, 255, 0.03);
+  border-radius: 3px;
+  color: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.popup-menu .message:hover, .popup-menu .message:focus {
+  background-color: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.popup-menu .message:active {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.message:second-in-stack {
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.message:lower-in-stack {
+  box-shadow: none;
+}
+
+.message .message-header {
+  padding: 0 0.409em;
+  spacing: 4px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.message .message-header:ltr {
+  padding-right: 0;
+}
+
+.message .message-header:rtl {
+  padding-left: 0;
+}
+
+.message .message-header .message-source-icon {
+  icon-size: 1.091em;
+  -st-icon-style: symbolic;
+}
+
+.message .message-header .message-header-content {
+  spacing: 4px;
+  min-height: 1.637em;
+  padding-bottom: 4px;
+}
+
+.message .message-header .message-header-content .message-source-title {
+  font-weight: bold;
+}
+
+.message .message-header .message-header-content .event-time {
+  color: rgba(255, 255, 255, 0.5);
+  padding-bottom: 0.068em;
+}
+
+.message .message-header .message-header-content .event-time:ltr {
+  text-align: right;
+}
+
+.message .message-header .message-header-content .event-time:rtl {
+  text-align: left;
+}
+
+.message .message-header .message-expand-button,
+.message .message-header .message-close-button {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0);
+  padding: 4px;
+}
+
+.message .message-header .message-expand-button:hover,
+.message .message-header .message-close-button:hover {
+  background-color: rgba(255, 255, 255, 0.09);
+}
+
+.message .message-header .message-expand-button:active, .message .message-header .message-expand-button:active:hover,
+.message .message-header .message-close-button:active,
+.message .message-header .message-close-button:active:hover {
+  background-color: rgba(255, 255, 255, 0.14);
+}
+
+.message .message-header .message-expand-button:insensitive,
+.message .message-header .message-close-button:insensitive {
+  background-color: rgba(255, 255, 255, 0);
+}
+
+.message .message-header .message-expand-button {
+  padding: 6px;
+}
+
+.message .message-header .message-expand-button:ltr {
+  margin-right: 4px;
+}
+
+.message .message-header .message-expand-button:rtl {
+  margin-left: 4px;
+}
+
+.message .message-box {
+  padding: 4px;
+  margin: 4px;
+  margin-top: 0;
+  spacing: 4px;
+}
+
+.message .message-box .message-icon {
+  icon-size: 48px;
+  -st-icon-style: symbolic;
+}
+
+.message .message-box .message-icon:ltr {
+  margin-right: 4px;
+}
+
+.message .message-box .message-icon:rtl {
+  margin-left: 4px;
+}
+
+.message .message-box .message-icon.message-themed-icon {
+  border-radius: 9999px;
+  background-color: rgba(255, 255, 255, 0.1);
+  icon-size: 16px;
+  min-width: 48px;
+  min-height: 48px;
+}
+
+.message .message-box:first-child {
+  margin-top: 8px;
+}
+
+.message .message-box .message-content {
+  spacing: 2px;
+}
+
+.message .message-box .message-content .message-title {
+  font-weight: bold;
+}
+
+.url-highlighter {
+  link-color: #3281ea;
+}
+
+/* Media Controls */
+.message-media-control {
+  margin: 4px 0;
+  padding: 0 8px;
+  border-radius: 9999px;
+  color: rgba(255, 255, 255, 0.7);
+  border: none;
+}
+
+.message-media-control:hover, .message-media-control:focus {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.message-media-control:active {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.message-media-control:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+}
+
+.message-media-control StIcon {
+  icon-size: 16px;
+}
+
+.media-message .message-icon {
+  border-radius: 3px !important;
+}
+
+.media-message .message-icon.message-themed-icon {
+  icon-size: 32px !important;
+}
+
+.candidate-popup-content {
+  background-color: rgba(32, 32, 32, 0.97);
+  border-radius: 3px;
+  box-shadow: 0 3px 8px -2px rgba(0, 0, 0, 0.25) !important;
+  margin: 2px 8px 11px;
+  padding: 4px;
+  spacing: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.candidate-index {
+  padding: 0 0.5em 0 0;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.candidate-box {
+  padding: 0.3em 0.5em 0.3em 0.5em;
+  margin-right: 2px;
+  border-radius: 3px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.candidate-box:hover {
+  background-color: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.candidate-box:active {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.candidate-box:selected {
+  background-color: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.candidate-box:last-child {
+  margin-right: 0;
+}
+
+.candidate-page-button-box {
+  height: 2em;
+}
+
+.vertical .candidate-page-button-box {
+  padding-top: 0.5em;
+}
+
+.horizontal .candidate-page-button-box {
+  padding-left: 0.5em;
+}
+
+.candidate-page-button {
+  padding: 4px;
+}
+
+.candidate-page-button-previous {
+  border-radius: 3px 0px 0px 3px;
+  border-right-width: 0;
+}
+
+.candidate-page-button-next {
+  border-radius: 0px 3px 3px 0px;
+}
+
+.candidate-page-button-icon {
+  icon-size: 1em;
+}
+
+/* Notifications & Message Tray */
+.notification-banner {
+  min-height: 64px;
+  width: 34em;
+  margin: 4px;
+  border-radius: 6px;
+}
+
+.notification-buttons-bin {
+  spacing: 0;
+  padding: 0 4px 4px;
+  margin: 0;
+  border: none;
+}
+
+.notification-button {
+  min-height: 20px;
+  padding: 4px 8px;
+  font-weight: bold;
+}
+
+.hotplug-notification-item {
+  padding: 2px 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  text-shadow: none;
+  font-size: 9.75pt;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.hotplug-notification-item:hover {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.06);
+  box-shadow: none;
+}
+
+.hotplug-notification-item:active {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.15);
+  box-shadow: 0 0 transparent;
+}
+
+.hotplug-notification-item:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.hotplug-notification-item:focus {
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: none;
+}
+
+.hotplug-notification-item:first-child {
+  border-radius: 0 0 0 3px;
+}
+
+.hotplug-notification-item:last-child {
+  border-radius: 0 0 3px 0;
+}
+
+.hotplug-notification-item:first-child:last-child {
+  border-radius: 0 0 3px 3px;
+}
+
+.hotplug-notification-item-icon {
+  icon-size: 24px;
+  padding: 0 4px;
+}
+
+/* Modal Dialogs */
+.headline {
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+.modal-dialog {
+  padding: 0;
+}
+
+.modal-dialog .modal-dialog-content-box {
+  margin: 32px 40px 42px;
+  spacing: 32px;
+  max-width: 28em;
+}
+
+.modal-dialog .modal-dialog-button-box {
+  padding: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 0 0 6px 6px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.modal-dialog .modal-dialog-button {
+  font-weight: bold;
+  background-gradient-direction: none !important;
+  margin: 0 !important;
+}
+
+/* End Session Dialog */
+.end-session-dialog {
+  width: 30em;
+}
+
+.end-session-dialog .end-session-dialog-battery-warning,
+.end-session-dialog .dialog-list-title {
+  color: #FF6D00;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child {
+  background-color: #FF5252 !important;
+  color: white !important;
+  border-color: rgba(255, 104, 104, 0.985) !important;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child:hover {
+  background-color: #ff8080 !important;
+  border-color: rgba(255, 119, 119, 0.975) !important;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child:active {
+  background-color: #ff5c5c !important;
+  border-color: rgba(255, 119, 119, 0.975) !important;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child:insensitive {
+  color: rgba(255, 255, 255, 0.5) !important;
+  background-color: rgba(255, 82, 82, 0.35) !important;
+  border-color: rgba(255, 96, 96, 0.99) !important;
+}
+
+/* Message Dialog */
+.message-dialog-content {
+  spacing: 18px;
+}
+
+.message-dialog-content .message-dialog-title {
+  text-align: center;
+  font-size: 18pt;
+  font-weight: 800;
+}
+
+.message-dialog-content .message-dialog-title.lightweight {
+  font-size: 13pt;
+  font-weight: 800;
+}
+
+.message-dialog-content .message-dialog-description {
+  text-align: center;
+}
+
+/* Dialog List */
+.dialog-list {
+  spacing: 18px;
+}
+
+.dialog-list .dialog-list-title {
+  text-align: center;
+  font-weight: bold;
+}
+
+.dialog-list .dialog-list-scrollview {
+  max-height: 200px;
+}
+
+.dialog-list .dialog-list-box {
+  spacing: 1em;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item {
+  spacing: 1em;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item .dialog-list-item-title {
+  font-weight: bold;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item .dialog-list-item-description {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+/* Run Dialog */
+.run-dialog .modal-dialog-content-box {
+  margin-top: 24px;
+  margin-bottom: 14px;
+}
+
+.run-dialog .run-dialog-entry {
+  width: 20em;
+}
+
+.run-dialog .run-dialog-description {
+  font-size: 11.25pt;
+  font-weight: 400;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+/* Password or Authentication Dialog */
+.prompt-dialog {
+  width: 28em;
+}
+
+.prompt-dialog .modal-dialog-content-box {
+  margin-bottom: 24px;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child {
+  background-color: #408aeb !important;
+  color: white !important;
+  border-color: rgba(88, 152, 238, 0.985) !important;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:hover {
+  background-color: #6aa3f0 !important;
+  border-color: rgba(105, 163, 240, 0.975) !important;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:active {
+  background-color: #498fec !important;
+  border-color: rgba(105, 163, 240, 0.975) !important;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:insensitive {
+  color: rgba(255, 255, 255, 0.5) !important;
+  background-color: rgba(64, 138, 235, 0.35) !important;
+  border-color: rgba(80, 147, 237, 0.99) !important;
+}
+
+.prompt-dialog-password-grid {
+  spacing-rows: 8px;
+  spacing-columns: 4px;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry {
+  width: auto;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry:ltr {
+  margin-left: 20px;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry:rtl {
+  margin-right: 20px;
+}
+
+.prompt-dialog-password-layout {
+  spacing: 8px;
+}
+
+.prompt-dialog-password-entry {
+  width: 20em;
+}
+
+.prompt-dialog-error-label,
+.prompt-dialog-info-label,
+.prompt-dialog-null-label {
+  text-align: center;
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+.prompt-dialog-error-label {
+  color: #FF6D00;
+}
+
+/* Polkit Dialog */
+.polkit-dialog-user-layout {
+  text-align: center;
+  spacing: 8px;
+  margin-bottom: 6px;
+}
+
+.polkit-dialog-user-layout .polkit-dialog-user-root-label {
+  color: #FF6D00;
+}
+
+/* Audio selection dialog */
+.audio-device-selection-dialog .modal-dialog-content-box {
+  margin-bottom: 28px;
+}
+
+.audio-device-selection-dialog .audio-selection-box {
+  spacing: 20px;
+}
+
+.audio-selection-device {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 3px;
+}
+
+.audio-selection-device:active, .audio-selection-device:hover, .audio-selection-device:focus {
+  background-color: #3281ea;
+}
+
+.audio-selection-device-box {
+  padding: 20px;
+  spacing: 20px;
+}
+
+.audio-selection-device-icon {
+  icon-size: 64px;
+}
+
+/* Welcome dialog */
+.welcome-dialog-image {
+  background-image: url("resource:///org/gnome/shell/theme/gnome-shell-start.svg");
+  background-size: contain;
+  /* Reasonable maximum dimensions */
+  height: 300px;
+  width: 300px;
+}
+
+/* Network Dialogs */
+.nm-dialog {
+  max-height: 34em;
+  min-height: 31em;
+  min-width: 32em;
+}
+
+.nm-dialog-content {
+  spacing: 20px;
+  padding: 24px;
+}
+
+.nm-dialog-airplane-box {
+  spacing: 12px;
+}
+
+.nm-dialog-airplane-headline {
+  font-weight: bold;
+  text-align: center;
+}
+
+.nm-dialog-airplane-text {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.nm-dialog-header {
+  font-weight: bold;
+}
+
+.nm-dialog-header-icon {
+  icon-size: 32px;
+}
+
+.nm-dialog-header-hbox {
+  spacing: 10px;
+}
+
+.nm-dialog-scroll-view {
+  border: none;
+  background-color: rgba(255, 255, 255, 0.06);
+  border-radius: 3px;
+  padding: 8px;
+  padding-right: 0;
+}
+
+.nm-dialog-item {
+  font-size: 1em;
+  border-bottom: none;
+  border-radius: -1px;
+  padding: 8px;
+  spacing: 0px;
+}
+
+.nm-dialog-item:hover, .nm-dialog-item:focus {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.nm-dialog-item:active {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.nm-dialog-item:selected {
+  background-color: #3281ea;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.nm-dialog-icon {
+  icon-size: 16px;
+}
+
+.nm-dialog-icons {
+  spacing: 8px;
+}
+
+.no-networks-label {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.no-networks-box {
+  spacing: 4px;
+}
+
+/* OSD */
+.screenshot-ui-panel, .workspace-switcher-container, .switcher-list, .resize-popup, .osd-window {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #222222;
+  border: none;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.35);
+  border-radius: 3px;
+  padding: 8px;
+}
+
+.osd-window {
+  text-align: center;
+  font-weight: bold;
+  spacing: 8px;
+  padding: 8px 12px;
+  margin-bottom: 4em;
+}
+
+.osd-window > * {
+  spacing: 8px;
+}
+
+.osd-window StIcon {
+  icon-size: 32px;
+}
+
+.osd-window StLabel:ltr {
+  margin-right: 6px;
+}
+
+.osd-window StLabel:rtl {
+  margin-left: 6px;
+}
+
+.osd-window .osd-monitor-label {
+  font-size: 3em;
+}
+
+.osd-window .level {
+  height: 4px;
+  -barlevel-height: 4px;
+  -barlevel-background-color: rgba(50, 129, 234, 0.3);
+  -barlevel-active-background-color: #3281ea;
+  -barlevel-overdrive-color: #FF5252;
+  -barlevel-overdrive-separator-width: 3px;
+  -barlevel-border-width: 0;
+}
+
+/* Pad OSD */
+.pad-osd-window {
+  padding: 32px;
+  background-color: rgba(0, 0, 0, 0.8);
+  border: none;
+}
+
+.pad-osd-window .pad-osd-title-box {
+  spacing: 12px;
+}
+
+.pad-osd-window .pad-osd-title-menu-box {
+  spacing: 6px;
+}
+
+.combo-box-label {
+  width: 15em;
+}
+
+/* App Switcher */
+.switcher-popup {
+  padding: 8px;
+  spacing: 16px;
+}
+
+.switcher-list .item-box {
+  padding: 8px;
+  border-radius: 3px;
+  border: none;
+}
+
+.switcher-list .item-box:outlined {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.switcher-list .item-box:selected {
+  background-color: #3281ea;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.switcher-list .thumbnail-box {
+  padding: 2px;
+  spacing: 4px;
+}
+
+.switcher-list .thumbnail {
+  width: 256px;
+}
+
+.switcher-list .separator {
+  width: 1px;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.switcher-list .switcher-list-item-container {
+  spacing: 8px;
+}
+
+.switcher-arrow {
+  border-color: rgba(0, 0, 0, 0);
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.switcher-arrow:highlighted {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.input-source-switcher-symbol {
+  font-size: 34pt;
+  width: 96px;
+  height: 96px;
+}
+
+.cycler-highlight {
+  border: 5px solid #3281ea;
+}
+
+/* Workspace Switcher */
+.workspace-switcher-group {
+  padding: 8px;
+}
+
+.workspace-switcher {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  spacing: 8px;
+}
+
+.ws-switcher-box {
+  height: 50px;
+  background-size: 32px;
+  border: none;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 3px;
+}
+
+.ws-switcher-active-up,
+.ws-switcher-active-down,
+.ws-switcher-active-left,
+.ws-switcher-active-right {
+  height: 52px;
+  background-color: #3281ea;
+  border: none;
+  border-radius: 5px;
+  color: #FFFFFF;
+}
+
+/* Top Bar */
+#panel .panel-button#panelActivities {
+  -natural-hpadding: 10px;
+}
+
+#panel .panel-button#panelActivities StBoxLayout {
+  spacing: 4px;
+}
+
+#panel .panel-button#panelActivities .workspace-dot {
+  border-radius: 9999px;
+  min-width: 8px;
+  min-height: 8px;
+  background-color: #FFFFFF;
+}
+
+#panel {
+  font-weight: normal;
+  font-feature-settings: "tnum";
+  transition-duration: 250ms;
+  border: none;
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.5);
+  margin: 0;
+  border-radius: 0;
+  height: 30px;
+}
+
+#panel #panelLeft, #panel #panelCenter {
+  spacing: 0;
+}
+
+#panel .panel-corner {
+  -panel-corner-radius: 0;
+  -panel-corner-background-color: rgba(0, 0, 0, 0.5);
+  -panel-corner-border-width: 0;
+  -panel-corner-border-color: transparent;
+  -panel-corner-opacity: 0;
+  transition-duration: 250ms;
+}
+
+#panel .panel-button {
+  -natural-hpadding: 4px;
+  -minimum-hpadding: 4px;
+  font-weight: normal;
+  color: rgba(255, 255, 255, 0.75);
+  transition-duration: 150ms;
+  text-shadow: none;
+  border-radius: 0;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#panel .panel-button StLabel {
+  padding: 0;
+}
+
+#panel .panel-button:hover {
+  color: rgba(255, 255, 255, 0.75);
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+#panel .panel-button:active, #panel .panel-button:checked, #panel .panel-button:focus {
+  color: #FFFFFF;
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#panel .panel-button:hover, #panel .panel-button:active, #panel .panel-button:overview, #panel .panel-button:focus, #panel .panel-button:checked {
+  text-shadow: none;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#panel .panel-button.clock-display {
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#panel .panel-button.clock-display:hover {
+  color: rgba(255, 255, 255, 0.75);
+  background-color: rgba(255, 255, 255, 0.1) !important;
+}
+
+#panel .panel-button.clock-display:active, #panel .panel-button.clock-display:checked, #panel .panel-button.clock-display:focus {
+  color: #FFFFFF;
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#panel .panel-button.clock-display:active .clock, #panel .panel-button.clock-display:checked .clock, #panel .panel-button.clock-display:focus .clock {
+  box-shadow: none;
+  background: none;
+  color: #FFFFFF;
+}
+
+#panel .panel-button.clock-display:hover, #panel .panel-button.clock-display:active, #panel .panel-button.clock-display:checked, #panel .panel-button.clock-display:focus {
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#panel .panel-button.clock-display .clock {
+  color: rgba(255, 255, 255, 0.75);
+  transition-duration: 150ms;
+  border: none;
+  border-radius: 0;
+}
+
+#panel .panel-button.clock-display .messages-indicator {
+  icon-size: 1.091em;
+}
+
+#panel .panel-button .system-status-icon {
+  icon-size: 16px;
+  padding: 4px;
+  margin: 0 2px;
+}
+
+#panel .panel-button .panel-status-menu-box .system-status-icon {
+  margin: 0;
+}
+
+#panel .panel-button .panel-status-menu-box StLabel {
+  padding: 0 0 0 2px;
+}
+
+#panel .panel-button .panel-status-menu-box,
+#panel .panel-button .panel-status-indicators-box {
+  spacing: 2px;
+}
+
+#panel .panel-button .appindicator-trayicons-box,
+#panel .panel-button .panel-status-indicators-box.appindicator-box {
+  margin: 0 4px;
+}
+
+#panel .panel-button .clipboard-indicator-icon {
+  margin: 0 4px;
+}
+
+#panel .panel-button .app-menu-icon {
+  -st-icon-style: symbolic;
+}
+
+#panel.unlock-screen, #panel.login-screen, #panel.lock-screen, #panel:overview {
+  background-color: transparent;
+}
+
+#panel.unlock-screen .panel-button, #panel.login-screen .panel-button, #panel.lock-screen .panel-button, #panel:overview .panel-button {
+  border-radius: 3px;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+}
+
+#panel.unlock-screen .panel-button:hover, #panel.login-screen .panel-button:hover, #panel.lock-screen .panel-button:hover, #panel:overview .panel-button:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#panel.unlock-screen .panel-button:active, #panel.unlock-screen .panel-button:checked, #panel.unlock-screen .panel-button:focus, #panel.login-screen .panel-button:active, #panel.login-screen .panel-button:checked, #panel.login-screen .panel-button:focus, #panel.lock-screen .panel-button:active, #panel.lock-screen .panel-button:checked, #panel.lock-screen .panel-button:focus, #panel:overview .panel-button:active, #panel:overview .panel-button:checked, #panel:overview .panel-button:focus {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+#panel.unlock-screen .panel-button.clock-display:hover, #panel.login-screen .panel-button.clock-display:hover, #panel.lock-screen .panel-button.clock-display:hover, #panel:overview .panel-button.clock-display:hover {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#panel.unlock-screen .panel-button.clock-display:active, #panel.unlock-screen .panel-button.clock-display:checked, #panel.unlock-screen .panel-button.clock-display:focus, #panel.login-screen .panel-button.clock-display:active, #panel.login-screen .panel-button.clock-display:checked, #panel.login-screen .panel-button.clock-display:focus, #panel.lock-screen .panel-button.clock-display:active, #panel.lock-screen .panel-button.clock-display:checked, #panel.lock-screen .panel-button.clock-display:focus, #panel:overview .panel-button.clock-display:active, #panel:overview .panel-button.clock-display:checked, #panel:overview .panel-button.clock-display:focus {
+  background-color: rgba(255, 255, 255, 0.3) !important;
+}
+
+#panel.unlock-screen .panel-button.clock-display .clock, #panel.login-screen .panel-button.clock-display .clock, #panel.lock-screen .panel-button.clock-display .clock, #panel:overview .panel-button.clock-display .clock {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+#panel.unlock-screen .panel-button#panelActivities, #panel.login-screen .panel-button#panelActivities, #panel.lock-screen .panel-button#panelActivities, #panel:overview .panel-button#panelActivities {
+  box-shadow: none;
+  border: none;
+  background-color: transparent;
+}
+
+#panel.unlock-screen .panel-button#panelActivities:hover, #panel.login-screen .panel-button#panelActivities:hover, #panel.lock-screen .panel-button#panelActivities:hover, #panel:overview .panel-button#panelActivities:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#panel.unlock-screen .panel-button#panelActivities .workspace-dot, #panel.login-screen .panel-button#panelActivities .workspace-dot, #panel.lock-screen .panel-button#panelActivities .workspace-dot, #panel:overview .panel-button#panelActivities .workspace-dot {
+  background-color: rgba(255, 255, 255, 0.85);
+}
+
+#panel.unlock-screen .panel-corner, #panel.login-screen .panel-corner, #panel.lock-screen .panel-corner, #panel:overview .panel-corner {
+  -panel-corner-opacity: 0;
+  -panel-corner-radius: 0;
+  -panel-corner-background-color: transparent;
+  -panel-corner-border-color: transparent;
+}
+
+#panel Gjs_ui_panel_AggregateMenu.panel-button .system-status-icon {
+  margin: 0 !important;
+  padding: 4px !important;
+}
+
+#panel Gjs_kimpanel_kde_org_indicator_KimIndicator.panel-button .panel-status-menu-box {
+  margin: 0 4px;
+}
+
+#panel .screencast-indicator,
+#panel .remote-access-indicator {
+  color: #FF6D00;
+}
+
+#appMenu {
+  spacing: 4px;
+}
+
+#appMenu .label-shadow {
+  color: transparent;
+}
+
+#appMenu .panel-status-menu-box {
+  padding: 0 4px;
+  spacing: 4px;
+}
+
+/* Activities Ripple */
+.ripple-box {
+  background-color: rgba(50, 129, 234, 0.35);
+  width: 52px;
+  height: 52px;
+  border-radius: 0 0 52px 0;
+}
+
+.ripple-box:rtl {
+  border-radius: 0 0 0 52px;
+}
+
+/* OVERVIEW */
+.controls-manager, .secondary-monitor-workspaces {
+  spacing: 8px;
+}
+
+#overviewGroup {
+  background-color: #222222;
+}
+
+.overview-controls {
+  padding-bottom: 32px;
+}
+
+/* Window Picker */
+.window-picker {
+  spacing: 4px;
+}
+
+.window-caption {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(32, 32, 32, 0.9);
+  border-radius: 6px;
+  padding: 4px 8px;
+}
+
+.window-close, .screenshot-ui-close-button {
+  background-color: #3281ea;
+  color: white;
+  border-radius: 9999px;
+  padding: 3px;
+  height: 30px;
+  width: 30px;
+  box-shadow: -1px 1px 5px 0px rgba(0, 0, 0, 0.5);
+  transition-duration: 300ms;
+}
+
+.window-close StIcon, .screenshot-ui-close-button StIcon {
+  icon-size: 24px;
+}
+
+.window-close:hover, .screenshot-ui-close-button:hover {
+  background-color: #77acf1;
+}
+
+.window-close:active, .screenshot-ui-close-button:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #1b73e8;
+}
+
+.workspace-background {
+  border-radius: 30px;
+  background-color: #222222;
+  box-shadow: 0 4px 16px 4px rgba(0, 0, 0, 0.3);
+  border: none;
+}
+
+.search-entry {
+  min-height: 24px;
+  padding: 2px 4px;
+  width: 320px;
+  border: none !important;
+  border-radius: 3px;
+  selection-background-color: #3281ea;
+  selected-color: #FFFFFF !important;
+  caret-color: rgba(255, 255, 255, 0.7);
+  color: rgba(255, 255, 255, 0.7);
+  background-color: rgba(255, 255, 255, 0.15);
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+.search-entry:hover {
+  border: 2px solid rgba(255, 255, 255, 0.15) !important;
+}
+
+.search-entry:focus {
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #3281ea !important;
+}
+
+.search-entry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.search-entry .search-entry-icon {
+  icon-size: 16px;
+  padding: 0 4px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.search-entry StLabel.hint-text {
+  margin-left: 2px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+#overview .search-entry {
+  min-height: 24px;
+  padding: 4px 6px;
+  margin-top: 8px;
+  margin-bottom: 4px;
+  border-radius: 5px;
+  caret-color: rgba(0, 0, 0, 0.75);
+  color: rgba(0, 0, 0, 0.75);
+  background-color: rgba(255, 255, 255, 0.75) !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#overview .search-entry:hover {
+  color: rgba(0, 0, 0, 0.75);
+  background-color: rgba(255, 255, 255, 0.85) !important;
+}
+
+#overview .search-entry:focus {
+  color: rgba(0, 0, 0, 0.85);
+  background-color: rgba(255, 255, 255, 0.95) !important;
+  border: none !important;
+  selection-background-color: #3281ea;
+  selected-color: #FFFFFF !important;
+}
+
+#overview .search-entry .search-entry-icon {
+  color: rgba(0, 0, 0, 0.65);
+}
+
+#overview .search-entry:hover .search-entry-icon, #overview .search-entry:focus .search-entry-icon {
+  color: rgba(0, 0, 0, 0.75);
+}
+
+#overview .search-entry StLabel.hint-text {
+  color: rgba(0, 0, 0, 0.35);
+}
+
+/* Search */
+#searchResults {
+  margin: 0 4px;
+}
+
+#searchResultsContent {
+  max-width: 1044px;
+}
+
+.search-section {
+  spacing: 8px;
+}
+
+.search-section .search-section-separator {
+  height: 4px;
+  background-color: transparent;
+}
+
+.search-section-content {
+  background-color: rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.1);
+  text-shadow: none;
+  color: rgba(255, 255, 255, 0.85);
+  padding: 12px;
+  spacing: 4px;
+}
+
+.list-search-result, .search-provider-icon {
+  border-radius: 6px;
+}
+
+.search-statustext {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.grid-search-results {
+  spacing: 24px;
+  margin: 0 6px;
+}
+
+.search-provider-icon:ltr {
+  margin-right: 2px;
+}
+
+.search-provider-icon:rtl {
+  margin-left: 2px;
+}
+
+.search-provider-icon .list-search-provider-content {
+  spacing: 8px;
+}
+
+.search-provider-icon .list-search-provider-content .list-search-provider-details {
+  width: 120px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.list-search-results {
+  spacing: 4px;
+}
+
+.list-search-result .list-search-result-content {
+  spacing: 4px;
+}
+
+.list-search-result .list-search-result-title {
+  spacing: 8px;
+}
+
+.list-search-result .list-search-result-description {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+/* Dash */
+#dash {
+  padding-left: 4px;
+  padding-right: 4px;
+}
+
+#dash .dash-background {
+  background-color: rgba(255, 255, 255, 0.2);
+  border-radius: 11px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 7px;
+  padding-right: 7px;
+}
+
+#dash .dash-item-container .placeholder {
+  background-image: none;
+  background-size: contain;
+  height: 32px;
+}
+
+#dash .dash-item-container .empty-dash-drop-target {
+  width: 32px;
+  height: 32px;
+}
+
+#dash .dash-item-container .show-apps,
+#dash .dash-item-container .overview-tile,
+#dash .dash-item-container .grid-search-result,
+#dash .dash-item-container .search-provider-icon,
+#dash .dash-item-container .list-search-result {
+  margin: 0 1px;
+  padding-bottom: 6px;
+}
+
+#dash .dash-item-container .show-apps .overview-icon,
+#dash .dash-item-container .overview-tile .overview-icon,
+#dash .dash-item-container .grid-search-result .overview-icon,
+#dash .dash-item-container .search-provider-icon .overview-icon,
+#dash .dash-item-container .list-search-result .overview-icon {
+  background-color: transparent;
+}
+
+#dash .dash-item-container .show-apps:focus .overview-icon,
+#dash .dash-item-container .overview-tile:focus .overview-icon,
+#dash .dash-item-container .grid-search-result:focus .overview-icon,
+#dash .dash-item-container .search-provider-icon:focus .overview-icon,
+#dash .dash-item-container .list-search-result:focus .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#dash .dash-item-container .show-apps:hover .overview-icon,
+#dash .dash-item-container .overview-tile:hover .overview-icon,
+#dash .dash-item-container .grid-search-result:hover .overview-icon,
+#dash .dash-item-container .search-provider-icon:hover .overview-icon,
+#dash .dash-item-container .list-search-result:hover .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#dash .dash-item-container .show-apps:active .overview-icon,
+#dash .dash-item-container .overview-tile:active .overview-icon,
+#dash .dash-item-container .grid-search-result:active .overview-icon,
+#dash .dash-item-container .search-provider-icon:active .overview-icon,
+#dash .dash-item-container .list-search-result:active .overview-icon {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+#dash .dash-item-container .show-apps:checked .overview-icon,
+#dash .dash-item-container .overview-tile:checked .overview-icon,
+#dash .dash-item-container .grid-search-result:checked .overview-icon,
+#dash .dash-item-container .search-provider-icon:checked .overview-icon,
+#dash .dash-item-container .list-search-result:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+#dash .dash-item-container .show-apps:insensitive .overview-icon,
+#dash .dash-item-container .overview-tile:insensitive .overview-icon,
+#dash .dash-item-container .grid-search-result:insensitive .overview-icon,
+#dash .dash-item-container .search-provider-icon:insensitive .overview-icon,
+#dash .dash-item-container .list-search-result:insensitive .overview-icon {
+  background-color: transparent;
+}
+
+#dash .dash-item-container .app-grid-running-dot {
+  offset-y: -8px;
+}
+
+#dash .dash-separator {
+  width: 1px;
+  margin-left: 2px;
+  margin-right: 2px;
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#dash .dash-separator,
+#dash .dash-background {
+  margin-bottom: 6px;
+}
+
+.dash-label {
+  border-radius: 3px;
+  padding: 4px 8px;
+  margin: 4px;
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(0, 0, 0, 0.75);
+  border: none;
+  box-shadow: none;
+  text-align: center;
+  -y-offset: 2px;
+}
+
+/* App Grid */
+.icon-grid {
+  row-spacing: 12px;
+  column-spacing: 12px;
+  max-row-spacing: 36px;
+  max-column-spacing: 36px;
+  page-padding-top: 24px;
+  page-padding-bottom: 24px;
+  page-padding-left: 18px;
+  page-padding-right: 18px;
+}
+
+/* App Icons */
+.overview-tile, .grid-search-result, .search-provider-icon, .list-search-result {
+  border-radius: 9px;
+  padding: 12px;
+  spacing: 6px;
+  transition-duration: 150ms;
+  text-align: center;
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.85);
+  border: 1px solid transparent;
+  box-shadow: inset 0 1px transparent;
+}
+
+.overview-tile:hover, .grid-search-result:hover, .search-provider-icon:hover, .list-search-result:hover, .overview-tile:focus, .grid-search-result:focus, .search-provider-icon:focus, .list-search-result:focus, .overview-tile:highlighted, .grid-search-result:highlighted, .search-provider-icon:highlighted, .list-search-result:highlighted, .overview-tile:selected, .grid-search-result:selected, .search-provider-icon:selected, .list-search-result:selected {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+  transition-duration: 0ms;
+  border-image: none;
+  background-image: none;
+}
+
+.overview-tile:active, .grid-search-result:active, .search-provider-icon:active, .list-search-result:active, .overview-tile:checked, .grid-search-result:checked, .search-provider-icon:checked, .list-search-result:checked {
+  background-color: rgba(255, 255, 255, 0.15);
+  transition-duration: 150ms;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.overview-tile .overview-icon.overview-icon-with-label > StBoxLayout, .grid-search-result .overview-icon.overview-icon-with-label > StBoxLayout, .search-provider-icon .overview-icon.overview-icon-with-label > StBoxLayout, .list-search-result .overview-icon.overview-icon-with-label > StBoxLayout {
+  spacing: 4px;
+}
+
+.app-folder {
+  background-color: rgba(255, 255, 255, 0.13);
+}
+
+.app-folder:focus {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.app-folder:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.app-folder:active {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.app-folder:highlighted, .app-folder:selected, .app-folder:checked {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.app-folder:insensitive {
+  background-color: transparent;
+}
+
+.app-grid-running-dot {
+  width: 6px;
+  height: 3px;
+  border-radius: 2px;
+  background-color: rgba(255, 255, 255, 0.5);
+  margin-bottom: 1px;
+}
+
+StWidget.focused .app-grid-running-dot {
+  width: 18px;
+  background-color: #3281ea;
+}
+
+.app-folder-dialog-container {
+  padding-top: 30px;
+}
+
+.app-folder-dialog {
+  width: 720px;
+  height: 720px;
+  border-radius: 12px;
+  background-color: rgba(34, 34, 34, 0.95);
+  color: white;
+  border: none;
+  box-shadow: none;
+}
+
+.app-folder-dialog .folder-name-container {
+  padding: 24px 36px 0;
+  spacing: 12px;
+  /* FIXME: this is to keep the label in sync with the entry */
+}
+
+.app-folder-dialog .folder-name-container .folder-name-label, .app-folder-dialog .folder-name-container .folder-name-entry {
+  font-size: 18pt;
+  font-weight: 800;
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry {
+  border: none;
+  color: #FFFFFF;
+  background-color: rgba(255, 255, 255, 0.15);
+  caret-color: #FFFFFF;
+  selection-background-color: #3281ea;
+  selected-color: #FFFFFF;
+  width: 300px;
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:focus {
+  color: #FFFFFF;
+  background-color: rgba(255, 255, 255, 0.25);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry .search-entry-icon {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:hover .search-entry-icon, .app-folder-dialog .folder-name-container .folder-name-entry:focus .search-entry-icon {
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:insensitive, .app-folder-dialog .folder-name-container .folder-name-entry StLabel.hint-text {
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-label {
+  padding: 5px 7px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.app-folder-dialog .folder-name-container .icon-button, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button {
+  background-color: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.7);
+  border: none;
+  padding: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 18px;
+}
+
+.app-folder-dialog .folder-name-container .icon-button > StIcon, .app-folder-dialog .folder-name-container .background-app-item .icon-button > StIcon, .app-folder-dialog .folder-name-container .message-notification-group .background-app-item .message-collapse-button > StIcon, .app-folder-dialog .folder-name-container .message .message-header .background-app-item .message-expand-button > StIcon,
+.app-folder-dialog .folder-name-container .message .message-header .background-app-item .message-close-button > StIcon, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button > StIcon, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button > StIcon, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button > StIcon, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button > StIcon,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button > StIcon,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button > StIcon {
+  icon-size: 16px;
+}
+
+.app-folder-dialog .folder-name-container .icon-button:hover, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button:hover, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button:hover, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:hover, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:hover,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:hover,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.app-folder-dialog .folder-name-container .icon-button:focus, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button:focus, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button:focus, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:focus, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:focus,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:focus,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:focus {
+  border: none !important;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.app-folder-dialog .folder-name-container .icon-button:checked, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button:checked, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button:checked, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:checked, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:checked,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:checked,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:checked, .app-folder-dialog .folder-name-container .icon-button:active, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button:active, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button:active, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:active, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:active,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:active,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:active {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.app-folder-dialog .icon-grid {
+  row-spacing: 12px;
+  column-spacing: 30px;
+  page-padding-top: 0;
+  page-padding-bottom: 0;
+  page-padding-left: 0;
+  page-padding-right: 0;
+}
+
+.app-folder-dialog .page-indicators {
+  margin-bottom: 18px;
+}
+
+.rename-folder-popup .rename-folder-popup-item {
+  spacing: 4px;
+}
+
+.rename-folder-popup .rename-folder-popup-item:ltr, .rename-folder-popup .rename-folder-popup-item:rtl {
+  padding: 0 8px;
+}
+
+.app-menu,
+.app-well-menu {
+  max-width: 27.25em;
+}
+
+.page-indicator {
+  padding: 4px 8px 0;
+}
+
+.page-indicator .page-indicator-icon {
+  width: 10px;
+  height: 10px;
+  border-radius: 10px;
+  background-color: white;
+  transition-duration: 400ms;
+}
+
+.apps-scroll-view {
+  padding: 0;
+}
+
+.system-action-icon {
+  background-color: rgba(0, 0, 0, 0.8);
+  color: white;
+  border-radius: 9999px;
+  icon-size: 8px;
+}
+
+.page-navigation-hint.dnd {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.page-navigation-hint.next:ltr, .page-navigation-hint.previous:rtl {
+  background-gradient-start: rgba(255, 255, 255, 0.05);
+  background-gradient-end: transparent;
+  background-gradient-direction: horizontal;
+  border-radius: 15px 0px 0px 15px;
+}
+
+.page-navigation-hint.previous:ltr, .page-navigation-hint.next:rtl {
+  background-gradient-start: transparent;
+  background-gradient-end: rgba(255, 255, 255, 0.05);
+  background-gradient-direction: horizontal;
+  border-radius: 0px 15px 15px 0px;
+}
+
+.page-navigation-arrow {
+  margin: 6px;
+  padding: 18px;
+  width: 24px;
+  height: 24px;
+  border-radius: 9999px;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+}
+
+.page-navigation-arrow > StIcon {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.page-navigation-arrow:insensitive {
+  background-color: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.page-navigation-arrow:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+  color: white;
+}
+
+.page-navigation-arrow:active {
+  background-color: rgba(255, 255, 255, 0.2);
+  color: white;
+}
+
+/* Workspace pager */
+.workspace-thumbnails .workspace-thumbnail {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.13);
+  border: none;
+}
+
+.workspace-thumbnails {
+  visible-width: 32px;
+  spacing: 4px;
+  padding: 4px;
+}
+
+.workspace-thumbnails .workspace-thumbnail {
+  border-radius: 3px;
+}
+
+.workspace-thumbnails .placeholder {
+  background-image: url("resource:///org/gnome/shell/theme/dash-placeholder.svg");
+  background-size: contain;
+  width: 18px;
+}
+
+.workspace-thumbnail-indicator {
+  border: 3px solid #3281ea;
+  border-radius: 6px;
+  padding: 0px;
+}
+
+.ripple-pointer-location {
+  width: 48px;
+  height: 48px;
+  border-radius: 24px;
+  background-color: rgba(189, 214, 248, 0.3);
+  box-shadow: 0 0 2px 2px #8fbaf3;
+}
+
+.pie-timer {
+  width: 60px;
+  height: 60px;
+  -pie-border-width: 3px;
+  -pie-border-color: #3281ea;
+  -pie-background-color: rgba(235, 243, 253, 0.3);
+}
+
+.magnifier-zoom-region {
+  border: 2px solid #3281ea;
+}
+
+.magnifier-zoom-region.full-screen {
+  border-width: 0;
+}
+
+.select-area-rubberband {
+  background-color: rgba(50, 129, 234, 0.3);
+  border: 1px solid #3281ea;
+}
+
+.user-icon {
+  background-size: contain;
+  color: rgba(255, 255, 255, 0.7);
+  border-radius: 9999px;
+  icon-size: 64px;
+}
+
+.user-icon:hover {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.user-icon StIcon {
+  background-color: rgba(255, 255, 255, 0.05);
+  border-radius: 99px;
+  padding: 8px;
+  width: 40px;
+  height: 40px;
+}
+
+.user-icon.user-avatar {
+  border: 2px rgba(255, 255, 255, 0.7);
+}
+
+.user-widget.vertical .user-icon {
+  icon-size: 128px;
+}
+
+.user-widget.vertical .user-icon StIcon {
+  padding: 14px;
+  padding-top: 12px;
+  padding-bottom: 16px;
+  width: 88px;
+  height: 88px;
+}
+
+.lightbox {
+  background-color: black;
+}
+
+.flashspot {
+  background-color: white;
+}
+
+.hidden {
+  color: rgba(0, 0, 0, 0);
+}
+
+.caps-lock-warning-label {
+  text-align: center;
+  padding-bottom: 8px;
+  font-size: 9.75pt;
+  font-weight: 400;
+  color: #FF6D00;
+}
+
+/* Workspace animation */
+.workspace-animation {
+  background-color: #222222;
+}
+
+/* Tiled window previews */
+.tile-preview {
+  background-color: rgba(36, 120, 233, 0.3);
+  border: 1px solid #2478e9;
+}
+
+.tile-preview-left.on-primary {
+  border-radius: 4px 0 0 0;
+}
+
+.tile-preview-right.on-primary {
+  border-radius: 0 4px 0 0;
+}
+
+.tile-preview-left.tile-preview-right.on-primary {
+  border-radius: 4px 4px 0 0;
+}
+
+/* On-screen Keyboard */
+#keyboard {
+  background-color: rgba(26, 26, 26, 0.95);
+  border: none;
+  border-top-width: 0;
+  box-shadow: none;
+}
+
+#keyboard .page-indicator {
+  padding: 4px;
+}
+
+#keyboard .page-indicator .page-indicator-icon {
+  width: 8px;
+  height: 8px;
+}
+
+.key-container {
+  padding: 2px;
+  spacing: 2px;
+}
+
+.keyboard-key {
+  min-height: 2em;
+  min-width: 2em;
+  font-size: 14pt;
+  font-weight: bold;
+  border-radius: 3px;
+  border: none;
+  color: inherit;
+  background-color: #4b4b4b;
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.1);
+}
+
+.keyboard-key:focus, .keyboard-key:hover {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: #656565;
+}
+
+.keyboard-key:checked, .keyboard-key:active {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: #7e7e7e;
+}
+
+.keyboard-key:grayed {
+  background-color: rgba(32, 32, 32, 0.75);
+  color: rgba(255, 255, 255, 0.85);
+  border-color: rgba(32, 32, 32, 0.75);
+}
+
+.keyboard-key.default-key {
+  background-color: #323232;
+}
+
+.keyboard-key.default-key:focus, .keyboard-key.default-key:hover {
+  color: rgba(255, 255, 255, 0.8);
+  background-color: #4c4c4c;
+}
+
+.keyboard-key.default-key:checked, .keyboard-key.default-key:active {
+  color: rgba(255, 255, 255, 0.8);
+  background-color: #585858;
+}
+
+.keyboard-key.enter-key {
+  background-color: #3281ea;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.keyboard-key.enter-key:focus, .keyboard-key.enter-key:hover {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #498fec;
+}
+
+.keyboard-key.enter-key:checked, .keyboard-key.enter-key:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #1667d3;
+}
+
+.keyboard-key.shift-key-uppercase {
+  color: #3281ea;
+}
+
+.keyboard-key StIcon {
+  icon-size: 1.125em;
+}
+
+.keyboard-subkeys {
+  color: inherit;
+  -arrow-border-radius: 3px;
+  -arrow-background-color: rgba(0, 0, 0, 0.45);
+  -arrow-border-width: 0;
+  -arrow-border-color: transparent;
+  -arrow-base: 20px;
+  -arrow-rise: 10px;
+  -boxpointer-gap: 5px;
+}
+
+.emoji-page .keyboard-key {
+  background-color: transparent;
+  border: none;
+  color: initial;
+}
+
+.emoji-panel .keyboard-key:latched {
+  border-color: #498fec;
+  background-color: #3281ea;
+}
+
+.word-suggestions {
+  font-size: 14pt;
+  spacing: 12px;
+  min-height: 20pt;
+}
+
+/* Looking Glass */
+#LookingGlassDialog {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: #202020;
+  spacing: 4px;
+  padding: 6px;
+  border: none;
+  border-radius: 3px;
+  box-shadow: 0 14px 14px rgba(0, 0, 0, 0.5);
+}
+
+#LookingGlassDialog > #Toolbar {
+  padding: 0 8px;
+  border: none;
+  border-radius: 0;
+  background-color: rgba(32, 32, 32, 0.01);
+  box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button:hover {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.06);
+  box-shadow: none;
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button:active {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.15);
+  box-shadow: 0 0 transparent;
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button:focus {
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: none;
+}
+
+#LookingGlassDialog .labels {
+  spacing: 0;
+}
+
+#LookingGlassDialog .notebook-tab {
+  -natural-hpadding: 12px;
+  -minimum-hpadding: 6px;
+  font-weight: bold;
+  color: rgba(255, 255, 255, 0.5);
+  transition-duration: 150ms;
+  padding-left: 16px;
+  padding-right: 16px;
+  min-height: 32px;
+  padding: 0 32px;
+  border-radius: 0;
+}
+
+#LookingGlassDialog .notebook-tab:hover {
+  box-shadow: inset 0 -2px 0 rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.9);
+  text-shadow: none;
+}
+
+#LookingGlassDialog .notebook-tab:selected {
+  background-color: rgba(32, 32, 32, 0.01);
+  box-shadow: inset 0 -2px 0 #3281ea;
+  color: rgba(255, 255, 255, 0.9);
+  text-shadow: none;
+}
+
+#LookingGlassDialog StBoxLayout#EvalBox {
+  padding: 4px;
+  spacing: 4px;
+}
+
+#LookingGlassDialog StBoxLayout#ResultsArea {
+  spacing: 4px;
+}
+
+.lg-dialog StEntry {
+  selection-background-color: #3281ea;
+  selected-color: rgba(255, 255, 255, 0.85) !important;
+}
+
+.lg-dialog .shell-link {
+  color: #3281ea;
+}
+
+.lg-dialog .shell-link:hover {
+  color: #3281ea;
+}
+
+.lg-completions-text {
+  font-size: 1em;
+  font-style: italic;
+}
+
+.lg-obj-inspector-title {
+  spacing: 4px;
+}
+
+.lg-obj-inspector-button {
+  min-height: 32px;
+  padding: 0 16px;
+  border: none;
+  border-radius: 3px;
+  font-size: 9.75pt;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.lg-obj-inspector-button:hover {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.06);
+  box-shadow: none;
+}
+
+.lg-obj-inspector-button:active {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.15);
+  box-shadow: 0 0 transparent;
+}
+
+.lg-obj-inspector-button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.lg-obj-inspector-button:focus {
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: none;
+}
+
+.lg-obj-inspector-button:hover {
+  border: none;
+}
+
+#lookingGlassExtensions {
+  padding: 4px;
+}
+
+.lg-extensions-list {
+  padding: 4px;
+  spacing: 6px;
+}
+
+.lg-extension {
+  border: none;
+  border-radius: 3px;
+  background-color: #606060;
+  padding: 4px;
+}
+
+.lg-extension-name {
+  font-size: 18pt;
+  font-weight: 400;
+}
+
+.lg-extension-meta {
+  spacing: 6px;
+}
+
+#LookingGlassPropertyInspector {
+  background: #202020;
+  border: none;
+  border-radius: 3px;
+  padding: 6px;
+  box-shadow: 0 14px 14px rgba(0, 0, 0, 0.5);
+}
+
+.quick-settings {
+  border-radius: 3px !important;
+  margin: 4px !important;
+  padding: 8px 10px 12px !important;
+}
+
+.quick-settings .icon-button, .quick-settings .message-notification-group .message-collapse-button, .message-notification-group .quick-settings .message-collapse-button, .quick-settings .message .message-header .message-expand-button, .message .message-header .quick-settings .message-expand-button,
+.quick-settings .message .message-header .message-close-button,
+.message .message-header .quick-settings .message-close-button, .quick-settings .button {
+  padding: 6px;
+}
+
+.quick-settings .icon-button > StIcon, .quick-settings .background-app-item .icon-button > StIcon, .quick-settings .message-notification-group .background-app-item .message-collapse-button > StIcon, .quick-settings .message .message-header .background-app-item .message-expand-button > StIcon,
+.quick-settings .message .message-header .background-app-item .message-close-button > StIcon, .quick-settings .message-notification-group .message-collapse-button > StIcon, .message-notification-group .quick-settings .message-collapse-button > StIcon, .quick-settings .message .message-header .message-expand-button > StIcon, .message .message-header .quick-settings .message-expand-button > StIcon,
+.quick-settings .message .message-header .message-close-button > StIcon,
+.message .message-header .quick-settings .message-close-button > StIcon, .quick-settings .button > StIcon {
+  icon-size: 16px;
+}
+
+.quick-settings-grid {
+  spacing-rows: 8px;
+  spacing-columns: 8px;
+}
+
+.quick-toggle, .quick-menu-toggle {
+  border-radius: 3px;
+  min-width: 12em;
+  max-width: 12em;
+  min-height: 38px;
+  padding: 0;
+  border: none;
+}
+
+.quick-toggle {
+  background-color: rgba(255, 255, 255, 0.06) !important;
+  /* Move padding into the box; this is to allow menu arrows
+       to extend to the border */
+}
+
+.quick-toggle:hover {
+  background-color: rgba(255, 255, 255, 0.12) !important;
+}
+
+.quick-toggle:active {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+.quick-toggle:checked {
+  background-color: #3281ea !important;
+  color: white;
+}
+
+.quick-toggle:checked:hover {
+  background-color: rgba(60, 135, 235, 0.994) !important;
+  color: white;
+}
+
+.quick-toggle:checked:active {
+  background-color: rgba(76, 145, 237, 0.985) !important;
+  color: white;
+}
+
+.quick-toggle > StBoxLayout {
+  spacing: 6px;
+}
+
+.quick-toggle.button {
+  padding: 0;
+}
+
+.quick-toggle > StBoxLayout {
+  padding: 0 8px;
+}
+
+.quick-toggle:ltr > StBoxLayout {
+  padding-left: 16px;
+}
+
+.quick-toggle:rtl > StBoxLayout {
+  padding-right: 16px;
+}
+
+.quick-toggle .quick-toggle-title {
+  font-weight: bold;
+}
+
+.quick-toggle StBoxLayout > .quick-toggle-subtitle {
+  font-weight: normal;
+  font-size: 12px;
+}
+
+.quick-toggle .quick-toggle-icon {
+  icon-size: 16px;
+}
+
+.quick-toggle-has-menu .quick-toggle {
+  min-width: auto;
+  max-width: auto;
+}
+
+.quick-toggle-has-menu .quick-toggle:ltr {
+  border-radius: 3px 0 0 3px;
+}
+
+.quick-toggle-has-menu .quick-toggle:ltr > StBoxLayout {
+  padding-right: 8px;
+}
+
+.quick-toggle-has-menu .quick-toggle:rtl {
+  border-radius: 0 3px 3px 0;
+}
+
+.quick-toggle-has-menu .quick-toggle:rtr > StBoxLayout {
+  padding-left: 8px;
+}
+
+.quick-toggle-has-menu .quick-toggle:ltr:last-child {
+  border-radius: 3px;
+}
+
+.quick-toggle-has-menu .quick-toggle:rtl:last-child {
+  border-radius: 3px;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button {
+  padding: 4px 8px;
+  border: none;
+  background-color: rgba(255, 255, 255, 0.06) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:hover {
+  background-color: rgba(255, 255, 255, 0.12) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:active {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:checked {
+  background-color: #3281ea !important;
+  color: white;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:checked:hover {
+  color: white;
+  background-color: st-mix(rgba(255, 255, 255, 0.9), #3281ea, 6%) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:checked:active {
+  color: white;
+  background-color: st-mix(rgba(255, 255, 255, 0.9), #3281ea, 15%) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:ltr {
+  border-radius: 0 3px 3px 0;
+  border-left-width: 0;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:rtl {
+  border-radius: 3px 0 0 3px;
+  border-right-width: 0;
+}
+
+.quick-toggle-has-menu .quick-toggle-separator {
+  width: 0;
+}
+
+.quick-slider > StBoxLayout {
+  spacing: 4px;
+}
+
+.quick-slider .slider-bin {
+  min-height: 16px;
+  padding: 4px;
+  border-radius: 9999px;
+}
+
+.quick-slider .slider-bin:focus {
+  color: #3281ea;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.quick-slider .slider-bin:focus:hover, .quick-slider .slider-bin:focus:active {
+  color: #3281ea;
+}
+
+.quick-slider .quick-toggle-icon {
+  icon-size: 16px;
+}
+
+.quick-slider .icon-button, .quick-slider .message-notification-group .message-collapse-button, .message-notification-group .quick-slider .message-collapse-button, .quick-slider .message .message-header .message-expand-button, .message .message-header .quick-slider .message-expand-button,
+.quick-slider .message .message-header .message-close-button,
+.message .message-header .quick-slider .message-close-button {
+  min-width: 22px;
+  min-height: 22px;
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.9) !important;
+}
+
+.quick-slider .icon-button:hover, .quick-slider .message-notification-group .message-collapse-button:hover, .message-notification-group .quick-slider .message-collapse-button:hover, .quick-slider .message .message-header .message-expand-button:hover, .message .message-header .quick-slider .message-expand-button:hover,
+.quick-slider .message .message-header .message-close-button:hover,
+.message .message-header .quick-slider .message-close-button:hover {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.quick-slider .icon-button:active, .quick-slider .message-notification-group .message-collapse-button:active, .message-notification-group .quick-slider .message-collapse-button:active, .quick-slider .message .message-header .message-expand-button:active, .message .message-header .quick-slider .message-expand-button:active,
+.quick-slider .message .message-header .message-close-button:active,
+.message .message-header .quick-slider .message-close-button:active {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.quick-toggle-menu {
+  background-color: #2d2d2d !important;
+  color: rgba(255, 255, 255, 0.9) !important;
+  border-radius: 3px !important;
+  padding: 12px;
+  margin: 8px 24px 0;
+  border: none !important;
+}
+
+.quick-toggle-menu .popup-menu-item {
+  border-radius: 3px !important;
+  min-height: 20px;
+}
+
+.quick-toggle-menu .popup-menu-item:focus, .quick-toggle-menu .popup-menu-item:hover, .quick-toggle-menu .popup-menu-item.selected {
+  color: rgba(255, 255, 255, 0.9) !important;
+  background-color: rgba(255, 255, 255, 0.1) !important;
+}
+
+.quick-toggle-menu .popup-menu-item:active {
+  color: rgba(255, 255, 255, 0.9) !important;
+  background-color: rgba(255, 255, 255, 0.2) !important;
+}
+
+.quick-toggle-menu .popup-menu-item > StIcon {
+  -st-icon-style: symbolic;
+}
+
+.quick-toggle-menu .header {
+  spacing-rows: 2px;
+  spacing-columns: 8px;
+  padding-bottom: 8px;
+}
+
+.quick-toggle-menu .header .icon {
+  icon-size: 24px;
+  border-radius: 3px;
+  padding: 6px;
+  background-color: rgba(255, 255, 255, 0.06) !important;
+}
+
+.quick-toggle-menu .header .icon.active {
+  background-color: #3281ea !important;
+  color: white;
+}
+
+.quick-settings-system-item > StBoxLayout {
+  spacing: 8px;
+}
+
+.quick-settings-system-item .icon-button, .quick-settings-system-item .message-notification-group .message-collapse-button, .message-notification-group .quick-settings-system-item .message-collapse-button, .quick-settings-system-item .message .message-header .message-expand-button, .message .message-header .quick-settings-system-item .message-expand-button,
+.quick-settings-system-item .message .message-header .message-close-button,
+.message .message-header .quick-settings-system-item .message-close-button {
+  background-color: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.9);
+  border-radius: 3px;
+  min-height: 22px;
+  min-width: 22px !important;
+}
+
+.quick-settings-system-item .icon-button:hover, .quick-settings-system-item .message-notification-group .message-collapse-button:hover, .message-notification-group .quick-settings-system-item .message-collapse-button:hover, .quick-settings-system-item .message .message-header .message-expand-button:hover, .message .message-header .quick-settings-system-item .message-expand-button:hover,
+.quick-settings-system-item .message .message-header .message-close-button:hover,
+.message .message-header .quick-settings-system-item .message-close-button:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.quick-settings-system-item .icon-button:active, .quick-settings-system-item .message-notification-group .message-collapse-button:active, .message-notification-group .quick-settings-system-item .message-collapse-button:active, .quick-settings-system-item .message .message-header .message-expand-button:active, .message .message-header .quick-settings-system-item .message-expand-button:active,
+.quick-settings-system-item .message .message-header .message-close-button:active,
+.message .message-header .quick-settings-system-item .message-close-button:active {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.quick-settings-system-item .icon-button > StIcon, .quick-settings-system-item .background-app-item .icon-button > StIcon, .quick-settings-system-item .message-notification-group .background-app-item .message-collapse-button > StIcon, .quick-settings-system-item .message .message-header .background-app-item .message-expand-button > StIcon,
+.quick-settings-system-item .message .message-header .background-app-item .message-close-button > StIcon, .quick-settings-system-item .message-notification-group .message-collapse-button > StIcon, .message-notification-group .quick-settings-system-item .message-collapse-button > StIcon, .quick-settings-system-item .message .message-header .message-expand-button > StIcon, .message .message-header .quick-settings-system-item .message-expand-button > StIcon,
+.quick-settings-system-item .message .message-header .message-close-button > StIcon,
+.message .message-header .quick-settings-system-item .message-close-button > StIcon {
+  -st-icon-style: symbolic;
+  icon-size: 16px;
+}
+
+.quick-settings-system-item .power-item {
+  min-height: 0;
+  min-width: 0;
+}
+
+.quick-settings-system-item .power-item:insensitive {
+  color: rgba(255, 255, 255, 0.8);
+  background-color: #343434;
+  border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: none;
+  background-color: transparent;
+}
+
+.nm-network-item .wireless-secure-icon {
+  icon-size: 8px;
+}
+
+.bt-device-item .popup-menu-icon {
+  -st-icon-style: symbolic;
+}
+
+.bt-menu-placeholder.popup-menu-item {
+  text-align: center;
+  padding: 2em 4em;
+}
+
+.device-subtitle {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.keyboard-brightness-level {
+  spacing: 4px;
+}
+
+.background-apps-quick-toggle {
+  min-height: 40px;
+  background-color: transparent;
+}
+
+.background-apps-quick-toggle StIcon {
+  icon-size: 16px !important;
+}
+
+.background-app-item .popup-menu-icon {
+  icon-size: 24px !important;
+  -st-icon-style: regular !important;
+}
+
+.background-app-item .icon-button, .background-app-item .message-notification-group .message-collapse-button, .message-notification-group .background-app-item .message-collapse-button, .background-app-item .message .message-header .message-expand-button, .message .message-header .background-app-item .message-expand-button,
+.background-app-item .message .message-header .message-close-button,
+.message .message-header .background-app-item .message-close-button {
+  padding: 4px;
+}
+
+.background-app-item .spinner {
+  padding: 4px;
+}
+
+.background-app-item.popup-inactive-menu-item {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.icon-label-button-container {
+  spacing: 4px;
+  font-size: 9pt;
+  font-weight: 400;
+}
+
+.icon-label-button-container StIcon {
+  icon-size: 32px;
+}
+
+.screenshot-ui-panel {
+  border-radius: 27px;
+  padding: 12px;
+  padding-bottom: 6px;
+  margin-bottom: 4em;
+  spacing: 8px;
+}
+
+.screenshot-ui-close-button {
+  padding: 4px;
+}
+
+.screenshot-ui-close-button.left {
+  margin-left: 8px;
+}
+
+.screenshot-ui-close-button.right {
+  margin-right: 8px;
+}
+
+.screenshot-ui-type-button {
+  padding: 8px 12px !important;
+  border-radius: 15px;
+}
+
+.screenshot-ui-capture-button {
+  width: 36px;
+  height: 36px;
+  border-radius: 9999px;
+  border: 4px rgba(255, 255, 255, 0.85);
+  padding: 4px;
+}
+
+.screenshot-ui-capture-button .screenshot-ui-capture-button-circle {
+  background-color: rgba(255, 255, 255, 0.85);
+  transition-duration: 200ms;
+  border-radius: 9999px;
+}
+
+.screenshot-ui-capture-button .screenshot-ui-capture-button-circle:hover, .screenshot-ui-capture-button .screenshot-ui-capture-button-circle:focus {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.screenshot-ui-capture-button:hover .screenshot-ui-capture-button-circle, .screenshot-ui-capture-button:focus .screenshot-ui-capture-button-circle {
+  background-color: rgba(217, 217, 217, 0.85);
+}
+
+.screenshot-ui-capture-button:active .screenshot-ui-capture-button-circle {
+  background-color: rgba(128, 128, 128, 0.85);
+}
+
+.screenshot-ui-capture-button:cast .screenshot-ui-capture-button-circle {
+  background-color: #DD2C00;
+}
+
+.screenshot-ui-capture-button:cast:hover .screenshot-ui-capture-button-circle, .screenshot-ui-capture-button:cast:focus .screenshot-ui-capture-button-circle {
+  background-color: #911d00;
+}
+
+.screenshot-ui-capture-button:cast:active .screenshot-ui-capture-button-circle {
+  background-color: #440e00;
+}
+
+.screenshot-ui-shot-cast-container {
+  background-color: rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  padding: 3px;
+  spacing: 3px;
+}
+
+.screenshot-ui-shot-cast-container:ltr {
+  margin-left: 9px;
+}
+
+.screenshot-ui-shot-cast-container:rtl {
+  margin-right: 9px;
+}
+
+.screenshot-ui-shot-cast-button {
+  padding: 4px 8px;
+  background-color: transparent;
+  border-radius: 3px;
+}
+
+.screenshot-ui-shot-cast-button:hover, .screenshot-ui-shot-cast-button:focus {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.screenshot-ui-shot-cast-button:active {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.screenshot-ui-shot-cast-button:checked {
+  background-color: white;
+  color: black;
+}
+
+.screenshot-ui-shot-cast-button StIcon {
+  icon-size: 16px;
+}
+
+.screenshot-ui-show-pointer-button {
+  border-radius: 9999px;
+  padding: 8px !important;
+}
+
+.screenshot-ui-show-pointer-button StIcon {
+  icon-size: 16px;
+}
+
+.screenshot-ui-area-indicator-shade {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.screenshot-ui-area-selector .screenshot-ui-area-indicator-shade {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.screenshot-ui-area-selector .screenshot-ui-area-indicator-selection {
+  border: 2px white;
+}
+
+.screenshot-ui-area-selector-handle {
+  border-radius: 9999px;
+  background-color: white;
+  box-shadow: 0 1px 3px 2px rgba(0, 0, 0, 0.2);
+  width: 24px;
+  height: 24px;
+}
+
+.screenshot-ui-window-selector {
+  background-color: #222222;
+}
+
+.screenshot-ui-window-selector .screenshot-ui-window-selector-window-container {
+  margin: 100px;
+}
+
+.screenshot-ui-window-selector:primary-monitor .screenshot-ui-window-selector-window-container {
+  margin-bottom: 200px;
+}
+
+.screenshot-ui-window-selector-window-border {
+  transition-duration: 200ms;
+  border-radius: 6px;
+  border: 6px transparent;
+}
+
+.screenshot-ui-window-selector-check {
+  transition-duration: 200ms;
+  color: transparent;
+  border-radius: 9999px;
+  border-width: 12px;
+  icon-size: 24px;
+}
+
+.screenshot-ui-window-selector-window:hover .screenshot-ui-window-selector-window-border {
+  border-color: #135cbc;
+}
+
+.screenshot-ui-window-selector-window:checked .screenshot-ui-window-selector-window-border {
+  border-color: #3281ea;
+  background-color: rgba(50, 129, 234, 0.2);
+}
+
+.screenshot-ui-window-selector-window:checked .screenshot-ui-window-selector-check {
+  color: white;
+  background-color: #3281ea;
+}
+
+.screenshot-ui-screen-selector {
+  transition-duration: 200ms;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.screenshot-ui-screen-selector:hover {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.screenshot-ui-screen-selector:active {
+  background-color: rgba(0, 0, 0, 0.7);
+}
+
+.screenshot-ui-screen-selector:checked {
+  background-color: transparent;
+  border: 2px white;
+}
+
+.screenshot-ui-tooltip {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #222222;
+  border-radius: 99px;
+  padding: 4px 8px;
+  text-align: center;
+  -y-offset: 24px;
+}
+
+/* Login Dialog */
+.login-dialog-banner-view {
+  padding-top: 24px;
+  max-width: 23em;
+}
+
+.login-dialog,
+.unlock-dialog {
+  border: none;
+  background-color: transparent;
+}
+
+.login-dialog StEntry,
+.unlock-dialog StEntry {
+  selection-background-color: #3281ea;
+  selected-color: rgba(255, 255, 255, 0.85) !important;
+  caret-color: rgba(255, 255, 255, 0.7);
+  color: rgba(255, 255, 255, 0.7);
+  background-color: rgba(255, 255, 255, 0.15);
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+.login-dialog StEntry:focus,
+.unlock-dialog StEntry:focus {
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #3281ea !important;
+}
+
+.login-dialog StEntry:insensitive,
+.unlock-dialog StEntry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog .modal-dialog-button-box,
+.unlock-dialog .modal-dialog-button-box {
+  spacing: 3px;
+}
+
+.login-dialog .modal-dialog-button,
+.unlock-dialog .modal-dialog-button {
+  padding: 4px 18px;
+  box-shadow: none;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:hover, .login-dialog .modal-dialog-button:focus,
+.unlock-dialog .modal-dialog-button:hover,
+.unlock-dialog .modal-dialog-button:focus {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.15);
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:active,
+.unlock-dialog .modal-dialog-button:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.3);
+  box-shadow: 0 0 transparent;
+}
+
+.login-dialog .modal-dialog-button:insensitive,
+.unlock-dialog .modal-dialog-button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default,
+.unlock-dialog .modal-dialog-button:default {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #408aeb;
+  border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:hover, .login-dialog .modal-dialog-button:default:focus,
+.unlock-dialog .modal-dialog-button:default:hover,
+.unlock-dialog .modal-dialog-button:default:focus {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #408aeb;
+  border-color: rgba(255, 255, 255, 0.15);
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:active,
+.unlock-dialog .modal-dialog-button:default:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #5798ee;
+  border-color: rgba(255, 255, 255, 0.15);
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:active:hover, .login-dialog .modal-dialog-button:default:active:focus,
+.unlock-dialog .modal-dialog-button:default:active:hover,
+.unlock-dialog .modal-dialog-button:default:active:focus {
+  background-color: #5798ee;
+}
+
+.login-dialog .modal-dialog-button:default:insensitive,
+.unlock-dialog .modal-dialog-button:default:insensitive {
+  color: rgba(255, 255, 255, 0.5);
+  background-color: rgba(255, 255, 255, 0.15);
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.login-dialog .cancel-button,
+.login-dialog .switch-user-button,
+.login-dialog .login-dialog-session-list-button,
+.unlock-dialog .cancel-button,
+.unlock-dialog .switch-user-button,
+.unlock-dialog .login-dialog-session-list-button {
+  padding: 0;
+  border-radius: 99px;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog .cancel-button:hover, .login-dialog .cancel-button:focus,
+.login-dialog .switch-user-button:hover,
+.login-dialog .switch-user-button:focus,
+.login-dialog .login-dialog-session-list-button:hover,
+.login-dialog .login-dialog-session-list-button:focus,
+.unlock-dialog .cancel-button:hover,
+.unlock-dialog .cancel-button:focus,
+.unlock-dialog .switch-user-button:hover,
+.unlock-dialog .switch-user-button:focus,
+.unlock-dialog .login-dialog-session-list-button:hover,
+.unlock-dialog .login-dialog-session-list-button:focus {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog .cancel-button:active,
+.login-dialog .switch-user-button:active,
+.login-dialog .login-dialog-session-list-button:active,
+.unlock-dialog .cancel-button:active,
+.unlock-dialog .switch-user-button:active,
+.unlock-dialog .login-dialog-session-list-button:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.login-dialog .cancel-button StIcon,
+.login-dialog .switch-user-button StIcon,
+.login-dialog .login-dialog-session-list-button StIcon,
+.unlock-dialog .cancel-button StIcon,
+.unlock-dialog .switch-user-button StIcon,
+.unlock-dialog .login-dialog-session-list-button StIcon {
+  icon-size: 16px;
+}
+
+.login-dialog .caps-lock-warning-label,
+.login-dialog .login-dialog-message-warning,
+.unlock-dialog .caps-lock-warning-label,
+.unlock-dialog .login-dialog-message-warning {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-logo-bin {
+  padding: 24px 0px;
+}
+
+.login-dialog-banner {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog-button-box {
+  width: 23em;
+  spacing: 5px;
+}
+
+.login-dialog-message {
+  text-align: center;
+}
+
+.login-dialog-user-selection-box {
+  padding: 100px 0px;
+}
+
+.login-dialog-not-listed-label {
+  padding-left: 2px;
+  font-size: 1em;
+  font-weight: bold;
+  color: rgba(255, 255, 255, 0.7);
+  padding-top: 1em;
+}
+
+.login-dialog-not-listed-label:hover {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-not-listed-label:focus {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.login-dialog-not-listed-button:focus .login-dialog-not-listed-label, .login-dialog-not-listed-button:hover .login-dialog-not-listed-label {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-view {
+  -st-vfade-offset: 1em;
+}
+
+.login-dialog-user-list {
+  spacing: 12px;
+  width: 23em;
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:selected {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:active {
+  background-color: rgba(255, 255, 255, 0.3);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:logged-in {
+  border-right: 2px solid rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-item {
+  border-radius: 3px;
+  padding: 6px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog-user-list-item:ltr {
+  padding-right: 1em;
+}
+
+.login-dialog-user-list-item:rtl {
+  padding-left: 1em;
+}
+
+.login-dialog-user-list-item:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-item:active {
+  background-color: rgba(255, 255, 255, 0.3);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-item .login-dialog-timed-login-indicator {
+  height: 2px;
+  margin: 6px 0 0 0;
+  background-color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-item:focus .login-dialog-timed-login-indicator {
+  background-color: rgba(255, 255, 255, 0.85);
+}
+
+.user-widget-label {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.user-widget.horizontal .user-widget-label {
+  font-size: 15pt;
+  font-weight: 500;
+  font-weight: bold;
+  padding-left: 15px;
+}
+
+.user-widget.horizontal .user-widget-label:ltr {
+  padding-left: 14px;
+  text-align: left;
+}
+
+.user-widget.horizontal .user-widget-label:rtl {
+  padding-right: 14px;
+  text-align: right;
+}
+
+.user-widget.vertical .user-widget-label {
+  font-size: 15pt;
+  font-weight: 500;
+  text-align: center;
+  font-weight: normal;
+  padding-top: 16px;
+}
+
+.login-dialog-prompt-layout {
+  padding-top: 24px;
+  padding-bottom: 12px;
+  spacing: 8px;
+  width: 23em;
+}
+
+.login-dialog-prompt-entry {
+  height: 1.5em;
+}
+
+.login-dialog-prompt-label {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 1em;
+  padding-top: 1em;
+}
+
+/* Screen Shield */
+.unlock-dialog-clock {
+  color: white;
+  font-weight: 300;
+  text-align: center;
+  spacing: 24px;
+  padding-bottom: 2.5em;
+}
+
+.unlock-dialog-clock-time {
+  font-size: 64pt;
+  padding-top: 42px;
+  font-feature-settings: "tnum";
+}
+
+.unlock-dialog-clock-date {
+  font-size: 16pt;
+  font-weight: normal;
+}
+
+.unlock-dialog-clock-hint {
+  font-weight: normal;
+  padding-top: 48px;
+}
+
+.unlock-dialog-notifications-container {
+  margin: 12px 0;
+  spacing: 6px;
+  width: 23em;
+  background-color: transparent;
+}
+
+.unlock-dialog-notifications-container .summary-notification-stack-scrollview {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.unlock-dialog-notifications-container .notification,
+.unlock-dialog-notifications-container .unlock-dialog-notification-source {
+  padding: 12px 6px;
+  border: none;
+  background-color: rgba(32, 32, 32, 0.9);
+  color: rgba(255, 255, 255, 0.85);
+  border-radius: 3px;
+}
+
+.unlock-dialog-notifications-container .notification.critical,
+.unlock-dialog-notifications-container .unlock-dialog-notification-source.critical {
+  background-color: rgba(34, 34, 34, 0.9);
+}
+
+.unlock-dialog-notification-label {
+  padding: 0px 0px 0px 12px;
+}
+
+.unlock-dialog-notification-count-text {
+  weight: bold;
+  padding: 0 6px;
+  color: rgba(32, 32, 32, 0.9);
+  background-color: rgba(255, 255, 255, 0.7);
+  border-radius: 99px;
+  margin-right: 12px;
+}
+
+.screen-shield-background {
+  background: black;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.6);
+}
+
+#lockDialogGroup {
+  background-color: #222222;
+}
+
+#unlockDialogNotifications StButton#vhandle, #unlockDialogNotifications StButton#hhandle {
+  background-color: rgba(32, 32, 32, 0.2);
+}
+
+#unlockDialogNotifications StButton#vhandle:hover, #unlockDialogNotifications StButton#vhandle:focus, #unlockDialogNotifications StButton#hhandle:hover, #unlockDialogNotifications StButton#hhandle:focus {
+  background-color: rgba(32, 32, 32, 0.4);
+}
+
+#unlockDialogNotifications StButton#vhandle:active, #unlockDialogNotifications StButton#hhandle:active {
+  background-color: rgba(50, 129, 234, 0.5);
+}
+
+.bottom #dashtodockDashScrollview,
+.top #dashtodockDashScrollview {
+  -st-hfade-offset: 24px;
+}
+
+.left #dashtodockDashScrollview,
+.right #dashtodockDashScrollview {
+  -st-vfade-offset: 24px;
+}
+
+#dashtodockContainer {
+  background-color: transparent;
+  box-shadow: none;
+}
+
+#dashtodockContainer .number-overlay {
+  color: #FFFFFF;
+  background-color: rgba(0, 0, 0, 0.75);
+  text-align: center;
+}
+
+#dashtodockContainer .notification-badge {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #3281ea;
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.25);
+  border-radius: 9999px;
+  margin: 2px 3px 5px;
+  padding: 0.2em 0.6em;
+  font-weight: bold;
+  text-align: center;
+}
+
+#dashtodockContainer.top.straight-corner #dash, #dashtodockContainer.top.shrink.straight-corner #dash, #dashtodockContainer.top.extended #dash, #dashtodockContainer.top.extended:overview #dash {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.straight-corner #dash .dash-background, #dashtodockContainer.top.shrink.straight-corner #dash .dash-background, #dashtodockContainer.top.extended #dash .dash-background, #dashtodockContainer.top.extended:overview #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.top.straight-corner #dash .show-apps,
+#dashtodockContainer.top.straight-corner #dash .overview-tile,
+#dashtodockContainer.top.straight-corner #dash .grid-search-result,
+#dashtodockContainer.top.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.top.straight-corner #dash .list-search-result, #dashtodockContainer.top.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.top.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.top.extended #dash .show-apps,
+#dashtodockContainer.top.extended #dash .overview-tile,
+#dashtodockContainer.top.extended #dash .grid-search-result,
+#dashtodockContainer.top.extended #dash .search-provider-icon,
+#dashtodockContainer.top.extended #dash .list-search-result, #dashtodockContainer.top.extended:overview #dash .show-apps,
+#dashtodockContainer.top.extended:overview #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash, #dashtodockContainer.bottom.shrink.straight-corner #dash, #dashtodockContainer.bottom.extended #dash, #dashtodockContainer.bottom.extended:overview #dash {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash .dash-background, #dashtodockContainer.bottom.shrink.straight-corner #dash .dash-background, #dashtodockContainer.bottom.extended #dash .dash-background, #dashtodockContainer.bottom.extended:overview #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash .show-apps,
+#dashtodockContainer.bottom.straight-corner #dash .overview-tile,
+#dashtodockContainer.bottom.straight-corner #dash .grid-search-result,
+#dashtodockContainer.bottom.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.bottom.straight-corner #dash .list-search-result, #dashtodockContainer.bottom.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.bottom.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.bottom.extended #dash .show-apps,
+#dashtodockContainer.bottom.extended #dash .overview-tile,
+#dashtodockContainer.bottom.extended #dash .grid-search-result,
+#dashtodockContainer.bottom.extended #dash .search-provider-icon,
+#dashtodockContainer.bottom.extended #dash .list-search-result, #dashtodockContainer.bottom.extended:overview #dash .show-apps,
+#dashtodockContainer.bottom.extended:overview #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash, #dashtodockContainer.left.shrink.straight-corner #dash, #dashtodockContainer.left.extended #dash, #dashtodockContainer.left.extended:overview #dash {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash .dash-background, #dashtodockContainer.left.shrink.straight-corner #dash .dash-background, #dashtodockContainer.left.extended #dash .dash-background, #dashtodockContainer.left.extended:overview #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash .show-apps,
+#dashtodockContainer.left.straight-corner #dash .overview-tile,
+#dashtodockContainer.left.straight-corner #dash .grid-search-result,
+#dashtodockContainer.left.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.left.straight-corner #dash .list-search-result, #dashtodockContainer.left.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.left.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.left.extended #dash .show-apps,
+#dashtodockContainer.left.extended #dash .overview-tile,
+#dashtodockContainer.left.extended #dash .grid-search-result,
+#dashtodockContainer.left.extended #dash .search-provider-icon,
+#dashtodockContainer.left.extended #dash .list-search-result, #dashtodockContainer.left.extended:overview #dash .show-apps,
+#dashtodockContainer.left.extended:overview #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash, #dashtodockContainer.right.shrink.straight-corner #dash, #dashtodockContainer.right.extended #dash, #dashtodockContainer.right.extended:overview #dash {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash .dash-background, #dashtodockContainer.right.shrink.straight-corner #dash .dash-background, #dashtodockContainer.right.extended #dash .dash-background, #dashtodockContainer.right.extended:overview #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash .show-apps,
+#dashtodockContainer.right.straight-corner #dash .overview-tile,
+#dashtodockContainer.right.straight-corner #dash .grid-search-result,
+#dashtodockContainer.right.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.right.straight-corner #dash .list-search-result, #dashtodockContainer.right.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.right.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.right.extended #dash .show-apps,
+#dashtodockContainer.right.extended #dash .overview-tile,
+#dashtodockContainer.right.extended #dash .grid-search-result,
+#dashtodockContainer.right.extended #dash .search-provider-icon,
+#dashtodockContainer.right.extended #dash .list-search-result, #dashtodockContainer.right.extended:overview #dash .show-apps,
+#dashtodockContainer.right.extended:overview #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.extended #dash .dash-background, #dashtodockContainer.straight-corner #dash .dash-background {
+  border-radius: 0;
+}
+
+#dashtodockContainer.shrink #dash .dash-background {
+  padding: 0 !important;
+  border-radius: 3px;
+}
+
+#dashtodockContainer.shrink #dash .show-apps,
+#dashtodockContainer.shrink #dash .overview-tile,
+#dashtodockContainer.shrink #dash .grid-search-result,
+#dashtodockContainer.shrink #dash .search-provider-icon,
+#dashtodockContainer.shrink #dash .list-search-result {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left #dash .overview-tile, #dashtodockContainer.left #dash .grid-search-result, #dashtodockContainer.left #dash .search-provider-icon, #dashtodockContainer.left #dash .list-search-result, #dashtodockContainer.right #dash .overview-tile, #dashtodockContainer.right #dash .grid-search-result, #dashtodockContainer.right #dash .search-provider-icon, #dashtodockContainer.right #dash .list-search-result {
+  padding: 1px 4px !important;
+}
+
+#dashtodockContainer.left #dash .show-apps, #dashtodockContainer.right #dash .show-apps {
+  padding-bottom: 4px !important;
+}
+
+#dashtodockContainer.left.shrink #dash .show-apps,
+#dashtodockContainer.left.shrink #dash .overview-tile,
+#dashtodockContainer.left.shrink #dash .grid-search-result,
+#dashtodockContainer.left.shrink #dash .search-provider-icon,
+#dashtodockContainer.left.shrink #dash .list-search-result, #dashtodockContainer.right.shrink #dash .show-apps,
+#dashtodockContainer.right.shrink #dash .overview-tile,
+#dashtodockContainer.right.shrink #dash .grid-search-result,
+#dashtodockContainer.right.shrink #dash .search-provider-icon,
+#dashtodockContainer.right.shrink #dash .list-search-result {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.extended #dash .show-apps,
+#dashtodockContainer.left.extended #dash .overview-tile,
+#dashtodockContainer.left.extended #dash .grid-search-result,
+#dashtodockContainer.left.extended #dash .search-provider-icon,
+#dashtodockContainer.left.extended #dash .list-search-result, #dashtodockContainer.left.straight-corner #dash .show-apps,
+#dashtodockContainer.left.straight-corner #dash .overview-tile,
+#dashtodockContainer.left.straight-corner #dash .grid-search-result,
+#dashtodockContainer.left.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.left.straight-corner #dash .list-search-result, #dashtodockContainer.right.extended #dash .show-apps,
+#dashtodockContainer.right.extended #dash .overview-tile,
+#dashtodockContainer.right.extended #dash .grid-search-result,
+#dashtodockContainer.right.extended #dash .search-provider-icon,
+#dashtodockContainer.right.extended #dash .list-search-result, #dashtodockContainer.right.straight-corner #dash .show-apps,
+#dashtodockContainer.right.straight-corner #dash .overview-tile,
+#dashtodockContainer.right.straight-corner #dash .grid-search-result,
+#dashtodockContainer.right.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.right.straight-corner #dash .list-search-result {
+  padding: 1px 8px !important;
+}
+
+#dashtodockContainer.top.shrink #dash .dash-background, #dashtodockContainer.bottom.shrink #dash .dash-background {
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.shrink #dash .show-apps,
+#dashtodockContainer.top.shrink #dash .overview-tile,
+#dashtodockContainer.top.shrink #dash .grid-search-result,
+#dashtodockContainer.top.shrink #dash .search-provider-icon,
+#dashtodockContainer.top.shrink #dash .list-search-result, #dashtodockContainer.bottom.shrink #dash .show-apps,
+#dashtodockContainer.bottom.shrink #dash .overview-tile,
+#dashtodockContainer.bottom.shrink #dash .grid-search-result,
+#dashtodockContainer.bottom.shrink #dash .search-provider-icon,
+#dashtodockContainer.bottom.shrink #dash .list-search-result {
+  margin: 0 !important;
+  padding: 0 0 18px !important;
+}
+
+#dashtodockContainer.top.extended #dash .dash-separator, #dashtodockContainer.top.straight-corner #dash .dash-separator, #dashtodockContainer.bottom.extended #dash .dash-separator, #dashtodockContainer.bottom.straight-corner #dash .dash-separator {
+  margin: 0 5px !important;
+}
+
+#dashtodockContainer.top.extended #dash .show-apps,
+#dashtodockContainer.top.extended #dash .overview-tile,
+#dashtodockContainer.top.extended #dash .grid-search-result,
+#dashtodockContainer.top.extended #dash .search-provider-icon,
+#dashtodockContainer.top.extended #dash .list-search-result, #dashtodockContainer.top.straight-corner #dash .show-apps,
+#dashtodockContainer.top.straight-corner #dash .overview-tile,
+#dashtodockContainer.top.straight-corner #dash .grid-search-result,
+#dashtodockContainer.top.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.top.straight-corner #dash .list-search-result, #dashtodockContainer.bottom.extended #dash .show-apps,
+#dashtodockContainer.bottom.extended #dash .overview-tile,
+#dashtodockContainer.bottom.extended #dash .grid-search-result,
+#dashtodockContainer.bottom.extended #dash .search-provider-icon,
+#dashtodockContainer.bottom.extended #dash .list-search-result, #dashtodockContainer.bottom.straight-corner #dash .show-apps,
+#dashtodockContainer.bottom.straight-corner #dash .overview-tile,
+#dashtodockContainer.bottom.straight-corner #dash .grid-search-result,
+#dashtodockContainer.bottom.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.bottom.straight-corner #dash .list-search-result {
+  padding: 8px 1px !important;
+}
+
+#dashtodockContainer #dash {
+  background: none;
+  box-shadow: none;
+}
+
+#dashtodockContainer #dash .dash-background {
+  background-color: rgba(0, 0, 0, 0.5);
+  background-clip: padding-box;
+}
+
+#dashtodockContainer #dash .show-apps .overview-icon,
+#dashtodockContainer #dash .overview-tile .overview-icon,
+#dashtodockContainer #dash .grid-search-result .overview-icon,
+#dashtodockContainer #dash .search-provider-icon .overview-icon,
+#dashtodockContainer #dash .list-search-result .overview-icon {
+  color: rgba(255, 255, 255, 0.75) !important;
+}
+
+#dashtodockContainer #dash .show-apps:hover .overview-icon, #dashtodockContainer #dash .show-apps:focus .overview-icon, #dashtodockContainer #dash .show-apps:selected .overview-icon,
+#dashtodockContainer #dash .overview-tile:hover .overview-icon,
+#dashtodockContainer #dash .grid-search-result:hover .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:hover .overview-icon,
+#dashtodockContainer #dash .list-search-result:hover .overview-icon,
+#dashtodockContainer #dash .overview-tile:focus .overview-icon,
+#dashtodockContainer #dash .grid-search-result:focus .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:focus .overview-icon,
+#dashtodockContainer #dash .list-search-result:focus .overview-icon,
+#dashtodockContainer #dash .overview-tile:selected .overview-icon,
+#dashtodockContainer #dash .grid-search-result:selected .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:selected .overview-icon,
+#dashtodockContainer #dash .list-search-result:selected .overview-icon {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+  color: #FFFFFF !important;
+}
+
+#dashtodockContainer #dash .show-apps:active .overview-icon, #dashtodockContainer #dash .show-apps:checked .overview-icon,
+#dashtodockContainer #dash .overview-tile:active .overview-icon,
+#dashtodockContainer #dash .grid-search-result:active .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:active .overview-icon,
+#dashtodockContainer #dash .list-search-result:active .overview-icon,
+#dashtodockContainer #dash .overview-tile:checked .overview-icon,
+#dashtodockContainer #dash .grid-search-result:checked .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:checked .overview-icon,
+#dashtodockContainer #dash .list-search-result:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+  color: #FFFFFF !important;
+}
+
+#dashtodockContainer .dash-separator {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#dashtodockContainer .app-grid-running-dot {
+  background-color: rgba(255, 255, 255, 0.55) !important;
+  margin: 0 0 3px !important;
+  offset-y: 0 !important;
+}
+
+#dashtodockContainer StWidget.focused .overview-icon {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+}
+
+#dashtodockContainer StWidget.focused:hover .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#dashtodockContainer StWidget.focused .app-grid-running-dot {
+  background-color: #3281ea !important;
+}
+
+#dashtodockContainer.opaque #dash .dash-background {
+  background-color: #202020;
+}
+
+#dashtodockContainer.transparent #dash .dash-background {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+#dashtodockContainer:overview #dash .dash-background {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+#dashtodockContainer:overview #dash .show-apps .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result .overview-icon {
+  color: rgba(255, 255, 255, 0.7) !important;
+}
+
+#dashtodockContainer:overview #dash .show-apps:hover .overview-icon, #dashtodockContainer:overview #dash .show-apps:focus .overview-icon, #dashtodockContainer:overview #dash .show-apps:selected .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:hover .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:hover .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:hover .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:hover .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:focus .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:focus .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:focus .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:focus .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:selected .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:selected .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:selected .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:selected .overview-icon {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+  color: rgba(255, 255, 255, 0.85) !important;
+}
+
+#dashtodockContainer:overview #dash .show-apps:active .overview-icon, #dashtodockContainer:overview #dash .show-apps:checked .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:active .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:active .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:active .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:active .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:checked .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:checked .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:checked .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+  color: rgba(255, 255, 255, 0.85) !important;
+}
+
+#dashtodockContainer:overview #dash .dash-separator {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#dashtodockContainer:overview #dash .app-grid-running-dot {
+  background-color: rgba(255, 255, 255, 0.5) !important;
+}
+
+#dashtodockContainer:overview #dash StWidget.focused .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#dashtodockContainer:overview #dash StWidget.focused:hover .overview-icon {
+  background-color: rgba(255, 255, 255, 0.3) !important;
+}
+
+#dashtodockContainer:overview #dash StWidget.focused .app-grid-running-dot {
+  background-color: #3281ea !important;
+}
+
+#dashtodockContainer.opaque:overview #dash, #dashtodockContainer.transparent:overview #dash {
+  background-color: transparent !important;
+  box-shadow: none !important;
+}
+
+#dashtodockContainer.opaque:overview #dash .dash-background, #dashtodockContainer.transparent:overview #dash .dash-background {
+  background-color: transparent !important;
+}
+
+#dashtodockContainer.extended:overview #dash, #dashtodockContainer.opaque.extended:overview #dash, #dashtodockContainer.transparent.extended:overview #dash {
+  background: none;
+}
+
+#dashtodockContainer.extended:overview .dash-background, #dashtodockContainer.opaque.extended:overview .dash-background, #dashtodockContainer.transparent.extended:overview .dash-background {
+  background-color: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#dashtodockContainer.running-dots .dash-item-container > StButton, #dashtodockContainer.dashtodock .dash-item-container > StButton {
+  transition-duration: 250ms;
+  background-size: contain;
+}
+
+#dashtodockContainer.extended .show-apps .overview-icon,
+#dashtodockContainer.extended .overview-tile .overview-icon,
+#dashtodockContainer.extended .grid-search-result .overview-icon,
+#dashtodockContainer.extended .search-provider-icon .overview-icon,
+#dashtodockContainer.extended .list-search-result .overview-icon, #dashtodockContainer.extended:overview .show-apps .overview-icon,
+#dashtodockContainer.extended:overview .overview-tile .overview-icon {
+  border-radius: 3px;
+}
+
+#dashtodockContainer .metro .overview-icon {
+  border-radius: 0;
+}
+
+.dashtodock-app-well-preview-menu-item {
+  padding: 1em 1em 0.5em 1em;
+}
+
+#dashtodockPreviewSeparator.popup-separator-menu-item-horizontal {
+  width: 1px;
+  height: auto;
+  border-right-width: 1px;
+  margin: 32px 0;
+}
+
+.dashtopanelMainPanel .show-apps,
+.dashtopanelMainPanel .overview-tile,
+.dashtopanelMainPanel .grid-search-result,
+.dashtopanelMainPanel .search-provider-icon,
+.dashtopanelMainPanel .list-search-result {
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+}
+
+.dashtopanelMainPanel .show-apps .overview-icon,
+.dashtopanelMainPanel .overview-tile .overview-icon,
+.dashtopanelMainPanel .grid-search-result .overview-icon,
+.dashtopanelMainPanel .search-provider-icon .overview-icon,
+.dashtopanelMainPanel .list-search-result .overview-icon {
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+}
+
+.dashtopanelMainPanel .show-apps .overview-icon {
+  border-radius: 3px !important;
+  color: rgba(255, 255, 255, 0.75) !important;
+}
+
+.dashtopanelMainPanel .show-apps:hover .overview-icon, .dashtopanelMainPanel .show-apps:focus .overview-icon, .dashtopanelMainPanel .show-apps:selected .overview-icon {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+  color: #FFFFFF !important;
+  box-shadow: none !important;
+}
+
+.dashtopanelMainPanel .show-apps:active .overview-icon, .dashtopanelMainPanel .show-apps:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+  color: #FFFFFF !important;
+  box-shadow: none !important;
+}
+
+.dashtopanelMainPanel .panel-button {
+  color: rgba(255, 255, 255, 0.75) !important;
+}
+
+.openweather-button, .openweather-button-action, .openweather-menu-button-container, .openweather-button-box {
+  border: 1px solid transparent !important;
+}
+
+.openweather-provider {
+  padding: 0 16px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.openweather-provider:hover {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.06);
+  box-shadow: none;
+}
+
+.openweather-provider:focus {
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: none;
+}
+
+.openweather-provider:active {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.15);
+  box-shadow: 0 0 transparent;
+}
+
+.openweather-current-icon, .openweather-current-summary, .openweather-current-summarybox {
+  background: none;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.openweather-current-databox-values {
+  background: none;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.openweather-current-databox-captions {
+  background: none;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.openweather-forecast-icon, .openweather-forecast-summary {
+  background: none;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.openweather-forecast-day, .openweather-forecast-temperature {
+  background: none;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.openweather-sunrise-icon, .openweather-sunset-icon, .openweather-build-icon {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.gsconnect-device-menu .popup-menu-item {
+  height: 20px !important;
+  padding: 2px 0;
+}
+
+.gsconnect-device-menu .popup-menu-item > :last-child:ltr {
+  padding-right: 4px !important;
+  margin-right: 8px !important;
+}
+
+.gsconnect-device-menu .popup-menu-item > :last-child:rtl {
+  padding-left: 4px !important;
+  padding-left: 8px !important;
+}
+
+#panel.light-panel .panel-button,
+#panel.dark-panel .panel-button,
+#panel.transparent-panel .panel-button {
+  color: rgba(255, 255, 255, 0.7) !important;
+}
+
+#panel.light-panel .panel-button.clock-display .clock,
+#panel.dark-panel .panel-button.clock-display .clock,
+#panel.transparent-panel .panel-button.clock-display .clock {
+  color: rgba(255, 255, 255, 0.7) !important;
+}
+
+#panel.light-panel .panel-button:hover,
+#panel.dark-panel .panel-button:hover,
+#panel.transparent-panel .panel-button:hover {
+  color: rgba(255, 255, 255, 0.7) !important;
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#panel.light-panel .panel-button:active, #panel.light-panel .panel-button:checked, #panel.light-panel .panel-button:focus,
+#panel.dark-panel .panel-button:active,
+#panel.dark-panel .panel-button:checked,
+#panel.dark-panel .panel-button:focus,
+#panel.transparent-panel .panel-button:active,
+#panel.transparent-panel .panel-button:checked,
+#panel.transparent-panel .panel-button:focus {
+  color: rgba(255, 255, 255, 0.85) !important;
+  background-color: rgba(255, 255, 255, 0.3) !important;
+}
+
+#panel.light-panel .panel-button:hover.clock-display .clock, #panel.light-panel .panel-button:active.clock-display .clock, #panel.light-panel .panel-button:overview.clock-display .clock, #panel.light-panel .panel-button:focus.clock-display .clock, #panel.light-panel .panel-button:checked.clock-display .clock,
+#panel.dark-panel .panel-button:hover.clock-display .clock,
+#panel.dark-panel .panel-button:active.clock-display .clock,
+#panel.dark-panel .panel-button:overview.clock-display .clock,
+#panel.dark-panel .panel-button:focus.clock-display .clock,
+#panel.dark-panel .panel-button:checked.clock-display .clock,
+#panel.transparent-panel .panel-button:hover.clock-display .clock,
+#panel.transparent-panel .panel-button:active.clock-display .clock,
+#panel.transparent-panel .panel-button:overview.clock-display .clock,
+#panel.transparent-panel .panel-button:focus.clock-display .clock,
+#panel.transparent-panel .panel-button:checked.clock-display .clock {
+  color: rgba(255, 255, 255, 0.85) !important;
+}
+
+.overview-components-transparent .search-entry,
+.overview-components-light .search-entry,
+.overview-components-dark .search-entry {
+  caret-color: rgba(255, 255, 255, 0.75) !important;
+}
+
+.overview-components-transparent .search-entry .search-entry-icon,
+.overview-components-light .search-entry .search-entry-icon,
+.overview-components-dark .search-entry .search-entry-icon {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.overview-components-transparent .search-entry StLabel.hint-text,
+.overview-components-light .search-entry StLabel.hint-text,
+.overview-components-dark .search-entry StLabel.hint-text {
+  color: rgba(255, 255, 255, 0.35) !important;
+}
+
+.arcmenu-menu {
+  border-image: none !important;
+  border-radius: 3px !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+}
+
+.arcmenu-menu .popup-menu-content {
+  padding: 4px !important;
+  margin: 4px !important;
+  border: none !important;
+  background-color: rgba(32, 32, 32, 0.97);
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.1) !important;
+  border-radius: 3px !important;
+}

--- a/src/gnome-shell/shell-48-0/gnome-shell-Dark-compact.scss
+++ b/src/gnome-shell/shell-48-0/gnome-shell-Dark-compact.scss
@@ -1,0 +1,10 @@
+$variant: 'dark';
+$laptop: 'true';
+$panel: 'dark';
+
+@import '../sass/variables';
+@import '../sass/colors';
+@import '../sass/drawing';
+@import '../sass/common-40-0';
+@import '../sass/widgets-48-0';
+@import '../sass/extensions-46-0';

--- a/src/gnome-shell/shell-48-0/gnome-shell-Dark.css
+++ b/src/gnome-shell/shell-48-0/gnome-shell-Dark.css
@@ -1,0 +1,4945 @@
+/* This stylesheet is generated, DO NOT EDIT */
+stage {
+  font-size: 10.5pt;
+  font-weight: 400;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+/* Common Stylings */
+#dash .dash-item-container .show-apps,
+#dash .dash-item-container .overview-tile,
+#dash .dash-item-container .grid-search-result,
+#dash .dash-item-container .search-provider-icon,
+#dash .dash-item-container .list-search-result {
+  background: none;
+  box-shadow: none;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  margin: 0;
+}
+
+#dash .dash-item-container .show-apps .overview-icon,
+#dash .dash-item-container .overview-tile .overview-icon,
+#dash .dash-item-container .grid-search-result .overview-icon,
+#dash .dash-item-container .search-provider-icon .overview-icon,
+#dash .dash-item-container .list-search-result .overview-icon {
+  border-radius: 6px;
+  padding: 6px;
+  spacing: 6px;
+  text-align: center;
+  transition-duration: 100ms;
+}
+
+.search-statustext {
+  font-size: 45px;
+  font-weight: 400;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.popup-menu-content {
+  background: rgba(32, 32, 32, 0.97);
+  color: rgba(255, 255, 255, 0.9);
+  border-radius: 3px;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.1);
+}
+
+.modal-dialog {
+  background: rgba(32, 32, 32, 0.97);
+  color: rgba(255, 255, 255, 0.9);
+  border-radius: 6px;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2);
+}
+
+/* General Typography */
+.message-notification-group .message-group-header .message-group-title, .message-list .message-list-placeholder {
+  font-weight: 800;
+  font-size: 1.364em;
+}
+
+.quick-toggle-menu .header .title {
+  font-weight: 700;
+  font-size: 1.364em;
+}
+
+.bt-menu-placeholder.popup-menu-item {
+  font-weight: 700;
+  font-size: 1.182em;
+}
+
+.background-app-item .title, .message-list-controls, .calendar .calendar-month-header .calendar-month-label {
+  font-weight: 700;
+  font-size: 1em;
+}
+
+.quick-toggle-menu .header .subtitle {
+  font-weight: 700;
+  font-size: 0.818em;
+}
+
+.background-app-item .subtitle, .message .message-header .message-header-content .event-time {
+  font-weight: 400;
+  font-size: 0.818em;
+}
+
+/* WIDGETS */
+.shell-link {
+  border-radius: 3px;
+  color: #3281ea;
+  background-color: transparent;
+}
+
+.shell-link:hover {
+  color: #3281ea;
+  background-color: rgba(50, 129, 234, 0.15);
+}
+
+.shell-link:active {
+  color: #3281ea;
+  background-color: rgba(50, 129, 234, 0.3);
+}
+
+.lowres-icon {
+  icon-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+}
+
+.icon-dropshadow {
+  icon-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+}
+
+/* Entries */
+StEntry {
+  min-height: 24px;
+  padding: 3px 9px;
+  border-radius: 3px;
+  border-width: 0;
+  caret-color: rgba(255, 255, 255, 0.7);
+  selection-background-color: #3281ea;
+  selected-color: #FFFFFF !important;
+  font-size: 12pt;
+  font-weight: 400;
+  caret-color: rgba(255, 255, 255, 0.7);
+  color: rgba(255, 255, 255, 0.7);
+  background-color: rgba(255, 255, 255, 0.15);
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+StEntry:hover {
+  border: 2px solid rgba(255, 255, 255, 0.15) !important;
+}
+
+StEntry:focus {
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #3281ea !important;
+}
+
+StEntry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+StEntry StIcon.capslock-warning {
+  icon-size: 16px;
+  warning-color: #FF6D00;
+  padding: 0 0;
+}
+
+StEntry StIcon.peek-password {
+  icon-size: 16px;
+  padding: 0 4px;
+}
+
+StEntry StLabel.hint-text {
+  margin-left: 2px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+/* Buttons */
+.screenshot-ui-show-pointer-button, .screenshot-ui-type-button {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:focus, .screenshot-ui-type-button:focus {
+  color: rgba(255, 255, 255, 0.85);
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:hover, .screenshot-ui-type-button:hover {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.15);
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:active, .screenshot-ui-type-button:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.3);
+  box-shadow: 0 0 transparent;
+}
+
+.screenshot-ui-show-pointer-button:checked, .screenshot-ui-type-button:checked {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #3281ea;
+  border-color: #3281ea;
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:checked:hover, .screenshot-ui-type-button:checked:hover, .screenshot-ui-show-pointer-button:checked:focus, .screenshot-ui-type-button:checked:focus {
+  background-color: #3281ea;
+}
+
+.screenshot-ui-show-pointer-button:insensitive, .screenshot-ui-type-button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.icon-button.flat, .message .message-header .flat.message-expand-button,
+.message .message-header .flat.message-close-button, .message-notification-group .flat.message-collapse-button, .button.flat {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.icon-button.flat:focus, .message .message-header .flat.message-expand-button:focus,
+.message .message-header .flat.message-close-button:focus, .message-notification-group .flat.message-collapse-button:focus, .button.flat:focus {
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: none;
+}
+
+.icon-button.flat:hover, .message .message-header .flat.message-expand-button:hover,
+.message .message-header .flat.message-close-button:hover, .message-notification-group .flat.message-collapse-button:hover, .button.flat:hover {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.06);
+  box-shadow: none;
+}
+
+.icon-button.flat:selected, .message .message-header .flat.message-expand-button:selected,
+.message .message-header .flat.message-close-button:selected, .message-notification-group .flat.message-collapse-button:selected, .button.flat:selected, .icon-button.flat:active, .message .message-header .flat.message-expand-button:active,
+.message .message-header .flat.message-close-button:active, .message-notification-group .flat.message-collapse-button:active, .button.flat:active {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.15);
+  box-shadow: 0 0 transparent;
+}
+
+.icon-button.flat:checked, .message .message-header .flat.message-expand-button:checked,
+.message .message-header .flat.message-close-button:checked, .message-notification-group .flat.message-collapse-button:checked, .button.flat:checked {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.15);
+  box-shadow: 0 0 transparent;
+}
+
+.icon-button.flat:insensitive, .message .message-header .flat.message-expand-button:insensitive,
+.message .message-header .flat.message-close-button:insensitive, .message-notification-group .flat.message-collapse-button:insensitive, .button.flat:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:checked, .icon-button.default, .message .message-header .default.message-expand-button,
+.message .message-header .default.message-close-button, .message-notification-group .default.message-collapse-button, .button.default {
+  color: #FFFFFF;
+  background-color: #3281ea;
+  border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:focus:checked, .icon-button.default:focus, .message .message-header .default.message-expand-button:focus,
+.message .message-header .default.message-close-button:focus, .message-notification-group .default.message-collapse-button:focus, .button.default:focus {
+  color: #3281ea;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.keyboard-brightness-level .button:focus:hover:checked, .icon-button.default:focus:hover, .message .message-header .default.message-expand-button:focus:hover,
+.message .message-header .default.message-close-button:focus:hover, .message-notification-group .default.message-collapse-button:focus:hover, .button.default:focus:hover, .keyboard-brightness-level .button:focus:active:checked, .icon-button.default:focus:active, .message .message-header .default.message-expand-button:focus:active,
+.message .message-header .default.message-close-button:focus:active, .message-notification-group .default.message-collapse-button:focus:active, .button.default:focus:active {
+  color: #3281ea;
+}
+
+.keyboard-brightness-level .button:hover:checked, .icon-button.default:hover, .message .message-header .default.message-expand-button:hover,
+.message .message-header .default.message-close-button:hover, .message-notification-group .default.message-collapse-button:hover, .button.default:hover {
+  color: #FFFFFF;
+  background-color: #3281ea;
+  border-color: rgba(255, 255, 255, 0.15);
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:insensitive:checked, .icon-button.default:insensitive, .message .message-header .default.message-expand-button:insensitive,
+.message .message-header .default.message-close-button:insensitive, .message-notification-group .default.message-collapse-button:insensitive, .button.default:insensitive {
+  color: #FFFFFF;
+  background-color: #3281ea;
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:active:checked, .icon-button.default:active, .message .message-header .default.message-expand-button:active,
+.message .message-header .default.message-close-button:active, .message-notification-group .default.message-collapse-button:active, .button.default:active {
+  color: #FFFFFF;
+  background-color: #498fec;
+  border-color: rgba(255, 255, 255, 0.15);
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:active:hover:checked, .icon-button.default:active:hover, .message .message-header .default.message-expand-button:active:hover,
+.message .message-header .default.message-close-button:active:hover, .message-notification-group .default.message-collapse-button:active:hover, .button.default:active:hover, .keyboard-brightness-level .button:active:focus:checked, .icon-button.default:active:focus, .message .message-header .default.message-expand-button:active:focus,
+.message .message-header .default.message-close-button:active:focus, .message-notification-group .default.message-collapse-button:active:focus, .button.default:active:focus {
+  background-color: #498fec;
+}
+
+.icon-button, .background-app-item .icon-button, .background-app-item .message-notification-group .message-collapse-button, .message-notification-group .background-app-item .message-collapse-button, .background-app-item .message .message-header .message-expand-button, .message .message-header .background-app-item .message-expand-button,
+.background-app-item .message .message-header .message-close-button,
+.message .message-header .background-app-item .message-close-button, .message .message-header .message-expand-button,
+.message .message-header .message-close-button, .message-notification-group .message-collapse-button, .button {
+  padding: 6px 12px;
+  border-width: 0;
+  border-radius: 3px;
+  font-size: 10.5pt;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.icon-button:focus, .message .message-header .message-expand-button:focus,
+.message .message-header .message-close-button:focus, .message-notification-group .message-collapse-button:focus, .button:focus {
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: none;
+}
+
+.icon-button:hover, .message .message-header .message-expand-button:hover,
+.message .message-header .message-close-button:hover, .message-notification-group .message-collapse-button:hover, .button:hover {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.06);
+  box-shadow: none;
+}
+
+.icon-button:selected, .message .message-header .message-expand-button:selected,
+.message .message-header .message-close-button:selected, .message-notification-group .message-collapse-button:selected, .button:selected, .icon-button:active, .message .message-header .message-expand-button:active,
+.message .message-header .message-close-button:active, .message-notification-group .message-collapse-button:active, .button:active {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.15);
+  box-shadow: 0 0 transparent;
+}
+
+.icon-button:checked, .message .message-header .message-expand-button:checked,
+.message .message-header .message-close-button:checked, .message-notification-group .message-collapse-button:checked, .button:checked {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #3281ea;
+  border-color: #3281ea;
+  box-shadow: none;
+}
+
+.icon-button:checked:hover, .message .message-header .message-expand-button:checked:hover,
+.message .message-header .message-close-button:checked:hover, .message-notification-group .message-collapse-button:checked:hover, .button:checked:hover, .icon-button:checked:focus, .message .message-header .message-expand-button:checked:focus,
+.message .message-header .message-close-button:checked:focus, .message-notification-group .message-collapse-button:checked:focus, .button:checked:focus {
+  background-color: #3281ea;
+}
+
+.icon-button:insensitive, .message .message-header .message-expand-button:insensitive,
+.message .message-header .message-close-button:insensitive, .message-notification-group .message-collapse-button:insensitive, .button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button, .notification-button {
+  border-radius: 3px;
+  border: 1px solid;
+  color: rgba(255, 255, 255, 0.8);
+  background-color: #343434;
+  border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button:focus, .notification-button:focus {
+  color: #3281ea;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.modal-dialog .modal-dialog-button:focus:hover, .notification-button:focus:hover, .modal-dialog .modal-dialog-button:focus:active, .notification-button:focus:active {
+  color: #3281ea;
+}
+
+.modal-dialog .modal-dialog-button:hover, .notification-button:hover {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: #343434;
+  border-color: rgba(255, 255, 255, 0.15);
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button:selected, .notification-button:selected, .modal-dialog .modal-dialog-button:active, .notification-button:active {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: #414141;
+  border-color: rgba(255, 255, 255, 0.15);
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button:selected:hover, .notification-button:selected:hover, .modal-dialog .modal-dialog-button:selected:focus, .notification-button:selected:focus, .modal-dialog .modal-dialog-button:active:hover, .notification-button:active:hover, .modal-dialog .modal-dialog-button:active:focus, .notification-button:active:focus {
+  background-color: #414141;
+}
+
+.modal-dialog .modal-dialog-button:checked, .notification-button:checked {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #3281ea;
+  border-color: #3281ea;
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button:checked:hover, .notification-button:checked:hover, .modal-dialog .modal-dialog-button:checked:focus, .notification-button:checked:focus {
+  background-color: #3281ea;
+}
+
+.modal-dialog .modal-dialog-button:insensitive, .notification-button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: #343434;
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.button {
+  min-height: 1.5em;
+}
+
+.icon-button, .background-app-item .icon-button, .background-app-item .message-notification-group .message-collapse-button, .message-notification-group .background-app-item .message-collapse-button, .background-app-item .message .message-header .message-expand-button, .message .message-header .background-app-item .message-expand-button,
+.background-app-item .message .message-header .message-close-button,
+.message .message-header .background-app-item .message-close-button, .message .message-header .message-expand-button,
+.message .message-header .message-close-button, .message-notification-group .message-collapse-button {
+  border-radius: 9999px;
+  padding: 0.818em;
+  min-height: 1.091em;
+}
+
+.icon-button StIcon, .background-app-item .icon-button StIcon, .background-app-item .message-notification-group .message-collapse-button StIcon, .message-notification-group .background-app-item .message-collapse-button StIcon, .background-app-item .message .message-header .message-expand-button StIcon, .message .message-header .background-app-item .message-expand-button StIcon,
+.background-app-item .message .message-header .message-close-button StIcon,
+.message .message-header .background-app-item .message-close-button StIcon, .message .message-header .message-expand-button StIcon,
+.message .message-header .message-close-button StIcon, .message-notification-group .message-collapse-button StIcon {
+  icon-size: 1.091em;
+  -st-icon-style: symbolic;
+}
+
+/* Check Boxes */
+.check-box StBoxLayout {
+  spacing: .8em;
+}
+
+.check-box StBin {
+  width: 24px;
+  height: 24px;
+  padding: 6px;
+  border-radius: 100px;
+  background-image: url("assets/checkbox-off.svg");
+}
+
+.check-box:focus StBin {
+  background-image: url("assets/checkbox-off.svg");
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.check-box:hover StBin {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.check-box:active StBin {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.check-box:checked StBin {
+  background-image: url("assets/checkbox.svg");
+}
+
+.check-box:focus:checked StBin {
+  background-image: url("assets/checkbox.svg");
+}
+
+.check-box:hover:checked StBin {
+  background-color: rgba(64, 138, 235, 0.15);
+}
+
+.check-box:active:checked StBin {
+  background-color: rgba(64, 138, 235, 0.3);
+}
+
+.check-box StIcon {
+  icon-size: 0;
+  padding: 0;
+  border: none;
+  background-color: transparent;
+  color: transparent;
+}
+
+.check-box:checked StIcon {
+  background-color: transparent;
+  color: transparent;
+}
+
+.check-box:checked:hover StIcon {
+  background-color: transparent;
+  color: transparent;
+}
+
+.check-box:checked:active StIcon {
+  background-color: transparent;
+  color: transparent;
+}
+
+/* Switches */
+.toggle-switch {
+  width: 40px;
+  height: 20px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+}
+
+.toggle-switch:hover {
+  background: transparent;
+  color: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.7);
+}
+
+.toggle-switch StIcon {
+  icon-size: 10px;
+}
+
+.toggle-switch .handle {
+  margin: 4px;
+  width: 12px;
+  height: 12px;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.7);
+  box-shadow: none;
+  transition-duration: 100ms;
+}
+
+.toggle-switch:checked {
+  background: #3281ea;
+  color: white;
+  border-color: #3281ea;
+}
+
+.toggle-switch:checked:hover {
+  background-color: #498fec;
+  color: white;
+  border-color: #498fec;
+}
+
+.toggle-switch:checked .handle {
+  background: white;
+}
+
+/* Slider */
+.slider {
+  height: 12px;
+  color: white;
+  -barlevel-height: 2px;
+  -barlevel-background-color: rgba(255, 255, 255, 0.15);
+  -barlevel-active-background-color: #408aeb;
+  -barlevel-overdrive-color: #FF5252;
+  -barlevel-overdrive-separator-width: 2px;
+  -slider-handle-radius: 6px;
+}
+
+.slider:hover {
+  color: white;
+}
+
+.slider:active {
+  color: #f2f2f2;
+}
+
+/* Scrollbars */
+StScrollView.vfade {
+  -st-vfade-offset: 32px;
+}
+
+StScrollView.hfade {
+  -st-hfade-offset: 32px;
+}
+
+StScrollBar {
+  padding: 0;
+}
+
+StScrollView StScrollBar {
+  min-width: 8px;
+  min-height: 8px;
+}
+
+StScrollBar StBin#trough {
+  border-radius: 9999px;
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+StScrollBar StButton#vhandle, StScrollBar StButton#hhandle {
+  border-radius: 9999px;
+  background-color: rgba(255, 255, 255, 0.5);
+  border: 4px solid transparent;
+}
+
+StScrollBar StButton#vhandle:hover, StScrollBar StButton#hhandle:hover {
+  background-color: rgba(255, 255, 255, 0.7);
+}
+
+StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
+  background-color: rgba(255, 255, 255, 0.9);
+}
+
+/* Popovers/Menus */
+.popup-menu-boxpointer, .candidate-popup-boxpointer {
+  -arrow-border-radius: 3px;
+  -arrow-background-color: transparent;
+  -arrow-border-width: 0;
+  -arrow-border-color: transparent;
+  -arrow-base: 27px;
+  -arrow-rise: 0;
+  -arrow-box-shadow: none;
+}
+
+.popup-menu {
+  min-width: 15em;
+  color: rgba(255, 255, 255, 0.9);
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+.popup-menu.panel-menu {
+  -boxpointer-gap: 4px;
+  margin-bottom: 1.75em;
+}
+
+.popup-menu-content {
+  padding: 6px;
+  margin: 2px 6px 10px;
+  border: none;
+}
+
+.popup-menu-item {
+  spacing: 6px;
+  padding: 6px 12px;
+  margin: 0;
+  color: rgba(255, 255, 255, 0.9);
+  transition-duration: 100ms;
+  border-radius: 3px;
+  background-image: none;
+  background-gradient-direction: none !important;
+}
+
+.popup-menu-item:ltr {
+  padding-right: 12px;
+  padding-left: 12px;
+}
+
+.popup-menu-item:rtl {
+  padding-right: 12px;
+  padding-left: 12px;
+}
+
+.popup-menu-item:checked {
+  background-color: rgba(255, 255, 255, 0.06) !important;
+  font-weight: normal;
+  border-radius: 3px 3px 0 0 !important;
+  border: none;
+  box-shadow: none;
+  color: rgba(255, 255, 255, 0.9) !important;
+  background-gradient-direction: none !important;
+}
+
+.popup-menu-item:checked.selected, .popup-menu-item:checked:hover, .popup-menu-item:checked:focus {
+  background-color: rgba(255, 255, 255, 0.08) !important;
+  color: rgba(255, 255, 255, 0.9) !important;
+}
+
+.popup-menu-item:checked:active, .popup-menu-item:checked.selected:active {
+  background-color: rgba(255, 255, 255, 0.06) !important;
+  color: rgba(255, 255, 255, 0.9) !important;
+}
+
+.popup-menu-item:checked:insensitive {
+  color: rgba(255, 255, 255, 0.5) !important;
+}
+
+.popup-menu-item.selected, .popup-menu-item:hover, .popup-menu-item:focus {
+  background-color: rgba(255, 255, 255, 0.06) !important;
+  color: rgba(255, 255, 255, 0.9) !important;
+  transition-duration: 0ms;
+  background-gradient-direction: none !important;
+}
+
+.popup-menu-item:active {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+  color: rgba(255, 255, 255, 0.9) !important;
+  transition-duration: 150ms;
+  background-gradient-direction: none !important;
+}
+
+.popup-menu-item.selected:active {
+  color: rgba(255, 255, 255, 0.9) !important;
+}
+
+.popup-menu-item:insensitive {
+  color: rgba(255, 255, 255, 0.5) !important;
+}
+
+.popup-inactive-menu-item {
+  color: rgba(255, 255, 255, 0.9) !important;
+}
+
+.popup-inactive-menu-item:insensitive {
+  color: rgba(255, 255, 255, 0.5) !important;
+}
+
+.popup-menu-arrow,
+.popup-menu-icon {
+  icon-size: 16px;
+}
+
+.popup-sub-menu {
+  margin: 0;
+  background-color: rgba(255, 255, 255, 0.06) !important;
+  border-radius: 0 0 3px 3px !important;
+  border: none;
+  box-shadow: none;
+  background-image: none !important;
+}
+
+.popup-sub-menu .popup-menu-item {
+  margin: 0;
+  border-radius: 0;
+  background-image: none !important;
+  background-color: transparent !important;
+}
+
+.popup-sub-menu .popup-menu-item.selected, .popup-sub-menu .popup-menu-item:hover, .popup-sub-menu .popup-menu-item:focus {
+  background-color: rgba(255, 255, 255, 0.06) !important;
+}
+
+.popup-sub-menu .popup-menu-item:active {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+.popup-sub-menu .popup-menu-item:last-child {
+  border-radius: 0 0 3px 3px !important;
+  border-bottom-width: 0;
+}
+
+.popup-sub-menu .popup-menu-section .popup-menu-item:last-child:hover, .popup-sub-menu .popup-menu-section .popup-menu-item:last-child:focus {
+  border-radius: 0;
+}
+
+.popup-sub-menu .popup-menu-section:last-child .popup-menu-item:last-child {
+  border-radius: 0 0 3px 3px !important;
+}
+
+.popup-menu-ornament {
+  width: 1.2em;
+}
+
+.popup-menu-ornament:ltr {
+  text-align: right;
+}
+
+.popup-menu-ornament:rtl {
+  text-align: left;
+}
+
+.popup-separator-menu-item {
+  background: none;
+  border: none;
+  padding: 0 0;
+  margin: 0 0;
+  height: 4px;
+}
+
+.popup-separator-menu-item .popup-separator-menu-item-separator {
+  height: 1px;
+  margin: 0 0;
+  padding: 0 0;
+  background: none;
+}
+
+.popup-sub-menu .popup-separator-menu-item .popup-separator-menu-item-separator {
+  margin: 0 0;
+  padding: 0 0;
+  background: none;
+}
+
+.background-menu {
+  -boxpointer-gap: 4px;
+  -arrow-rise: 0px;
+}
+
+.aggregate-menu {
+  min-width: 21em;
+}
+
+.aggregate-menu .popup-menu-icon {
+  padding: 0;
+  margin: 0;
+  -st-icon-style: symbolic;
+}
+
+.aggregate-menu .popup-menu-icon:ltr {
+  margin-right: 4px;
+}
+
+.aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
+  padding-left: 12px !important;
+  margin-left: 0 !important;
+}
+
+.aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
+  padding-right: 12px !important;
+  margin-right: 0 !important;
+}
+
+/* Date/Time Menu */
+#calendarArea {
+  padding: 6px 0;
+}
+
+.datemenu-popover {
+  border-radius: 9px !important;
+}
+
+.calendar {
+  padding: 0;
+  margin: 0 6px;
+  border: none;
+  box-shadow: none;
+  background: none;
+  text-shadow: none;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.calendar .calendar-month-header .calendar-change-month-back StIcon,
+.calendar .calendar-month-header .calendar-change-month-forward StIcon {
+  icon-size: 1.091em;
+}
+
+.calendar .calendar-month-header .calendar-month-label {
+  background-color: transparent !important;
+  color: rgba(255, 255, 255, 0.9) !important;
+  padding: 8px 0;
+  width: 10em;
+  text-align: center;
+}
+
+.calendar .calendar-day-heading {
+  width: 32px;
+  height: 25px;
+  margin-top: 2px;
+  padding: 7px 0 0;
+  border-radius: 9999px;
+  background-color: transparent !important;
+  color: rgba(255, 255, 255, 0.5) !important;
+  font-size: 9pt;
+  font-weight: 400;
+  font-weight: bold;
+  text-align: center;
+}
+
+.datemenu-calendar-column {
+  spacing: 6px;
+  border: none;
+  padding: 0;
+  margin: 0;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.datemenu-calendar-column:hover, .datemenu-calendar-column:focus {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.datemenu-calendar-column:active {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.datemenu-calendar-column:ltr {
+  margin-right: 4px;
+  margin-left: 10px;
+  border-left-width: 0;
+}
+
+.datemenu-calendar-column:rtl {
+  margin-left: 4px;
+  margin-right: 10px;
+  border-right-width: 0;
+}
+
+.datemenu-calendar-column .datemenu-displays-section {
+  padding-bottom: 0;
+}
+
+.datemenu-calendar-column .datemenu-displays-box {
+  spacing: 6px;
+}
+
+.datemenu-today-button {
+  min-height: 56px;
+  padding: 6px;
+  border-radius: 3px;
+  border: none;
+  box-shadow: none;
+  text-shadow: none;
+  background: none;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.datemenu-today-button .day-label {
+  font-size: 15pt;
+  font-weight: 500;
+  font-weight: bold;
+}
+
+.datemenu-today-button .date-label {
+  font-size: 18pt;
+  font-weight: 400;
+}
+
+.datemenu-today-button:hover, .datemenu-today-button:focus {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.datemenu-today-button:active {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.pager-button {
+  width: 32px;
+  height: 32px;
+  margin: 2px !important;
+  padding: 0 !important;
+  border-radius: 9999px;
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.pager-button:hover, .pager-button:focus {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.pager-button:active {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.calendar-change-month-back {
+  padding: 2px !important;
+  background-image: url("assets/calendar-arrow-left.svg");
+}
+
+.calendar-change-month-back:rtl {
+  background-image: url("assets/calendar-arrow-right.svg");
+}
+
+.calendar-change-month-forward {
+  padding: 2px !important;
+  background-image: url("assets/calendar-arrow-right.svg");
+}
+
+.calendar-change-month-forward:rtl {
+  background-image: url("assets/calendar-arrow-left.svg");
+}
+
+.calendar-day {
+  font-size: 9pt;
+  font-weight: 400;
+  text-align: center;
+  width: 32px !important;
+  height: 32px !important;
+  padding: 2px !important;
+  margin: 2px !important;
+  border-radius: 9999px;
+  color: rgba(255, 255, 255, 0.7) !important;
+  background-color: transparent !important;
+  border: none;
+  font-feature-settings: "tnum";
+  text-shadow: none;
+}
+
+.calendar-day:hover, .calendar-day:focus {
+  background-color: rgba(255, 255, 255, 0.06) !important;
+  box-shadow: none !important;
+}
+
+.calendar-day:active {
+  color: rgba(255, 255, 255, 0.7) !important;
+  background-color: rgba(255, 255, 255, 0.15) !important;
+  border-color: transparent;
+}
+
+.calendar-day:selected {
+  color: rgba(255, 255, 255, 0.9) !important;
+  background-color: rgba(255, 255, 255, 0.15) !important;
+  border-color: transparent;
+  box-shadow: none !important;
+}
+
+.calendar-day {
+  border-width: 0;
+}
+
+.calendar-day-top {
+  border-top-width: 0;
+}
+
+.calendar-day-left {
+  border-left-width: 0;
+}
+
+.calendar-nonwork-day {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.calendar-today {
+  font-weight: bold !important;
+  color: white !important;
+  background-color: #3281ea !important;
+  border: none;
+}
+
+.calendar-today:hover, .calendar-today:focus {
+  background-color: #408aeb !important;
+  color: white !important;
+  box-shadow: none !important;
+}
+
+.calendar-today:active, .calendar-today:selected {
+  background-color: #3281ea !important;
+  color: white !important;
+  box-shadow: none !important;
+}
+
+.calendar-today:active:hover, .calendar-today:active:focus, .calendar-today:selected:hover, .calendar-today:selected:focus {
+  background-color: #408aeb !important;
+  color: white !important;
+}
+
+.calendar-day-with-events {
+  color: rgba(255, 255, 255, 0.5);
+  background-image: url("assets/calendar-today.svg");
+}
+
+.calendar-day-with-events.calendar-work-day {
+  color: rgba(255, 255, 255, 0.5);
+  font-weight: bold;
+}
+
+.calendar-weekend {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.calendar-other-month {
+  color: rgba(255, 255, 255, 0.3) !important;
+  opacity: 1;
+  font-weight: normal;
+}
+
+.calendar-other-month.calendar-weekend {
+  color: rgba(255, 255, 255, 0.3) !important;
+}
+
+.calendar-week-number {
+  height: 1.8em !important;
+  width: 2.6em !important;
+  padding: 1px 0 !important;
+  margin: 6px 0 !important;
+  border-radius: 9999px;
+  background-color: rgba(255, 255, 255, 0.03);
+  color: rgba(255, 255, 255, 0.5);
+  font-size: inherit;
+  font-weight: bold;
+  text-align: center;
+  text-shadow: none;
+}
+
+.world-clocks-button,
+.weather-button,
+.events-button {
+  padding: 6px 8px;
+  border-radius: 3px;
+  box-shadow: none;
+  text-shadow: none;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: rgba(255, 255, 255, 0.03) !important;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.world-clocks-button:hover, .world-clocks-button:focus,
+.weather-button:hover,
+.weather-button:focus,
+.events-button:hover,
+.events-button:focus {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.08) !important;
+  border-color: rgba(255, 255, 255, 0.06);
+  box-shadow: none;
+}
+
+.world-clocks-button:active,
+.weather-button:active,
+.events-button:active {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.12) !important;
+  box-shadow: none;
+}
+
+.world-clocks-header,
+.weather-header,
+.message-list-section-title,
+.events-section-title,
+.events-title {
+  color: rgba(255, 255, 255, 0.5);
+  font-weight: bold;
+  margin-bottom: 4px;
+  text-shadow: none;
+}
+
+.weather-grid,
+.world-clocks-grid {
+  spacing-rows: 8px;
+  spacing-columns: 16px;
+}
+
+.world-clocks-header,
+.weather-header,
+.events-section-title {
+  color: rgba(255, 255, 255, 0.5);
+  font-weight: bold;
+}
+
+.events-button .events-box {
+  spacing: 6px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.events-button .events-list {
+  spacing: 12px;
+  text-shadow: none;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.events-button .event-time {
+  color: rgba(255, 255, 255, 0.3);
+  font-feature-settings: "tnum";
+}
+
+.world-clocks-button .world-clocks-city {
+  color: rgba(255, 255, 255, 0.5);
+  font-weight: normal;
+  font-size: 1em;
+}
+
+.world-clocks-button .world-clocks-time {
+  color: rgba(255, 255, 255, 0.5);
+  font-feature-settings: "tnum";
+  font-weight: bold;
+  font-size: 1em;
+}
+
+.world-clocks-button .world-clocks-time:ltr {
+  text-align: right;
+}
+
+.world-clocks-button .world-clocks-time:rtl {
+  text-align: left;
+}
+
+.world-clocks-button .world-clocks-timezone {
+  color: rgba(255, 255, 255, 0.5);
+  font-feature-settings: "tnum";
+  font-size: 1em;
+}
+
+.weather-button .weather-box {
+  spacing: 6px;
+}
+
+.weather-button .weather-header-box {
+  spacing: 6px;
+}
+
+.weather-button .weather-header.location {
+  font-weight: normal;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.weather-button .weather-forecast-icon {
+  icon-size: 32px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.weather-button .weather-forecast-time {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.8em;
+  font-feature-settings: "tnum";
+  font-weight: normal;
+  padding-top: 0.2em;
+  padding-bottom: 0.4em;
+}
+
+.weather-button .weather-forecast-temp {
+  font-weight: bold;
+  color: rgba(255, 255, 255, 0.55);
+  text-shadow: none;
+}
+
+/* Message List */
+.message-list {
+  width: 29em;
+  padding: 0;
+  color: rgba(255, 255, 255, 0.7);
+  text-shadow: none;
+  box-shadow: none;
+  border: 0 solid rgba(255, 255, 255, 0.1);
+}
+
+.message-list:ltr {
+  margin-left: 6px;
+  margin-right: 0;
+  padding-right: 12px;
+  border-right-width: 1px;
+}
+
+.message-list:rtl {
+  margin-right: 6px;
+  margin-left: 0;
+  padding-left: 12px;
+  border-left-width: 1px;
+}
+
+.message-list .message-list-placeholder {
+  color: rgba(255, 255, 255, 0.3);
+}
+
+.message-list .message-list-placeholder > StIcon {
+  icon-size: 96px;
+  margin-bottom: 12px;
+  -st-icon-style: symbolic;
+}
+
+.message-view {
+  -st-vfade-offset: 68px;
+}
+
+.message-view:ltr {
+  margin-right: 0;
+}
+
+.message-view:rtl {
+  margin-left: 0;
+}
+
+.message-view .message {
+  margin-bottom: 12px !important;
+}
+
+.message-list-controls {
+  padding: 12px;
+  padding-bottom: 6px;
+  spacing: 6px;
+}
+
+.message-list-controls .dnd-button {
+  border-width: 2px;
+  border-color: transparent;
+  border-radius: 32px;
+  border-style: solid;
+}
+
+.message-list-controls .dnd-button:focus {
+  border-color: rgba(50, 129, 234, 0.6);
+}
+
+.message-notification-group {
+  spacing: 12px;
+}
+
+.message-notification-group .message-group-header {
+  padding: 6px;
+}
+
+.message-notification-group .message-group-header .message-group-title {
+  margin: 0 4px;
+}
+
+.message-notification-group .message-collapse-button {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.1);
+  padding: 4px;
+}
+
+.message-notification-group .message-collapse-button:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+.message-notification-group .message-collapse-button:active {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.message {
+  background-color: rgba(255, 255, 255, 0.03);
+  border-radius: 3px;
+  color: rgba(255, 255, 255, 0.7);
+  text-shadow: none;
+  padding: 0;
+  margin: 4px;
+  box-shadow: 0 3px 8px -2px rgba(0, 0, 0, 0.15);
+  background-color: rgba(32, 32, 32, 0.95);
+  border: 1px solid transparent;
+  border-left: none;
+  border-bottom: none;
+}
+
+.message:hover, .message:focus, .message:active {
+  background-color: #202020;
+}
+
+.popup-menu .message {
+  margin: 0 0 4px;
+  box-shadow: none;
+  background-color: rgba(255, 255, 255, 0.03);
+  border-radius: 3px;
+  color: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.popup-menu .message:hover, .popup-menu .message:focus {
+  background-color: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.popup-menu .message:active {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.message:second-in-stack {
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.message:lower-in-stack {
+  box-shadow: none;
+}
+
+.message .message-header {
+  padding: 0 0.409em;
+  spacing: 6px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.message .message-header:ltr {
+  padding-right: 0;
+}
+
+.message .message-header:rtl {
+  padding-left: 0;
+}
+
+.message .message-header .message-source-icon {
+  icon-size: 1.091em;
+  -st-icon-style: symbolic;
+}
+
+.message .message-header .message-header-content {
+  spacing: 6px;
+  min-height: 1.637em;
+  padding-bottom: 6px;
+}
+
+.message .message-header .message-header-content .message-source-title {
+  font-weight: bold;
+}
+
+.message .message-header .message-header-content .event-time {
+  color: rgba(255, 255, 255, 0.5);
+  padding-bottom: 0.068em;
+}
+
+.message .message-header .message-header-content .event-time:ltr {
+  text-align: right;
+}
+
+.message .message-header .message-header-content .event-time:rtl {
+  text-align: left;
+}
+
+.message .message-header .message-expand-button,
+.message .message-header .message-close-button {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0);
+  padding: 4px;
+}
+
+.message .message-header .message-expand-button:hover,
+.message .message-header .message-close-button:hover {
+  background-color: rgba(255, 255, 255, 0.09);
+}
+
+.message .message-header .message-expand-button:active, .message .message-header .message-expand-button:active:hover,
+.message .message-header .message-close-button:active,
+.message .message-header .message-close-button:active:hover {
+  background-color: rgba(255, 255, 255, 0.14);
+}
+
+.message .message-header .message-expand-button:insensitive,
+.message .message-header .message-close-button:insensitive {
+  background-color: rgba(255, 255, 255, 0);
+}
+
+.message .message-header .message-expand-button {
+  padding: 6px;
+}
+
+.message .message-header .message-expand-button:ltr {
+  margin-right: 6px;
+}
+
+.message .message-header .message-expand-button:rtl {
+  margin-left: 6px;
+}
+
+.message .message-box {
+  padding: 6px;
+  margin: 6px;
+  margin-top: 0;
+  spacing: 6px;
+}
+
+.message .message-box .message-icon {
+  icon-size: 48px;
+  -st-icon-style: symbolic;
+}
+
+.message .message-box .message-icon:ltr {
+  margin-right: 6px;
+}
+
+.message .message-box .message-icon:rtl {
+  margin-left: 6px;
+}
+
+.message .message-box .message-icon.message-themed-icon {
+  border-radius: 9999px;
+  background-color: rgba(255, 255, 255, 0.1);
+  icon-size: 16px;
+  min-width: 48px;
+  min-height: 48px;
+}
+
+.message .message-box:first-child {
+  margin-top: 12px;
+}
+
+.message .message-box .message-content {
+  spacing: 4px;
+}
+
+.message .message-box .message-content .message-title {
+  font-weight: bold;
+}
+
+.url-highlighter {
+  link-color: #3281ea;
+}
+
+/* Media Controls */
+.message-media-control {
+  margin: 4px 0;
+  padding: 0 12px;
+  border-radius: 9999px;
+  color: rgba(255, 255, 255, 0.7);
+  border: none;
+}
+
+.message-media-control:hover, .message-media-control:focus {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.message-media-control:active {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.message-media-control:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+}
+
+.message-media-control StIcon {
+  icon-size: 16px;
+}
+
+.media-message .message-icon {
+  border-radius: 3px !important;
+}
+
+.media-message .message-icon.message-themed-icon {
+  icon-size: 32px !important;
+}
+
+.candidate-popup-content {
+  background-color: rgba(32, 32, 32, 0.97);
+  border-radius: 3px;
+  box-shadow: 0 3px 8px -2px rgba(0, 0, 0, 0.25) !important;
+  margin: 3px 8px 11px;
+  padding: 6px;
+  spacing: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.candidate-index {
+  padding: 0 0.5em 0 0;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.candidate-box {
+  padding: 0.3em 0.5em 0.3em 0.5em;
+  margin-right: 3px;
+  border-radius: 3px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.candidate-box:hover {
+  background-color: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.candidate-box:active {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.candidate-box:selected {
+  background-color: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.candidate-box:last-child {
+  margin-right: 0;
+}
+
+.candidate-page-button-box {
+  height: 2em;
+}
+
+.vertical .candidate-page-button-box {
+  padding-top: 0.5em;
+}
+
+.horizontal .candidate-page-button-box {
+  padding-left: 0.5em;
+}
+
+.candidate-page-button {
+  padding: 4px;
+}
+
+.candidate-page-button-previous {
+  border-radius: 3px 0px 0px 3px;
+  border-right-width: 0;
+}
+
+.candidate-page-button-next {
+  border-radius: 0px 3px 3px 0px;
+}
+
+.candidate-page-button-icon {
+  icon-size: 1em;
+}
+
+/* Notifications & Message Tray */
+.notification-banner {
+  min-height: 64px;
+  width: 34em;
+  margin: 6px;
+  border-radius: 6px;
+}
+
+.notification-buttons-bin {
+  spacing: 0;
+  padding: 0 6px 6px;
+  margin: 0;
+  border: none;
+}
+
+.notification-button {
+  min-height: 24px;
+  padding: 6px 12px;
+  font-weight: bold;
+}
+
+.hotplug-notification-item {
+  padding: 2px 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  text-shadow: none;
+  font-size: 10.5pt;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.hotplug-notification-item:hover {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.06);
+  box-shadow: none;
+}
+
+.hotplug-notification-item:active {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.15);
+  box-shadow: 0 0 transparent;
+}
+
+.hotplug-notification-item:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.hotplug-notification-item:focus {
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: none;
+}
+
+.hotplug-notification-item:first-child {
+  border-radius: 0 0 0 3px;
+}
+
+.hotplug-notification-item:last-child {
+  border-radius: 0 0 3px 0;
+}
+
+.hotplug-notification-item:first-child:last-child {
+  border-radius: 0 0 3px 3px;
+}
+
+.hotplug-notification-item-icon {
+  icon-size: 24px;
+  padding: 0 4px;
+}
+
+/* Modal Dialogs */
+.headline {
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+.modal-dialog {
+  padding: 0;
+}
+
+.modal-dialog .modal-dialog-content-box {
+  margin: 32px 40px 42px;
+  spacing: 32px;
+  max-width: 28em;
+}
+
+.modal-dialog .modal-dialog-button-box {
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 0 0 6px 6px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.modal-dialog .modal-dialog-button {
+  font-weight: bold;
+  background-gradient-direction: none !important;
+  margin: 0 !important;
+}
+
+/* End Session Dialog */
+.end-session-dialog {
+  width: 30em;
+}
+
+.end-session-dialog .end-session-dialog-battery-warning,
+.end-session-dialog .dialog-list-title {
+  color: #FF6D00;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child {
+  background-color: #FF5252 !important;
+  color: white !important;
+  border-color: rgba(255, 104, 104, 0.985) !important;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child:hover {
+  background-color: #ff8080 !important;
+  border-color: rgba(255, 119, 119, 0.975) !important;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child:active {
+  background-color: #ff5c5c !important;
+  border-color: rgba(255, 119, 119, 0.975) !important;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child:insensitive {
+  color: rgba(255, 255, 255, 0.5) !important;
+  background-color: rgba(255, 82, 82, 0.35) !important;
+  border-color: rgba(255, 96, 96, 0.99) !important;
+}
+
+/* Message Dialog */
+.message-dialog-content {
+  spacing: 18px;
+}
+
+.message-dialog-content .message-dialog-title {
+  text-align: center;
+  font-size: 18pt;
+  font-weight: 800;
+}
+
+.message-dialog-content .message-dialog-title.lightweight {
+  font-size: 13pt;
+  font-weight: 800;
+}
+
+.message-dialog-content .message-dialog-description {
+  text-align: center;
+}
+
+/* Dialog List */
+.dialog-list {
+  spacing: 18px;
+}
+
+.dialog-list .dialog-list-title {
+  text-align: center;
+  font-weight: bold;
+}
+
+.dialog-list .dialog-list-scrollview {
+  max-height: 200px;
+}
+
+.dialog-list .dialog-list-box {
+  spacing: 1em;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item {
+  spacing: 1em;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item .dialog-list-item-title {
+  font-weight: bold;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item .dialog-list-item-description {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+/* Run Dialog */
+.run-dialog .modal-dialog-content-box {
+  margin-top: 24px;
+  margin-bottom: 14px;
+}
+
+.run-dialog .run-dialog-entry {
+  width: 20em;
+}
+
+.run-dialog .run-dialog-description {
+  font-size: 12pt;
+  font-weight: 400;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+/* Password or Authentication Dialog */
+.prompt-dialog {
+  width: 28em;
+}
+
+.prompt-dialog .modal-dialog-content-box {
+  margin-bottom: 24px;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child {
+  background-color: #408aeb !important;
+  color: white !important;
+  border-color: rgba(88, 152, 238, 0.985) !important;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:hover {
+  background-color: #6aa3f0 !important;
+  border-color: rgba(105, 163, 240, 0.975) !important;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:active {
+  background-color: #498fec !important;
+  border-color: rgba(105, 163, 240, 0.975) !important;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:insensitive {
+  color: rgba(255, 255, 255, 0.5) !important;
+  background-color: rgba(64, 138, 235, 0.35) !important;
+  border-color: rgba(80, 147, 237, 0.99) !important;
+}
+
+.prompt-dialog-password-grid {
+  spacing-rows: 8px;
+  spacing-columns: 4px;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry {
+  width: auto;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry:ltr {
+  margin-left: 20px;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry:rtl {
+  margin-right: 20px;
+}
+
+.prompt-dialog-password-layout {
+  spacing: 8px;
+}
+
+.prompt-dialog-password-entry {
+  width: 20em;
+}
+
+.prompt-dialog-error-label,
+.prompt-dialog-info-label,
+.prompt-dialog-null-label {
+  text-align: center;
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+.prompt-dialog-error-label {
+  color: #FF6D00;
+}
+
+/* Polkit Dialog */
+.polkit-dialog-user-layout {
+  text-align: center;
+  spacing: 8px;
+  margin-bottom: 6px;
+}
+
+.polkit-dialog-user-layout .polkit-dialog-user-root-label {
+  color: #FF6D00;
+}
+
+/* Audio selection dialog */
+.audio-device-selection-dialog .modal-dialog-content-box {
+  margin-bottom: 28px;
+}
+
+.audio-device-selection-dialog .audio-selection-box {
+  spacing: 20px;
+}
+
+.audio-selection-device {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 3px;
+}
+
+.audio-selection-device:active, .audio-selection-device:hover, .audio-selection-device:focus {
+  background-color: #3281ea;
+}
+
+.audio-selection-device-box {
+  padding: 20px;
+  spacing: 20px;
+}
+
+.audio-selection-device-icon {
+  icon-size: 64px;
+}
+
+/* Welcome dialog */
+.welcome-dialog-image {
+  background-image: url("resource:///org/gnome/shell/theme/gnome-shell-start.svg");
+  background-size: contain;
+  /* Reasonable maximum dimensions */
+  height: 300px;
+  width: 300px;
+}
+
+/* Network Dialogs */
+.nm-dialog {
+  max-height: 34em;
+  min-height: 31em;
+  min-width: 32em;
+}
+
+.nm-dialog-content {
+  spacing: 20px;
+  padding: 24px;
+}
+
+.nm-dialog-airplane-box {
+  spacing: 12px;
+}
+
+.nm-dialog-airplane-headline {
+  font-weight: bold;
+  text-align: center;
+}
+
+.nm-dialog-airplane-text {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.nm-dialog-header {
+  font-weight: bold;
+}
+
+.nm-dialog-header-icon {
+  icon-size: 32px;
+}
+
+.nm-dialog-header-hbox {
+  spacing: 10px;
+}
+
+.nm-dialog-scroll-view {
+  border: none;
+  background-color: rgba(255, 255, 255, 0.06);
+  border-radius: 3px;
+  padding: 12px;
+  padding-right: 0;
+}
+
+.nm-dialog-item {
+  font-size: 1em;
+  border-bottom: none;
+  border-radius: -3px;
+  padding: 12px;
+  spacing: 0px;
+}
+
+.nm-dialog-item:hover, .nm-dialog-item:focus {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.nm-dialog-item:active {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.nm-dialog-item:selected {
+  background-color: #3281ea;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.nm-dialog-icon {
+  icon-size: 16px;
+}
+
+.nm-dialog-icons {
+  spacing: 12px;
+}
+
+.no-networks-label {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.no-networks-box {
+  spacing: 6px;
+}
+
+/* OSD */
+.screenshot-ui-panel, .workspace-switcher-container, .switcher-list, .resize-popup, .osd-window {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #222222;
+  border: none;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.35);
+  border-radius: 3px;
+  padding: 12px;
+}
+
+.osd-window {
+  text-align: center;
+  font-weight: bold;
+  spacing: 12px;
+  padding: 12px 18px;
+  margin-bottom: 4em;
+}
+
+.osd-window > * {
+  spacing: 8px;
+}
+
+.osd-window StIcon {
+  icon-size: 32px;
+}
+
+.osd-window StLabel:ltr {
+  margin-right: 6px;
+}
+
+.osd-window StLabel:rtl {
+  margin-left: 6px;
+}
+
+.osd-window .osd-monitor-label {
+  font-size: 3em;
+}
+
+.osd-window .level {
+  height: 4px;
+  -barlevel-height: 4px;
+  -barlevel-background-color: rgba(50, 129, 234, 0.3);
+  -barlevel-active-background-color: #3281ea;
+  -barlevel-overdrive-color: #FF5252;
+  -barlevel-overdrive-separator-width: 3px;
+  -barlevel-border-width: 0;
+}
+
+/* Pad OSD */
+.pad-osd-window {
+  padding: 32px;
+  background-color: rgba(0, 0, 0, 0.8);
+  border: none;
+}
+
+.pad-osd-window .pad-osd-title-box {
+  spacing: 12px;
+}
+
+.pad-osd-window .pad-osd-title-menu-box {
+  spacing: 6px;
+}
+
+.combo-box-label {
+  width: 15em;
+}
+
+/* App Switcher */
+.switcher-popup {
+  padding: 8px;
+  spacing: 24px;
+}
+
+.switcher-list .item-box {
+  padding: 8px;
+  border-radius: 3px;
+  border: none;
+}
+
+.switcher-list .item-box:outlined {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.switcher-list .item-box:selected {
+  background-color: #3281ea;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.switcher-list .thumbnail-box {
+  padding: 2px;
+  spacing: 6px;
+}
+
+.switcher-list .thumbnail {
+  width: 256px;
+}
+
+.switcher-list .separator {
+  width: 1px;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.switcher-list .switcher-list-item-container {
+  spacing: 12px;
+}
+
+.switcher-arrow {
+  border-color: rgba(0, 0, 0, 0);
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.switcher-arrow:highlighted {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.input-source-switcher-symbol {
+  font-size: 34pt;
+  width: 96px;
+  height: 96px;
+}
+
+.cycler-highlight {
+  border: 5px solid #3281ea;
+}
+
+/* Workspace Switcher */
+.workspace-switcher-group {
+  padding: 12px;
+}
+
+.workspace-switcher {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  spacing: 12px;
+}
+
+.ws-switcher-box {
+  height: 50px;
+  background-size: 32px;
+  border: none;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 3px;
+}
+
+.ws-switcher-active-up,
+.ws-switcher-active-down,
+.ws-switcher-active-left,
+.ws-switcher-active-right {
+  height: 52px;
+  background-color: #3281ea;
+  border: none;
+  border-radius: 6px;
+  color: #FFFFFF;
+}
+
+/* Top Bar */
+#panel .panel-button#panelActivities {
+  -natural-hpadding: 15px;
+}
+
+#panel .panel-button#panelActivities StBoxLayout {
+  spacing: 6px;
+}
+
+#panel .panel-button#panelActivities .workspace-dot {
+  border-radius: 9999px;
+  min-width: 8px;
+  min-height: 8px;
+  background-color: #FFFFFF;
+}
+
+#panel {
+  font-weight: normal;
+  font-feature-settings: "tnum";
+  transition-duration: 250ms;
+  border: none;
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.5);
+  margin: 0;
+  border-radius: 0;
+  height: 34px;
+}
+
+#panel #panelLeft, #panel #panelCenter {
+  spacing: 0;
+}
+
+#panel .panel-corner {
+  -panel-corner-radius: 0;
+  -panel-corner-background-color: rgba(0, 0, 0, 0.5);
+  -panel-corner-border-width: 0;
+  -panel-corner-border-color: transparent;
+  -panel-corner-opacity: 0;
+  transition-duration: 250ms;
+}
+
+#panel .panel-button {
+  -natural-hpadding: 8px;
+  -minimum-hpadding: 8px;
+  font-weight: normal;
+  color: rgba(255, 255, 255, 0.75);
+  transition-duration: 150ms;
+  text-shadow: none;
+  border-radius: 0;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#panel .panel-button StLabel {
+  padding: 0;
+}
+
+#panel .panel-button:hover {
+  color: rgba(255, 255, 255, 0.75);
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+#panel .panel-button:active, #panel .panel-button:checked, #panel .panel-button:focus {
+  color: #FFFFFF;
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#panel .panel-button:hover, #panel .panel-button:active, #panel .panel-button:overview, #panel .panel-button:focus, #panel .panel-button:checked {
+  text-shadow: none;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#panel .panel-button.clock-display {
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#panel .panel-button.clock-display:hover {
+  color: rgba(255, 255, 255, 0.75);
+  background-color: rgba(255, 255, 255, 0.1) !important;
+}
+
+#panel .panel-button.clock-display:active, #panel .panel-button.clock-display:checked, #panel .panel-button.clock-display:focus {
+  color: #FFFFFF;
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#panel .panel-button.clock-display:active .clock, #panel .panel-button.clock-display:checked .clock, #panel .panel-button.clock-display:focus .clock {
+  box-shadow: none;
+  background: none;
+  color: #FFFFFF;
+}
+
+#panel .panel-button.clock-display:hover, #panel .panel-button.clock-display:active, #panel .panel-button.clock-display:checked, #panel .panel-button.clock-display:focus {
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#panel .panel-button.clock-display .clock {
+  color: rgba(255, 255, 255, 0.75);
+  transition-duration: 150ms;
+  border: none;
+  border-radius: 0;
+}
+
+#panel .panel-button.clock-display .messages-indicator {
+  icon-size: 1.091em;
+}
+
+#panel .panel-button .system-status-icon {
+  icon-size: 16px;
+  padding: 6px;
+  margin: 0 3px;
+}
+
+#panel .panel-button .panel-status-menu-box .system-status-icon {
+  margin: 0;
+}
+
+#panel .panel-button .panel-status-menu-box StLabel {
+  padding: 0 0 0 3px;
+}
+
+#panel .panel-button .panel-status-menu-box,
+#panel .panel-button .panel-status-indicators-box {
+  spacing: 3px;
+}
+
+#panel .panel-button .appindicator-trayicons-box,
+#panel .panel-button .panel-status-indicators-box.appindicator-box {
+  margin: 0 6px;
+}
+
+#panel .panel-button .clipboard-indicator-icon {
+  margin: 0 6px;
+}
+
+#panel .panel-button .app-menu-icon {
+  -st-icon-style: symbolic;
+}
+
+#panel.unlock-screen, #panel.login-screen, #panel.lock-screen, #panel:overview {
+  background-color: transparent;
+}
+
+#panel.unlock-screen .panel-button, #panel.login-screen .panel-button, #panel.lock-screen .panel-button, #panel:overview .panel-button {
+  border-radius: 3px;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+}
+
+#panel.unlock-screen .panel-button:hover, #panel.login-screen .panel-button:hover, #panel.lock-screen .panel-button:hover, #panel:overview .panel-button:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#panel.unlock-screen .panel-button:active, #panel.unlock-screen .panel-button:checked, #panel.unlock-screen .panel-button:focus, #panel.login-screen .panel-button:active, #panel.login-screen .panel-button:checked, #panel.login-screen .panel-button:focus, #panel.lock-screen .panel-button:active, #panel.lock-screen .panel-button:checked, #panel.lock-screen .panel-button:focus, #panel:overview .panel-button:active, #panel:overview .panel-button:checked, #panel:overview .panel-button:focus {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+#panel.unlock-screen .panel-button.clock-display:hover, #panel.login-screen .panel-button.clock-display:hover, #panel.lock-screen .panel-button.clock-display:hover, #panel:overview .panel-button.clock-display:hover {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#panel.unlock-screen .panel-button.clock-display:active, #panel.unlock-screen .panel-button.clock-display:checked, #panel.unlock-screen .panel-button.clock-display:focus, #panel.login-screen .panel-button.clock-display:active, #panel.login-screen .panel-button.clock-display:checked, #panel.login-screen .panel-button.clock-display:focus, #panel.lock-screen .panel-button.clock-display:active, #panel.lock-screen .panel-button.clock-display:checked, #panel.lock-screen .panel-button.clock-display:focus, #panel:overview .panel-button.clock-display:active, #panel:overview .panel-button.clock-display:checked, #panel:overview .panel-button.clock-display:focus {
+  background-color: rgba(255, 255, 255, 0.3) !important;
+}
+
+#panel.unlock-screen .panel-button.clock-display .clock, #panel.login-screen .panel-button.clock-display .clock, #panel.lock-screen .panel-button.clock-display .clock, #panel:overview .panel-button.clock-display .clock {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+#panel.unlock-screen .panel-button#panelActivities, #panel.login-screen .panel-button#panelActivities, #panel.lock-screen .panel-button#panelActivities, #panel:overview .panel-button#panelActivities {
+  box-shadow: none;
+  border: none;
+  background-color: transparent;
+}
+
+#panel.unlock-screen .panel-button#panelActivities:hover, #panel.login-screen .panel-button#panelActivities:hover, #panel.lock-screen .panel-button#panelActivities:hover, #panel:overview .panel-button#panelActivities:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#panel.unlock-screen .panel-button#panelActivities .workspace-dot, #panel.login-screen .panel-button#panelActivities .workspace-dot, #panel.lock-screen .panel-button#panelActivities .workspace-dot, #panel:overview .panel-button#panelActivities .workspace-dot {
+  background-color: rgba(255, 255, 255, 0.85);
+}
+
+#panel.unlock-screen .panel-corner, #panel.login-screen .panel-corner, #panel.lock-screen .panel-corner, #panel:overview .panel-corner {
+  -panel-corner-opacity: 0;
+  -panel-corner-radius: 0;
+  -panel-corner-background-color: transparent;
+  -panel-corner-border-color: transparent;
+}
+
+#panel Gjs_ui_panel_AggregateMenu.panel-button .system-status-icon {
+  margin: 0 !important;
+  padding: 6px !important;
+}
+
+#panel Gjs_kimpanel_kde_org_indicator_KimIndicator.panel-button .panel-status-menu-box {
+  margin: 0 6px;
+}
+
+#panel .screencast-indicator,
+#panel .remote-access-indicator {
+  color: #FF6D00;
+}
+
+#appMenu {
+  spacing: 6px;
+}
+
+#appMenu .label-shadow {
+  color: transparent;
+}
+
+#appMenu .panel-status-menu-box {
+  padding: 0 6px;
+  spacing: 6px;
+}
+
+/* Activities Ripple */
+.ripple-box {
+  background-color: rgba(50, 129, 234, 0.35);
+  width: 52px;
+  height: 52px;
+  border-radius: 0 0 52px 0;
+}
+
+.ripple-box:rtl {
+  border-radius: 0 0 0 52px;
+}
+
+/* OVERVIEW */
+.controls-manager, .secondary-monitor-workspaces {
+  spacing: 12px;
+}
+
+#overviewGroup {
+  background-color: #222222;
+}
+
+.overview-controls {
+  padding-bottom: 32px;
+}
+
+/* Window Picker */
+.window-picker {
+  spacing: 6px;
+}
+
+.window-caption {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(32, 32, 32, 0.9);
+  border-radius: 6px;
+  padding: 6px 12px;
+}
+
+.window-close, .screenshot-ui-close-button {
+  background-color: #3281ea;
+  color: white;
+  border-radius: 9999px;
+  padding: 3px;
+  height: 30px;
+  width: 30px;
+  box-shadow: -1px 1px 5px 0px rgba(0, 0, 0, 0.5);
+  transition-duration: 300ms;
+}
+
+.window-close StIcon, .screenshot-ui-close-button StIcon {
+  icon-size: 24px;
+}
+
+.window-close:hover, .screenshot-ui-close-button:hover {
+  background-color: #77acf1;
+}
+
+.window-close:active, .screenshot-ui-close-button:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #1b73e8;
+}
+
+.workspace-background {
+  border-radius: 30px;
+  background-color: #222222;
+  box-shadow: 0 4px 16px 4px rgba(0, 0, 0, 0.3);
+  border: none;
+}
+
+.search-entry {
+  min-height: 24px;
+  padding: 3px 6px;
+  width: 320px;
+  border: none !important;
+  border-radius: 3px;
+  selection-background-color: #3281ea;
+  selected-color: #FFFFFF !important;
+  caret-color: rgba(255, 255, 255, 0.7);
+  color: rgba(255, 255, 255, 0.7);
+  background-color: rgba(255, 255, 255, 0.15);
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+.search-entry:hover {
+  border: 2px solid rgba(255, 255, 255, 0.15) !important;
+}
+
+.search-entry:focus {
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #3281ea !important;
+}
+
+.search-entry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.search-entry .search-entry-icon {
+  icon-size: 16px;
+  padding: 0 4px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.search-entry StLabel.hint-text {
+  margin-left: 2px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+#overview .search-entry {
+  min-height: 24px;
+  padding: 6px 9px;
+  margin-top: 12px;
+  margin-bottom: 6px;
+  border-radius: 5px;
+  caret-color: rgba(0, 0, 0, 0.75);
+  color: rgba(0, 0, 0, 0.75);
+  background-color: rgba(255, 255, 255, 0.75) !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#overview .search-entry:hover {
+  color: rgba(0, 0, 0, 0.75);
+  background-color: rgba(255, 255, 255, 0.85) !important;
+}
+
+#overview .search-entry:focus {
+  color: rgba(0, 0, 0, 0.85);
+  background-color: rgba(255, 255, 255, 0.95) !important;
+  border: none !important;
+  selection-background-color: #3281ea;
+  selected-color: #FFFFFF !important;
+}
+
+#overview .search-entry .search-entry-icon {
+  color: rgba(0, 0, 0, 0.65);
+}
+
+#overview .search-entry:hover .search-entry-icon, #overview .search-entry:focus .search-entry-icon {
+  color: rgba(0, 0, 0, 0.75);
+}
+
+#overview .search-entry StLabel.hint-text {
+  color: rgba(0, 0, 0, 0.35);
+}
+
+/* Search */
+#searchResults {
+  margin: 0 8px;
+}
+
+#searchResultsContent {
+  max-width: 1044px;
+}
+
+.search-section {
+  spacing: 12px;
+}
+
+.search-section .search-section-separator {
+  height: 8px;
+  background-color: transparent;
+}
+
+.search-section-content {
+  background-color: rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.1);
+  text-shadow: none;
+  color: rgba(255, 255, 255, 0.85);
+  padding: 18px;
+  spacing: 8px;
+}
+
+.list-search-result, .search-provider-icon {
+  border-radius: 6px;
+}
+
+.search-statustext {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.grid-search-results {
+  spacing: 36px;
+  margin: 0 12px;
+}
+
+.search-provider-icon:ltr {
+  margin-right: 4px;
+}
+
+.search-provider-icon:rtl {
+  margin-left: 4px;
+}
+
+.search-provider-icon .list-search-provider-content {
+  spacing: 12px;
+}
+
+.search-provider-icon .list-search-provider-content .list-search-provider-details {
+  width: 120px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.list-search-results {
+  spacing: 6px;
+}
+
+.list-search-result .list-search-result-content {
+  spacing: 6px;
+}
+
+.list-search-result .list-search-result-title {
+  spacing: 12px;
+}
+
+.list-search-result .list-search-result-description {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+/* Dash */
+#dash {
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+#dash .dash-background {
+  background-color: rgba(255, 255, 255, 0.2);
+  border-radius: 15px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+#dash .dash-item-container .placeholder {
+  background-image: none;
+  background-size: contain;
+  height: 32px;
+}
+
+#dash .dash-item-container .empty-dash-drop-target {
+  width: 32px;
+  height: 32px;
+}
+
+#dash .dash-item-container .show-apps,
+#dash .dash-item-container .overview-tile,
+#dash .dash-item-container .grid-search-result,
+#dash .dash-item-container .search-provider-icon,
+#dash .dash-item-container .list-search-result {
+  margin: 0 2px;
+  padding-bottom: 12px;
+}
+
+#dash .dash-item-container .show-apps .overview-icon,
+#dash .dash-item-container .overview-tile .overview-icon,
+#dash .dash-item-container .grid-search-result .overview-icon,
+#dash .dash-item-container .search-provider-icon .overview-icon,
+#dash .dash-item-container .list-search-result .overview-icon {
+  background-color: transparent;
+}
+
+#dash .dash-item-container .show-apps:focus .overview-icon,
+#dash .dash-item-container .overview-tile:focus .overview-icon,
+#dash .dash-item-container .grid-search-result:focus .overview-icon,
+#dash .dash-item-container .search-provider-icon:focus .overview-icon,
+#dash .dash-item-container .list-search-result:focus .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#dash .dash-item-container .show-apps:hover .overview-icon,
+#dash .dash-item-container .overview-tile:hover .overview-icon,
+#dash .dash-item-container .grid-search-result:hover .overview-icon,
+#dash .dash-item-container .search-provider-icon:hover .overview-icon,
+#dash .dash-item-container .list-search-result:hover .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#dash .dash-item-container .show-apps:active .overview-icon,
+#dash .dash-item-container .overview-tile:active .overview-icon,
+#dash .dash-item-container .grid-search-result:active .overview-icon,
+#dash .dash-item-container .search-provider-icon:active .overview-icon,
+#dash .dash-item-container .list-search-result:active .overview-icon {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+#dash .dash-item-container .show-apps:checked .overview-icon,
+#dash .dash-item-container .overview-tile:checked .overview-icon,
+#dash .dash-item-container .grid-search-result:checked .overview-icon,
+#dash .dash-item-container .search-provider-icon:checked .overview-icon,
+#dash .dash-item-container .list-search-result:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+#dash .dash-item-container .show-apps:insensitive .overview-icon,
+#dash .dash-item-container .overview-tile:insensitive .overview-icon,
+#dash .dash-item-container .grid-search-result:insensitive .overview-icon,
+#dash .dash-item-container .search-provider-icon:insensitive .overview-icon,
+#dash .dash-item-container .list-search-result:insensitive .overview-icon {
+  background-color: transparent;
+}
+
+#dash .dash-item-container .app-grid-running-dot {
+  offset-y: -12px;
+}
+
+#dash .dash-separator {
+  width: 1px;
+  margin-left: 4px;
+  margin-right: 4px;
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#dash .dash-separator,
+#dash .dash-background {
+  margin-bottom: 12px;
+}
+
+.dash-label {
+  border-radius: 3px;
+  padding: 6px 12px;
+  margin: 6px;
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(0, 0, 0, 0.75);
+  border: none;
+  box-shadow: none;
+  text-align: center;
+  -y-offset: 4px;
+}
+
+/* App Grid */
+.icon-grid {
+  row-spacing: 12px;
+  column-spacing: 12px;
+  max-row-spacing: 36px;
+  max-column-spacing: 36px;
+  page-padding-top: 24px;
+  page-padding-bottom: 24px;
+  page-padding-left: 18px;
+  page-padding-right: 18px;
+}
+
+/* App Icons */
+.overview-tile, .grid-search-result, .search-provider-icon, .list-search-result {
+  border-radius: 9px;
+  padding: 12px;
+  spacing: 6px;
+  transition-duration: 150ms;
+  text-align: center;
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.85);
+  border: 1px solid transparent;
+  box-shadow: inset 0 1px transparent;
+}
+
+.overview-tile:hover, .grid-search-result:hover, .search-provider-icon:hover, .list-search-result:hover, .overview-tile:focus, .grid-search-result:focus, .search-provider-icon:focus, .list-search-result:focus, .overview-tile:highlighted, .grid-search-result:highlighted, .search-provider-icon:highlighted, .list-search-result:highlighted, .overview-tile:selected, .grid-search-result:selected, .search-provider-icon:selected, .list-search-result:selected {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+  transition-duration: 0ms;
+  border-image: none;
+  background-image: none;
+}
+
+.overview-tile:active, .grid-search-result:active, .search-provider-icon:active, .list-search-result:active, .overview-tile:checked, .grid-search-result:checked, .search-provider-icon:checked, .list-search-result:checked {
+  background-color: rgba(255, 255, 255, 0.15);
+  transition-duration: 150ms;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.overview-tile .overview-icon.overview-icon-with-label > StBoxLayout, .grid-search-result .overview-icon.overview-icon-with-label > StBoxLayout, .search-provider-icon .overview-icon.overview-icon-with-label > StBoxLayout, .list-search-result .overview-icon.overview-icon-with-label > StBoxLayout {
+  spacing: 6px;
+}
+
+.app-folder {
+  background-color: rgba(255, 255, 255, 0.13);
+}
+
+.app-folder:focus {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.app-folder:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.app-folder:active {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.app-folder:highlighted, .app-folder:selected, .app-folder:checked {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.app-folder:insensitive {
+  background-color: transparent;
+}
+
+.app-grid-running-dot {
+  width: 6px;
+  height: 3px;
+  border-radius: 2px;
+  background-color: rgba(255, 255, 255, 0.5);
+  margin-bottom: 1px;
+}
+
+StWidget.focused .app-grid-running-dot {
+  width: 18px;
+  background-color: #3281ea;
+}
+
+.app-folder-dialog-container {
+  padding-top: 34px;
+}
+
+.app-folder-dialog {
+  width: 720px;
+  height: 720px;
+  border-radius: 12px;
+  background-color: rgba(34, 34, 34, 0.95);
+  color: white;
+  border: none;
+  box-shadow: none;
+}
+
+.app-folder-dialog .folder-name-container {
+  padding: 24px 36px 0;
+  spacing: 12px;
+  /* FIXME: this is to keep the label in sync with the entry */
+}
+
+.app-folder-dialog .folder-name-container .folder-name-label, .app-folder-dialog .folder-name-container .folder-name-entry {
+  font-size: 18pt;
+  font-weight: 800;
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry {
+  border: none;
+  color: #FFFFFF;
+  background-color: rgba(255, 255, 255, 0.15);
+  caret-color: #FFFFFF;
+  selection-background-color: #3281ea;
+  selected-color: #FFFFFF;
+  width: 300px;
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:focus {
+  color: #FFFFFF;
+  background-color: rgba(255, 255, 255, 0.25);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry .search-entry-icon {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:hover .search-entry-icon, .app-folder-dialog .folder-name-container .folder-name-entry:focus .search-entry-icon {
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:insensitive, .app-folder-dialog .folder-name-container .folder-name-entry StLabel.hint-text {
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-label {
+  padding: 5px 7px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.app-folder-dialog .folder-name-container .icon-button, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button {
+  background-color: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.7);
+  border: none;
+  padding: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 18px;
+}
+
+.app-folder-dialog .folder-name-container .icon-button > StIcon, .app-folder-dialog .folder-name-container .background-app-item .icon-button > StIcon, .app-folder-dialog .folder-name-container .message-notification-group .background-app-item .message-collapse-button > StIcon, .app-folder-dialog .folder-name-container .message .message-header .background-app-item .message-expand-button > StIcon,
+.app-folder-dialog .folder-name-container .message .message-header .background-app-item .message-close-button > StIcon, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button > StIcon, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button > StIcon, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button > StIcon, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button > StIcon,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button > StIcon,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button > StIcon {
+  icon-size: 16px;
+}
+
+.app-folder-dialog .folder-name-container .icon-button:hover, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button:hover, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button:hover, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:hover, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:hover,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:hover,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.app-folder-dialog .folder-name-container .icon-button:focus, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button:focus, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button:focus, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:focus, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:focus,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:focus,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:focus {
+  border: none !important;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.app-folder-dialog .folder-name-container .icon-button:checked, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button:checked, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button:checked, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:checked, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:checked,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:checked,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:checked, .app-folder-dialog .folder-name-container .icon-button:active, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button:active, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button:active, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:active, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:active,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:active,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:active {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.app-folder-dialog .icon-grid {
+  row-spacing: 12px;
+  column-spacing: 30px;
+  page-padding-top: 0;
+  page-padding-bottom: 0;
+  page-padding-left: 0;
+  page-padding-right: 0;
+}
+
+.app-folder-dialog .page-indicators {
+  margin-bottom: 18px;
+}
+
+.rename-folder-popup .rename-folder-popup-item {
+  spacing: 6px;
+}
+
+.rename-folder-popup .rename-folder-popup-item:ltr, .rename-folder-popup .rename-folder-popup-item:rtl {
+  padding: 0 12px;
+}
+
+.app-menu,
+.app-well-menu {
+  max-width: 27.25em;
+}
+
+.page-indicator {
+  padding: 6px 12px 0;
+}
+
+.page-indicator .page-indicator-icon {
+  width: 10px;
+  height: 10px;
+  border-radius: 10px;
+  background-color: white;
+  transition-duration: 400ms;
+}
+
+.apps-scroll-view {
+  padding: 0;
+}
+
+.system-action-icon {
+  background-color: rgba(0, 0, 0, 0.8);
+  color: white;
+  border-radius: 9999px;
+  icon-size: 8px;
+}
+
+.page-navigation-hint.dnd {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.page-navigation-hint.next:ltr, .page-navigation-hint.previous:rtl {
+  background-gradient-start: rgba(255, 255, 255, 0.05);
+  background-gradient-end: transparent;
+  background-gradient-direction: horizontal;
+  border-radius: 15px 0px 0px 15px;
+}
+
+.page-navigation-hint.previous:ltr, .page-navigation-hint.next:rtl {
+  background-gradient-start: transparent;
+  background-gradient-end: rgba(255, 255, 255, 0.05);
+  background-gradient-direction: horizontal;
+  border-radius: 0px 15px 15px 0px;
+}
+
+.page-navigation-arrow {
+  margin: 6px;
+  padding: 18px;
+  width: 24px;
+  height: 24px;
+  border-radius: 9999px;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+}
+
+.page-navigation-arrow > StIcon {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.page-navigation-arrow:insensitive {
+  background-color: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.page-navigation-arrow:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+  color: white;
+}
+
+.page-navigation-arrow:active {
+  background-color: rgba(255, 255, 255, 0.2);
+  color: white;
+}
+
+/* Workspace pager */
+.workspace-thumbnails .workspace-thumbnail {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.13);
+  border: none;
+}
+
+.workspace-thumbnails {
+  visible-width: 32px;
+  spacing: 6px;
+  padding: 6px;
+}
+
+.workspace-thumbnails .workspace-thumbnail {
+  border-radius: 3px;
+}
+
+.workspace-thumbnails .placeholder {
+  background-image: url("resource:///org/gnome/shell/theme/dash-placeholder.svg");
+  background-size: contain;
+  width: 18px;
+}
+
+.workspace-thumbnail-indicator {
+  border: 3px solid #3281ea;
+  border-radius: 6px;
+  padding: 0px;
+}
+
+.ripple-pointer-location {
+  width: 48px;
+  height: 48px;
+  border-radius: 24px;
+  background-color: rgba(189, 214, 248, 0.3);
+  box-shadow: 0 0 2px 2px #8fbaf3;
+}
+
+.pie-timer {
+  width: 60px;
+  height: 60px;
+  -pie-border-width: 3px;
+  -pie-border-color: #3281ea;
+  -pie-background-color: rgba(235, 243, 253, 0.3);
+}
+
+.magnifier-zoom-region {
+  border: 2px solid #3281ea;
+}
+
+.magnifier-zoom-region.full-screen {
+  border-width: 0;
+}
+
+.select-area-rubberband {
+  background-color: rgba(50, 129, 234, 0.3);
+  border: 1px solid #3281ea;
+}
+
+.user-icon {
+  background-size: contain;
+  color: rgba(255, 255, 255, 0.7);
+  border-radius: 9999px;
+  icon-size: 64px;
+}
+
+.user-icon:hover {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.user-icon StIcon {
+  background-color: rgba(255, 255, 255, 0.05);
+  border-radius: 99px;
+  padding: 12px;
+  width: 40px;
+  height: 40px;
+}
+
+.user-icon.user-avatar {
+  border: 2px rgba(255, 255, 255, 0.7);
+}
+
+.user-widget.vertical .user-icon {
+  icon-size: 128px;
+}
+
+.user-widget.vertical .user-icon StIcon {
+  padding: 20px;
+  padding-top: 18px;
+  padding-bottom: 22px;
+  width: 88px;
+  height: 88px;
+}
+
+.lightbox {
+  background-color: black;
+}
+
+.flashspot {
+  background-color: white;
+}
+
+.hidden {
+  color: rgba(0, 0, 0, 0);
+}
+
+.caps-lock-warning-label {
+  text-align: center;
+  padding-bottom: 8px;
+  font-size: 10.5pt;
+  font-weight: 400;
+  color: #FF6D00;
+}
+
+/* Workspace animation */
+.workspace-animation {
+  background-color: #222222;
+}
+
+/* Tiled window previews */
+.tile-preview {
+  background-color: rgba(36, 120, 233, 0.3);
+  border: 1px solid #2478e9;
+}
+
+.tile-preview-left.on-primary {
+  border-radius: 4px 0 0 0;
+}
+
+.tile-preview-right.on-primary {
+  border-radius: 0 4px 0 0;
+}
+
+.tile-preview-left.tile-preview-right.on-primary {
+  border-radius: 4px 4px 0 0;
+}
+
+/* On-screen Keyboard */
+#keyboard {
+  background-color: rgba(26, 26, 26, 0.95);
+  border: none;
+  border-top-width: 0;
+  box-shadow: none;
+}
+
+#keyboard .page-indicator {
+  padding: 6px;
+}
+
+#keyboard .page-indicator .page-indicator-icon {
+  width: 8px;
+  height: 8px;
+}
+
+.key-container {
+  padding: 4px;
+  spacing: 4px;
+}
+
+.keyboard-key {
+  min-height: 2em;
+  min-width: 2em;
+  font-size: 14pt;
+  font-weight: bold;
+  border-radius: 3px;
+  border: none;
+  color: inherit;
+  background-color: #4b4b4b;
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.1);
+}
+
+.keyboard-key:focus, .keyboard-key:hover {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: #656565;
+}
+
+.keyboard-key:checked, .keyboard-key:active {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: #7e7e7e;
+}
+
+.keyboard-key:grayed {
+  background-color: rgba(32, 32, 32, 0.75);
+  color: rgba(255, 255, 255, 0.85);
+  border-color: rgba(32, 32, 32, 0.75);
+}
+
+.keyboard-key.default-key {
+  background-color: #323232;
+}
+
+.keyboard-key.default-key:focus, .keyboard-key.default-key:hover {
+  color: rgba(255, 255, 255, 0.8);
+  background-color: #4c4c4c;
+}
+
+.keyboard-key.default-key:checked, .keyboard-key.default-key:active {
+  color: rgba(255, 255, 255, 0.8);
+  background-color: #585858;
+}
+
+.keyboard-key.enter-key {
+  background-color: #3281ea;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.keyboard-key.enter-key:focus, .keyboard-key.enter-key:hover {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #498fec;
+}
+
+.keyboard-key.enter-key:checked, .keyboard-key.enter-key:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #1667d3;
+}
+
+.keyboard-key.shift-key-uppercase {
+  color: #3281ea;
+}
+
+.keyboard-key StIcon {
+  icon-size: 1.125em;
+}
+
+.keyboard-subkeys {
+  color: inherit;
+  -arrow-border-radius: 3px;
+  -arrow-background-color: rgba(0, 0, 0, 0.45);
+  -arrow-border-width: 0;
+  -arrow-border-color: transparent;
+  -arrow-base: 20px;
+  -arrow-rise: 10px;
+  -boxpointer-gap: 5px;
+}
+
+.emoji-page .keyboard-key {
+  background-color: transparent;
+  border: none;
+  color: initial;
+}
+
+.emoji-panel .keyboard-key:latched {
+  border-color: #498fec;
+  background-color: #3281ea;
+}
+
+.word-suggestions {
+  font-size: 14pt;
+  spacing: 12px;
+  min-height: 20pt;
+}
+
+/* Looking Glass */
+#LookingGlassDialog {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: #202020;
+  spacing: 4px;
+  padding: 6px;
+  border: none;
+  border-radius: 3px;
+  box-shadow: 0 14px 14px rgba(0, 0, 0, 0.5);
+}
+
+#LookingGlassDialog > #Toolbar {
+  padding: 0 8px;
+  border: none;
+  border-radius: 0;
+  background-color: rgba(32, 32, 32, 0.01);
+  box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button:hover {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.06);
+  box-shadow: none;
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button:active {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.15);
+  box-shadow: 0 0 transparent;
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button:focus {
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: none;
+}
+
+#LookingGlassDialog .labels {
+  spacing: 0;
+}
+
+#LookingGlassDialog .notebook-tab {
+  -natural-hpadding: 12px;
+  -minimum-hpadding: 6px;
+  font-weight: bold;
+  color: rgba(255, 255, 255, 0.5);
+  transition-duration: 150ms;
+  padding-left: 16px;
+  padding-right: 16px;
+  min-height: 36px;
+  padding: 0 32px;
+  border-radius: 0;
+}
+
+#LookingGlassDialog .notebook-tab:hover {
+  box-shadow: inset 0 -2px 0 rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.9);
+  text-shadow: none;
+}
+
+#LookingGlassDialog .notebook-tab:selected {
+  background-color: rgba(32, 32, 32, 0.01);
+  box-shadow: inset 0 -2px 0 #3281ea;
+  color: rgba(255, 255, 255, 0.9);
+  text-shadow: none;
+}
+
+#LookingGlassDialog StBoxLayout#EvalBox {
+  padding: 4px;
+  spacing: 4px;
+}
+
+#LookingGlassDialog StBoxLayout#ResultsArea {
+  spacing: 4px;
+}
+
+.lg-dialog StEntry {
+  selection-background-color: #3281ea;
+  selected-color: rgba(255, 255, 255, 0.85) !important;
+}
+
+.lg-dialog .shell-link {
+  color: #3281ea;
+}
+
+.lg-dialog .shell-link:hover {
+  color: #3281ea;
+}
+
+.lg-completions-text {
+  font-size: 1em;
+  font-style: italic;
+}
+
+.lg-obj-inspector-title {
+  spacing: 4px;
+}
+
+.lg-obj-inspector-button {
+  min-height: 36px;
+  padding: 0 16px;
+  border: none;
+  border-radius: 3px;
+  font-size: 10.5pt;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.lg-obj-inspector-button:hover {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.06);
+  box-shadow: none;
+}
+
+.lg-obj-inspector-button:active {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.15);
+  box-shadow: 0 0 transparent;
+}
+
+.lg-obj-inspector-button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.lg-obj-inspector-button:focus {
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: none;
+}
+
+.lg-obj-inspector-button:hover {
+  border: none;
+}
+
+#lookingGlassExtensions {
+  padding: 4px;
+}
+
+.lg-extensions-list {
+  padding: 4px;
+  spacing: 6px;
+}
+
+.lg-extension {
+  border: none;
+  border-radius: 3px;
+  background-color: #606060;
+  padding: 4px;
+}
+
+.lg-extension-name {
+  font-size: 18pt;
+  font-weight: 400;
+}
+
+.lg-extension-meta {
+  spacing: 6px;
+}
+
+#LookingGlassPropertyInspector {
+  background: #202020;
+  border: none;
+  border-radius: 3px;
+  padding: 6px;
+  box-shadow: 0 14px 14px rgba(0, 0, 0, 0.5);
+}
+
+.quick-settings {
+  border-radius: 3px !important;
+  margin: 6px !important;
+  padding: 10px 12px 14px !important;
+}
+
+.quick-settings .icon-button, .quick-settings .message-notification-group .message-collapse-button, .message-notification-group .quick-settings .message-collapse-button, .quick-settings .message .message-header .message-expand-button, .message .message-header .quick-settings .message-expand-button,
+.quick-settings .message .message-header .message-close-button,
+.message .message-header .quick-settings .message-close-button, .quick-settings .button {
+  padding: 9px;
+}
+
+.quick-settings .icon-button > StIcon, .quick-settings .background-app-item .icon-button > StIcon, .quick-settings .message-notification-group .background-app-item .message-collapse-button > StIcon, .quick-settings .message .message-header .background-app-item .message-expand-button > StIcon,
+.quick-settings .message .message-header .background-app-item .message-close-button > StIcon, .quick-settings .message-notification-group .message-collapse-button > StIcon, .message-notification-group .quick-settings .message-collapse-button > StIcon, .quick-settings .message .message-header .message-expand-button > StIcon, .message .message-header .quick-settings .message-expand-button > StIcon,
+.quick-settings .message .message-header .message-close-button > StIcon,
+.message .message-header .quick-settings .message-close-button > StIcon, .quick-settings .button > StIcon {
+  icon-size: 16px;
+}
+
+.quick-settings-grid {
+  spacing-rows: 12px;
+  spacing-columns: 12px;
+}
+
+.quick-toggle, .quick-menu-toggle {
+  border-radius: 3px;
+  min-width: 12em;
+  max-width: 12em;
+  min-height: 44px;
+  padding: 0;
+  border: none;
+}
+
+.quick-toggle {
+  background-color: rgba(255, 255, 255, 0.06) !important;
+  /* Move padding into the box; this is to allow menu arrows
+       to extend to the border */
+}
+
+.quick-toggle:hover {
+  background-color: rgba(255, 255, 255, 0.12) !important;
+}
+
+.quick-toggle:active {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+.quick-toggle:checked {
+  background-color: #3281ea !important;
+  color: white;
+}
+
+.quick-toggle:checked:hover {
+  background-color: rgba(60, 135, 235, 0.994) !important;
+  color: white;
+}
+
+.quick-toggle:checked:active {
+  background-color: rgba(76, 145, 237, 0.985) !important;
+  color: white;
+}
+
+.quick-toggle > StBoxLayout {
+  spacing: 9px;
+}
+
+.quick-toggle.button {
+  padding: 0;
+}
+
+.quick-toggle > StBoxLayout {
+  padding: 0 12px;
+}
+
+.quick-toggle:ltr > StBoxLayout {
+  padding-left: 24px;
+}
+
+.quick-toggle:rtl > StBoxLayout {
+  padding-right: 24px;
+}
+
+.quick-toggle .quick-toggle-title {
+  font-weight: bold;
+}
+
+.quick-toggle StBoxLayout > .quick-toggle-subtitle {
+  font-weight: normal;
+  font-size: 12px;
+}
+
+.quick-toggle .quick-toggle-icon {
+  icon-size: 16px;
+}
+
+.quick-toggle-has-menu .quick-toggle {
+  min-width: auto;
+  max-width: auto;
+}
+
+.quick-toggle-has-menu .quick-toggle:ltr {
+  border-radius: 3px 0 0 3px;
+}
+
+.quick-toggle-has-menu .quick-toggle:ltr > StBoxLayout {
+  padding-right: 12px;
+}
+
+.quick-toggle-has-menu .quick-toggle:rtl {
+  border-radius: 0 3px 3px 0;
+}
+
+.quick-toggle-has-menu .quick-toggle:rtr > StBoxLayout {
+  padding-left: 12px;
+}
+
+.quick-toggle-has-menu .quick-toggle:ltr:last-child {
+  border-radius: 3px;
+}
+
+.quick-toggle-has-menu .quick-toggle:rtl:last-child {
+  border-radius: 3px;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button {
+  padding: 6px 12px;
+  border: none;
+  background-color: rgba(255, 255, 255, 0.06) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:hover {
+  background-color: rgba(255, 255, 255, 0.12) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:active {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:checked {
+  background-color: #3281ea !important;
+  color: white;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:checked:hover {
+  color: white;
+  background-color: st-mix(rgba(255, 255, 255, 0.9), #3281ea, 6%) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:checked:active {
+  color: white;
+  background-color: st-mix(rgba(255, 255, 255, 0.9), #3281ea, 15%) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:ltr {
+  border-radius: 0 3px 3px 0;
+  border-left-width: 0;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:rtl {
+  border-radius: 3px 0 0 3px;
+  border-right-width: 0;
+}
+
+.quick-toggle-has-menu .quick-toggle-separator {
+  width: 0;
+}
+
+.quick-slider > StBoxLayout {
+  spacing: 6px;
+}
+
+.quick-slider .slider-bin {
+  min-height: 16px;
+  padding: 6px;
+  border-radius: 9999px;
+}
+
+.quick-slider .slider-bin:focus {
+  color: #3281ea;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.quick-slider .slider-bin:focus:hover, .quick-slider .slider-bin:focus:active {
+  color: #3281ea;
+}
+
+.quick-slider .quick-toggle-icon {
+  icon-size: 16px;
+}
+
+.quick-slider .icon-button, .quick-slider .message-notification-group .message-collapse-button, .message-notification-group .quick-slider .message-collapse-button, .quick-slider .message .message-header .message-expand-button, .message .message-header .quick-slider .message-expand-button,
+.quick-slider .message .message-header .message-close-button,
+.message .message-header .quick-slider .message-close-button {
+  min-width: 22px;
+  min-height: 22px;
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.9) !important;
+}
+
+.quick-slider .icon-button:hover, .quick-slider .message-notification-group .message-collapse-button:hover, .message-notification-group .quick-slider .message-collapse-button:hover, .quick-slider .message .message-header .message-expand-button:hover, .message .message-header .quick-slider .message-expand-button:hover,
+.quick-slider .message .message-header .message-close-button:hover,
+.message .message-header .quick-slider .message-close-button:hover {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.quick-slider .icon-button:active, .quick-slider .message-notification-group .message-collapse-button:active, .message-notification-group .quick-slider .message-collapse-button:active, .quick-slider .message .message-header .message-expand-button:active, .message .message-header .quick-slider .message-expand-button:active,
+.quick-slider .message .message-header .message-close-button:active,
+.message .message-header .quick-slider .message-close-button:active {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.quick-toggle-menu {
+  background-color: #2d2d2d !important;
+  color: rgba(255, 255, 255, 0.9) !important;
+  border-radius: 3px !important;
+  padding: 18px;
+  margin: 12px 36px 0;
+  border: none !important;
+}
+
+.quick-toggle-menu .popup-menu-item {
+  border-radius: 3px !important;
+  min-height: 20px;
+}
+
+.quick-toggle-menu .popup-menu-item:focus, .quick-toggle-menu .popup-menu-item:hover, .quick-toggle-menu .popup-menu-item.selected {
+  color: rgba(255, 255, 255, 0.9) !important;
+  background-color: rgba(255, 255, 255, 0.1) !important;
+}
+
+.quick-toggle-menu .popup-menu-item:active {
+  color: rgba(255, 255, 255, 0.9) !important;
+  background-color: rgba(255, 255, 255, 0.2) !important;
+}
+
+.quick-toggle-menu .popup-menu-item > StIcon {
+  -st-icon-style: symbolic;
+}
+
+.quick-toggle-menu .header {
+  spacing-rows: 3px;
+  spacing-columns: 12px;
+  padding-bottom: 12px;
+}
+
+.quick-toggle-menu .header .icon {
+  icon-size: 24px;
+  border-radius: 3px;
+  padding: 9px;
+  background-color: rgba(255, 255, 255, 0.06) !important;
+}
+
+.quick-toggle-menu .header .icon.active {
+  background-color: #3281ea !important;
+  color: white;
+}
+
+.quick-settings-system-item > StBoxLayout {
+  spacing: 12px;
+}
+
+.quick-settings-system-item .icon-button, .quick-settings-system-item .message-notification-group .message-collapse-button, .message-notification-group .quick-settings-system-item .message-collapse-button, .quick-settings-system-item .message .message-header .message-expand-button, .message .message-header .quick-settings-system-item .message-expand-button,
+.quick-settings-system-item .message .message-header .message-close-button,
+.message .message-header .quick-settings-system-item .message-close-button {
+  background-color: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.9);
+  border-radius: 3px;
+  min-height: 22px;
+  min-width: 22px !important;
+}
+
+.quick-settings-system-item .icon-button:hover, .quick-settings-system-item .message-notification-group .message-collapse-button:hover, .message-notification-group .quick-settings-system-item .message-collapse-button:hover, .quick-settings-system-item .message .message-header .message-expand-button:hover, .message .message-header .quick-settings-system-item .message-expand-button:hover,
+.quick-settings-system-item .message .message-header .message-close-button:hover,
+.message .message-header .quick-settings-system-item .message-close-button:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.quick-settings-system-item .icon-button:active, .quick-settings-system-item .message-notification-group .message-collapse-button:active, .message-notification-group .quick-settings-system-item .message-collapse-button:active, .quick-settings-system-item .message .message-header .message-expand-button:active, .message .message-header .quick-settings-system-item .message-expand-button:active,
+.quick-settings-system-item .message .message-header .message-close-button:active,
+.message .message-header .quick-settings-system-item .message-close-button:active {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.quick-settings-system-item .icon-button > StIcon, .quick-settings-system-item .background-app-item .icon-button > StIcon, .quick-settings-system-item .message-notification-group .background-app-item .message-collapse-button > StIcon, .quick-settings-system-item .message .message-header .background-app-item .message-expand-button > StIcon,
+.quick-settings-system-item .message .message-header .background-app-item .message-close-button > StIcon, .quick-settings-system-item .message-notification-group .message-collapse-button > StIcon, .message-notification-group .quick-settings-system-item .message-collapse-button > StIcon, .quick-settings-system-item .message .message-header .message-expand-button > StIcon, .message .message-header .quick-settings-system-item .message-expand-button > StIcon,
+.quick-settings-system-item .message .message-header .message-close-button > StIcon,
+.message .message-header .quick-settings-system-item .message-close-button > StIcon {
+  -st-icon-style: symbolic;
+  icon-size: 16px;
+}
+
+.quick-settings-system-item .power-item {
+  min-height: 0;
+  min-width: 0;
+}
+
+.quick-settings-system-item .power-item:insensitive {
+  color: rgba(255, 255, 255, 0.8);
+  background-color: #343434;
+  border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: none;
+  background-color: transparent;
+}
+
+.nm-network-item .wireless-secure-icon {
+  icon-size: 8px;
+}
+
+.bt-device-item .popup-menu-icon {
+  -st-icon-style: symbolic;
+}
+
+.bt-menu-placeholder.popup-menu-item {
+  text-align: center;
+  padding: 2em 4em;
+}
+
+.device-subtitle {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.keyboard-brightness-level {
+  spacing: 6px;
+}
+
+.background-apps-quick-toggle {
+  min-height: 40px;
+  background-color: transparent;
+}
+
+.background-apps-quick-toggle StIcon {
+  icon-size: 16px !important;
+}
+
+.background-app-item .popup-menu-icon {
+  icon-size: 24px !important;
+  -st-icon-style: regular !important;
+}
+
+.background-app-item .icon-button, .background-app-item .message-notification-group .message-collapse-button, .message-notification-group .background-app-item .message-collapse-button, .background-app-item .message .message-header .message-expand-button, .message .message-header .background-app-item .message-expand-button,
+.background-app-item .message .message-header .message-close-button,
+.message .message-header .background-app-item .message-close-button {
+  padding: 6px;
+}
+
+.background-app-item .spinner {
+  padding: 6px;
+}
+
+.background-app-item.popup-inactive-menu-item {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.icon-label-button-container {
+  spacing: 6px;
+  font-size: 9pt;
+  font-weight: 400;
+}
+
+.icon-label-button-container StIcon {
+  icon-size: 32px;
+}
+
+.screenshot-ui-panel {
+  border-radius: 27px;
+  padding: 18px;
+  padding-bottom: 12px;
+  margin-bottom: 4em;
+  spacing: 12px;
+}
+
+.screenshot-ui-close-button {
+  padding: 6px;
+}
+
+.screenshot-ui-close-button.left {
+  margin-left: 8px;
+}
+
+.screenshot-ui-close-button.right {
+  margin-right: 8px;
+}
+
+.screenshot-ui-type-button {
+  padding: 12px 18px !important;
+  border-radius: 9px;
+}
+
+.screenshot-ui-capture-button {
+  width: 36px;
+  height: 36px;
+  border-radius: 9999px;
+  border: 4px rgba(255, 255, 255, 0.85);
+  padding: 4px;
+}
+
+.screenshot-ui-capture-button .screenshot-ui-capture-button-circle {
+  background-color: rgba(255, 255, 255, 0.85);
+  transition-duration: 200ms;
+  border-radius: 9999px;
+}
+
+.screenshot-ui-capture-button .screenshot-ui-capture-button-circle:hover, .screenshot-ui-capture-button .screenshot-ui-capture-button-circle:focus {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.screenshot-ui-capture-button:hover .screenshot-ui-capture-button-circle, .screenshot-ui-capture-button:focus .screenshot-ui-capture-button-circle {
+  background-color: rgba(217, 217, 217, 0.85);
+}
+
+.screenshot-ui-capture-button:active .screenshot-ui-capture-button-circle {
+  background-color: rgba(128, 128, 128, 0.85);
+}
+
+.screenshot-ui-capture-button:cast .screenshot-ui-capture-button-circle {
+  background-color: #DD2C00;
+}
+
+.screenshot-ui-capture-button:cast:hover .screenshot-ui-capture-button-circle, .screenshot-ui-capture-button:cast:focus .screenshot-ui-capture-button-circle {
+  background-color: #911d00;
+}
+
+.screenshot-ui-capture-button:cast:active .screenshot-ui-capture-button-circle {
+  background-color: #440e00;
+}
+
+.screenshot-ui-shot-cast-container {
+  background-color: rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  padding: 3px;
+  spacing: 3px;
+}
+
+.screenshot-ui-shot-cast-container:ltr {
+  margin-left: 3px;
+}
+
+.screenshot-ui-shot-cast-container:rtl {
+  margin-right: 3px;
+}
+
+.screenshot-ui-shot-cast-button {
+  padding: 6px 12px;
+  background-color: transparent;
+  border-radius: 3px;
+}
+
+.screenshot-ui-shot-cast-button:hover, .screenshot-ui-shot-cast-button:focus {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.screenshot-ui-shot-cast-button:active {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.screenshot-ui-shot-cast-button:checked {
+  background-color: white;
+  color: black;
+}
+
+.screenshot-ui-shot-cast-button StIcon {
+  icon-size: 16px;
+}
+
+.screenshot-ui-show-pointer-button {
+  border-radius: 9999px;
+  padding: 12px !important;
+}
+
+.screenshot-ui-show-pointer-button StIcon {
+  icon-size: 16px;
+}
+
+.screenshot-ui-area-indicator-shade {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.screenshot-ui-area-selector .screenshot-ui-area-indicator-shade {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.screenshot-ui-area-selector .screenshot-ui-area-indicator-selection {
+  border: 2px white;
+}
+
+.screenshot-ui-area-selector-handle {
+  border-radius: 9999px;
+  background-color: white;
+  box-shadow: 0 1px 3px 2px rgba(0, 0, 0, 0.2);
+  width: 24px;
+  height: 24px;
+}
+
+.screenshot-ui-window-selector {
+  background-color: #222222;
+}
+
+.screenshot-ui-window-selector .screenshot-ui-window-selector-window-container {
+  margin: 100px;
+}
+
+.screenshot-ui-window-selector:primary-monitor .screenshot-ui-window-selector-window-container {
+  margin-bottom: 200px;
+}
+
+.screenshot-ui-window-selector-window-border {
+  transition-duration: 200ms;
+  border-radius: 6px;
+  border: 6px transparent;
+}
+
+.screenshot-ui-window-selector-check {
+  transition-duration: 200ms;
+  color: transparent;
+  border-radius: 9999px;
+  border-width: 12px;
+  icon-size: 24px;
+}
+
+.screenshot-ui-window-selector-window:hover .screenshot-ui-window-selector-window-border {
+  border-color: #135cbc;
+}
+
+.screenshot-ui-window-selector-window:checked .screenshot-ui-window-selector-window-border {
+  border-color: #3281ea;
+  background-color: rgba(50, 129, 234, 0.2);
+}
+
+.screenshot-ui-window-selector-window:checked .screenshot-ui-window-selector-check {
+  color: white;
+  background-color: #3281ea;
+}
+
+.screenshot-ui-screen-selector {
+  transition-duration: 200ms;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.screenshot-ui-screen-selector:hover {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.screenshot-ui-screen-selector:active {
+  background-color: rgba(0, 0, 0, 0.7);
+}
+
+.screenshot-ui-screen-selector:checked {
+  background-color: transparent;
+  border: 2px white;
+}
+
+.screenshot-ui-tooltip {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #222222;
+  border-radius: 99px;
+  padding: 6px 12px;
+  text-align: center;
+  -y-offset: 24px;
+}
+
+/* Login Dialog */
+.login-dialog-banner-view {
+  padding-top: 24px;
+  max-width: 23em;
+}
+
+.login-dialog,
+.unlock-dialog {
+  border: none;
+  background-color: transparent;
+}
+
+.login-dialog StEntry,
+.unlock-dialog StEntry {
+  selection-background-color: #3281ea;
+  selected-color: rgba(255, 255, 255, 0.85) !important;
+  caret-color: rgba(255, 255, 255, 0.7);
+  color: rgba(255, 255, 255, 0.7);
+  background-color: rgba(255, 255, 255, 0.15);
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+.login-dialog StEntry:focus,
+.unlock-dialog StEntry:focus {
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #3281ea !important;
+}
+
+.login-dialog StEntry:insensitive,
+.unlock-dialog StEntry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog .modal-dialog-button-box,
+.unlock-dialog .modal-dialog-button-box {
+  spacing: 3px;
+}
+
+.login-dialog .modal-dialog-button,
+.unlock-dialog .modal-dialog-button {
+  padding: 4px 18px;
+  box-shadow: none;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:hover, .login-dialog .modal-dialog-button:focus,
+.unlock-dialog .modal-dialog-button:hover,
+.unlock-dialog .modal-dialog-button:focus {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.15);
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:active,
+.unlock-dialog .modal-dialog-button:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.3);
+  box-shadow: 0 0 transparent;
+}
+
+.login-dialog .modal-dialog-button:insensitive,
+.unlock-dialog .modal-dialog-button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default,
+.unlock-dialog .modal-dialog-button:default {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #408aeb;
+  border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:hover, .login-dialog .modal-dialog-button:default:focus,
+.unlock-dialog .modal-dialog-button:default:hover,
+.unlock-dialog .modal-dialog-button:default:focus {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #408aeb;
+  border-color: rgba(255, 255, 255, 0.15);
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:active,
+.unlock-dialog .modal-dialog-button:default:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #5798ee;
+  border-color: rgba(255, 255, 255, 0.15);
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:active:hover, .login-dialog .modal-dialog-button:default:active:focus,
+.unlock-dialog .modal-dialog-button:default:active:hover,
+.unlock-dialog .modal-dialog-button:default:active:focus {
+  background-color: #5798ee;
+}
+
+.login-dialog .modal-dialog-button:default:insensitive,
+.unlock-dialog .modal-dialog-button:default:insensitive {
+  color: rgba(255, 255, 255, 0.5);
+  background-color: rgba(255, 255, 255, 0.15);
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.login-dialog .cancel-button,
+.login-dialog .switch-user-button,
+.login-dialog .login-dialog-session-list-button,
+.unlock-dialog .cancel-button,
+.unlock-dialog .switch-user-button,
+.unlock-dialog .login-dialog-session-list-button {
+  padding: 0;
+  border-radius: 99px;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog .cancel-button:hover, .login-dialog .cancel-button:focus,
+.login-dialog .switch-user-button:hover,
+.login-dialog .switch-user-button:focus,
+.login-dialog .login-dialog-session-list-button:hover,
+.login-dialog .login-dialog-session-list-button:focus,
+.unlock-dialog .cancel-button:hover,
+.unlock-dialog .cancel-button:focus,
+.unlock-dialog .switch-user-button:hover,
+.unlock-dialog .switch-user-button:focus,
+.unlock-dialog .login-dialog-session-list-button:hover,
+.unlock-dialog .login-dialog-session-list-button:focus {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog .cancel-button:active,
+.login-dialog .switch-user-button:active,
+.login-dialog .login-dialog-session-list-button:active,
+.unlock-dialog .cancel-button:active,
+.unlock-dialog .switch-user-button:active,
+.unlock-dialog .login-dialog-session-list-button:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.login-dialog .cancel-button StIcon,
+.login-dialog .switch-user-button StIcon,
+.login-dialog .login-dialog-session-list-button StIcon,
+.unlock-dialog .cancel-button StIcon,
+.unlock-dialog .switch-user-button StIcon,
+.unlock-dialog .login-dialog-session-list-button StIcon {
+  icon-size: 16px;
+}
+
+.login-dialog .caps-lock-warning-label,
+.login-dialog .login-dialog-message-warning,
+.unlock-dialog .caps-lock-warning-label,
+.unlock-dialog .login-dialog-message-warning {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-logo-bin {
+  padding: 24px 0px;
+}
+
+.login-dialog-banner {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog-button-box {
+  width: 23em;
+  spacing: 5px;
+}
+
+.login-dialog-message {
+  text-align: center;
+}
+
+.login-dialog-user-selection-box {
+  padding: 100px 0px;
+}
+
+.login-dialog-not-listed-label {
+  padding-left: 2px;
+  font-size: 1em;
+  font-weight: bold;
+  color: rgba(255, 255, 255, 0.7);
+  padding-top: 1em;
+}
+
+.login-dialog-not-listed-label:hover {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-not-listed-label:focus {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.login-dialog-not-listed-button:focus .login-dialog-not-listed-label, .login-dialog-not-listed-button:hover .login-dialog-not-listed-label {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-view {
+  -st-vfade-offset: 1em;
+}
+
+.login-dialog-user-list {
+  spacing: 12px;
+  width: 23em;
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:selected {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:active {
+  background-color: rgba(255, 255, 255, 0.3);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:logged-in {
+  border-right: 2px solid rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-item {
+  border-radius: 3px;
+  padding: 6px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog-user-list-item:ltr {
+  padding-right: 1em;
+}
+
+.login-dialog-user-list-item:rtl {
+  padding-left: 1em;
+}
+
+.login-dialog-user-list-item:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-item:active {
+  background-color: rgba(255, 255, 255, 0.3);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-item .login-dialog-timed-login-indicator {
+  height: 2px;
+  margin: 6px 0 0 0;
+  background-color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-item:focus .login-dialog-timed-login-indicator {
+  background-color: rgba(255, 255, 255, 0.85);
+}
+
+.user-widget-label {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.user-widget.horizontal .user-widget-label {
+  font-size: 15pt;
+  font-weight: 500;
+  font-weight: bold;
+  padding-left: 15px;
+}
+
+.user-widget.horizontal .user-widget-label:ltr {
+  padding-left: 14px;
+  text-align: left;
+}
+
+.user-widget.horizontal .user-widget-label:rtl {
+  padding-right: 14px;
+  text-align: right;
+}
+
+.user-widget.vertical .user-widget-label {
+  font-size: 15pt;
+  font-weight: 500;
+  text-align: center;
+  font-weight: normal;
+  padding-top: 16px;
+}
+
+.login-dialog-prompt-layout {
+  padding-top: 24px;
+  padding-bottom: 12px;
+  spacing: 12px;
+  width: 23em;
+}
+
+.login-dialog-prompt-entry {
+  height: 1.5em;
+}
+
+.login-dialog-prompt-label {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 1em;
+  padding-top: 1em;
+}
+
+/* Screen Shield */
+.unlock-dialog-clock {
+  color: white;
+  font-weight: 300;
+  text-align: center;
+  spacing: 24px;
+  padding-bottom: 2.5em;
+}
+
+.unlock-dialog-clock-time {
+  font-size: 64pt;
+  padding-top: 42px;
+  font-feature-settings: "tnum";
+}
+
+.unlock-dialog-clock-date {
+  font-size: 16pt;
+  font-weight: normal;
+}
+
+.unlock-dialog-clock-hint {
+  font-weight: normal;
+  padding-top: 48px;
+}
+
+.unlock-dialog-notifications-container {
+  margin: 12px 0;
+  spacing: 6px;
+  width: 23em;
+  background-color: transparent;
+}
+
+.unlock-dialog-notifications-container .summary-notification-stack-scrollview {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.unlock-dialog-notifications-container .notification,
+.unlock-dialog-notifications-container .unlock-dialog-notification-source {
+  padding: 12px 6px;
+  border: none;
+  background-color: rgba(32, 32, 32, 0.9);
+  color: rgba(255, 255, 255, 0.85);
+  border-radius: 3px;
+}
+
+.unlock-dialog-notifications-container .notification.critical,
+.unlock-dialog-notifications-container .unlock-dialog-notification-source.critical {
+  background-color: rgba(34, 34, 34, 0.9);
+}
+
+.unlock-dialog-notification-label {
+  padding: 0px 0px 0px 12px;
+}
+
+.unlock-dialog-notification-count-text {
+  weight: bold;
+  padding: 0 6px;
+  color: rgba(32, 32, 32, 0.9);
+  background-color: rgba(255, 255, 255, 0.7);
+  border-radius: 99px;
+  margin-right: 12px;
+}
+
+.screen-shield-background {
+  background: black;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.6);
+}
+
+#lockDialogGroup {
+  background-color: #222222;
+}
+
+#unlockDialogNotifications StButton#vhandle, #unlockDialogNotifications StButton#hhandle {
+  background-color: rgba(32, 32, 32, 0.2);
+}
+
+#unlockDialogNotifications StButton#vhandle:hover, #unlockDialogNotifications StButton#vhandle:focus, #unlockDialogNotifications StButton#hhandle:hover, #unlockDialogNotifications StButton#hhandle:focus {
+  background-color: rgba(32, 32, 32, 0.4);
+}
+
+#unlockDialogNotifications StButton#vhandle:active, #unlockDialogNotifications StButton#hhandle:active {
+  background-color: rgba(50, 129, 234, 0.5);
+}
+
+.bottom #dashtodockDashScrollview,
+.top #dashtodockDashScrollview {
+  -st-hfade-offset: 24px;
+}
+
+.left #dashtodockDashScrollview,
+.right #dashtodockDashScrollview {
+  -st-vfade-offset: 24px;
+}
+
+#dashtodockContainer {
+  background-color: transparent;
+  box-shadow: none;
+}
+
+#dashtodockContainer .number-overlay {
+  color: #FFFFFF;
+  background-color: rgba(0, 0, 0, 0.75);
+  text-align: center;
+}
+
+#dashtodockContainer .notification-badge {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #3281ea;
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.25);
+  border-radius: 9999px;
+  margin: 2px 3px 5px;
+  padding: 0.2em 0.6em;
+  font-weight: bold;
+  text-align: center;
+}
+
+#dashtodockContainer.top.straight-corner #dash, #dashtodockContainer.top.shrink.straight-corner #dash, #dashtodockContainer.top.extended #dash, #dashtodockContainer.top.extended:overview #dash {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.straight-corner #dash .dash-background, #dashtodockContainer.top.shrink.straight-corner #dash .dash-background, #dashtodockContainer.top.extended #dash .dash-background, #dashtodockContainer.top.extended:overview #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.top.straight-corner #dash .show-apps,
+#dashtodockContainer.top.straight-corner #dash .overview-tile,
+#dashtodockContainer.top.straight-corner #dash .grid-search-result,
+#dashtodockContainer.top.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.top.straight-corner #dash .list-search-result, #dashtodockContainer.top.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.top.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.top.extended #dash .show-apps,
+#dashtodockContainer.top.extended #dash .overview-tile,
+#dashtodockContainer.top.extended #dash .grid-search-result,
+#dashtodockContainer.top.extended #dash .search-provider-icon,
+#dashtodockContainer.top.extended #dash .list-search-result, #dashtodockContainer.top.extended:overview #dash .show-apps,
+#dashtodockContainer.top.extended:overview #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash, #dashtodockContainer.bottom.shrink.straight-corner #dash, #dashtodockContainer.bottom.extended #dash, #dashtodockContainer.bottom.extended:overview #dash {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash .dash-background, #dashtodockContainer.bottom.shrink.straight-corner #dash .dash-background, #dashtodockContainer.bottom.extended #dash .dash-background, #dashtodockContainer.bottom.extended:overview #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash .show-apps,
+#dashtodockContainer.bottom.straight-corner #dash .overview-tile,
+#dashtodockContainer.bottom.straight-corner #dash .grid-search-result,
+#dashtodockContainer.bottom.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.bottom.straight-corner #dash .list-search-result, #dashtodockContainer.bottom.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.bottom.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.bottom.extended #dash .show-apps,
+#dashtodockContainer.bottom.extended #dash .overview-tile,
+#dashtodockContainer.bottom.extended #dash .grid-search-result,
+#dashtodockContainer.bottom.extended #dash .search-provider-icon,
+#dashtodockContainer.bottom.extended #dash .list-search-result, #dashtodockContainer.bottom.extended:overview #dash .show-apps,
+#dashtodockContainer.bottom.extended:overview #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash, #dashtodockContainer.left.shrink.straight-corner #dash, #dashtodockContainer.left.extended #dash, #dashtodockContainer.left.extended:overview #dash {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash .dash-background, #dashtodockContainer.left.shrink.straight-corner #dash .dash-background, #dashtodockContainer.left.extended #dash .dash-background, #dashtodockContainer.left.extended:overview #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash .show-apps,
+#dashtodockContainer.left.straight-corner #dash .overview-tile,
+#dashtodockContainer.left.straight-corner #dash .grid-search-result,
+#dashtodockContainer.left.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.left.straight-corner #dash .list-search-result, #dashtodockContainer.left.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.left.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.left.extended #dash .show-apps,
+#dashtodockContainer.left.extended #dash .overview-tile,
+#dashtodockContainer.left.extended #dash .grid-search-result,
+#dashtodockContainer.left.extended #dash .search-provider-icon,
+#dashtodockContainer.left.extended #dash .list-search-result, #dashtodockContainer.left.extended:overview #dash .show-apps,
+#dashtodockContainer.left.extended:overview #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash, #dashtodockContainer.right.shrink.straight-corner #dash, #dashtodockContainer.right.extended #dash, #dashtodockContainer.right.extended:overview #dash {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash .dash-background, #dashtodockContainer.right.shrink.straight-corner #dash .dash-background, #dashtodockContainer.right.extended #dash .dash-background, #dashtodockContainer.right.extended:overview #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash .show-apps,
+#dashtodockContainer.right.straight-corner #dash .overview-tile,
+#dashtodockContainer.right.straight-corner #dash .grid-search-result,
+#dashtodockContainer.right.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.right.straight-corner #dash .list-search-result, #dashtodockContainer.right.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.right.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.right.extended #dash .show-apps,
+#dashtodockContainer.right.extended #dash .overview-tile,
+#dashtodockContainer.right.extended #dash .grid-search-result,
+#dashtodockContainer.right.extended #dash .search-provider-icon,
+#dashtodockContainer.right.extended #dash .list-search-result, #dashtodockContainer.right.extended:overview #dash .show-apps,
+#dashtodockContainer.right.extended:overview #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.extended #dash .dash-background, #dashtodockContainer.straight-corner #dash .dash-background {
+  border-radius: 0;
+}
+
+#dashtodockContainer.shrink #dash .dash-background {
+  padding: 0 !important;
+  border-radius: 3px;
+}
+
+#dashtodockContainer.shrink #dash .show-apps,
+#dashtodockContainer.shrink #dash .overview-tile,
+#dashtodockContainer.shrink #dash .grid-search-result,
+#dashtodockContainer.shrink #dash .search-provider-icon,
+#dashtodockContainer.shrink #dash .list-search-result {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left #dash .overview-tile, #dashtodockContainer.left #dash .grid-search-result, #dashtodockContainer.left #dash .search-provider-icon, #dashtodockContainer.left #dash .list-search-result, #dashtodockContainer.right #dash .overview-tile, #dashtodockContainer.right #dash .grid-search-result, #dashtodockContainer.right #dash .search-provider-icon, #dashtodockContainer.right #dash .list-search-result {
+  padding: 2px 6px !important;
+}
+
+#dashtodockContainer.left #dash .show-apps, #dashtodockContainer.right #dash .show-apps {
+  padding-bottom: 6px !important;
+}
+
+#dashtodockContainer.left.shrink #dash .show-apps,
+#dashtodockContainer.left.shrink #dash .overview-tile,
+#dashtodockContainer.left.shrink #dash .grid-search-result,
+#dashtodockContainer.left.shrink #dash .search-provider-icon,
+#dashtodockContainer.left.shrink #dash .list-search-result, #dashtodockContainer.right.shrink #dash .show-apps,
+#dashtodockContainer.right.shrink #dash .overview-tile,
+#dashtodockContainer.right.shrink #dash .grid-search-result,
+#dashtodockContainer.right.shrink #dash .search-provider-icon,
+#dashtodockContainer.right.shrink #dash .list-search-result {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.extended #dash .show-apps,
+#dashtodockContainer.left.extended #dash .overview-tile,
+#dashtodockContainer.left.extended #dash .grid-search-result,
+#dashtodockContainer.left.extended #dash .search-provider-icon,
+#dashtodockContainer.left.extended #dash .list-search-result, #dashtodockContainer.left.straight-corner #dash .show-apps,
+#dashtodockContainer.left.straight-corner #dash .overview-tile,
+#dashtodockContainer.left.straight-corner #dash .grid-search-result,
+#dashtodockContainer.left.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.left.straight-corner #dash .list-search-result, #dashtodockContainer.right.extended #dash .show-apps,
+#dashtodockContainer.right.extended #dash .overview-tile,
+#dashtodockContainer.right.extended #dash .grid-search-result,
+#dashtodockContainer.right.extended #dash .search-provider-icon,
+#dashtodockContainer.right.extended #dash .list-search-result, #dashtodockContainer.right.straight-corner #dash .show-apps,
+#dashtodockContainer.right.straight-corner #dash .overview-tile,
+#dashtodockContainer.right.straight-corner #dash .grid-search-result,
+#dashtodockContainer.right.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.right.straight-corner #dash .list-search-result {
+  padding: 2px 12px !important;
+}
+
+#dashtodockContainer.top.shrink #dash .dash-background, #dashtodockContainer.bottom.shrink #dash .dash-background {
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.shrink #dash .show-apps,
+#dashtodockContainer.top.shrink #dash .overview-tile,
+#dashtodockContainer.top.shrink #dash .grid-search-result,
+#dashtodockContainer.top.shrink #dash .search-provider-icon,
+#dashtodockContainer.top.shrink #dash .list-search-result, #dashtodockContainer.bottom.shrink #dash .show-apps,
+#dashtodockContainer.bottom.shrink #dash .overview-tile,
+#dashtodockContainer.bottom.shrink #dash .grid-search-result,
+#dashtodockContainer.bottom.shrink #dash .search-provider-icon,
+#dashtodockContainer.bottom.shrink #dash .list-search-result {
+  margin: 0 !important;
+  padding: 0 0 18px !important;
+}
+
+#dashtodockContainer.top.extended #dash .dash-separator, #dashtodockContainer.top.straight-corner #dash .dash-separator, #dashtodockContainer.bottom.extended #dash .dash-separator, #dashtodockContainer.bottom.straight-corner #dash .dash-separator {
+  margin: 0 8px !important;
+}
+
+#dashtodockContainer.top.extended #dash .show-apps,
+#dashtodockContainer.top.extended #dash .overview-tile,
+#dashtodockContainer.top.extended #dash .grid-search-result,
+#dashtodockContainer.top.extended #dash .search-provider-icon,
+#dashtodockContainer.top.extended #dash .list-search-result, #dashtodockContainer.top.straight-corner #dash .show-apps,
+#dashtodockContainer.top.straight-corner #dash .overview-tile,
+#dashtodockContainer.top.straight-corner #dash .grid-search-result,
+#dashtodockContainer.top.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.top.straight-corner #dash .list-search-result, #dashtodockContainer.bottom.extended #dash .show-apps,
+#dashtodockContainer.bottom.extended #dash .overview-tile,
+#dashtodockContainer.bottom.extended #dash .grid-search-result,
+#dashtodockContainer.bottom.extended #dash .search-provider-icon,
+#dashtodockContainer.bottom.extended #dash .list-search-result, #dashtodockContainer.bottom.straight-corner #dash .show-apps,
+#dashtodockContainer.bottom.straight-corner #dash .overview-tile,
+#dashtodockContainer.bottom.straight-corner #dash .grid-search-result,
+#dashtodockContainer.bottom.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.bottom.straight-corner #dash .list-search-result {
+  padding: 12px 2px !important;
+}
+
+#dashtodockContainer #dash {
+  background: none;
+  box-shadow: none;
+}
+
+#dashtodockContainer #dash .dash-background {
+  background-color: rgba(0, 0, 0, 0.5);
+  background-clip: padding-box;
+}
+
+#dashtodockContainer #dash .show-apps .overview-icon,
+#dashtodockContainer #dash .overview-tile .overview-icon,
+#dashtodockContainer #dash .grid-search-result .overview-icon,
+#dashtodockContainer #dash .search-provider-icon .overview-icon,
+#dashtodockContainer #dash .list-search-result .overview-icon {
+  color: rgba(255, 255, 255, 0.75) !important;
+}
+
+#dashtodockContainer #dash .show-apps:hover .overview-icon, #dashtodockContainer #dash .show-apps:focus .overview-icon, #dashtodockContainer #dash .show-apps:selected .overview-icon,
+#dashtodockContainer #dash .overview-tile:hover .overview-icon,
+#dashtodockContainer #dash .grid-search-result:hover .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:hover .overview-icon,
+#dashtodockContainer #dash .list-search-result:hover .overview-icon,
+#dashtodockContainer #dash .overview-tile:focus .overview-icon,
+#dashtodockContainer #dash .grid-search-result:focus .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:focus .overview-icon,
+#dashtodockContainer #dash .list-search-result:focus .overview-icon,
+#dashtodockContainer #dash .overview-tile:selected .overview-icon,
+#dashtodockContainer #dash .grid-search-result:selected .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:selected .overview-icon,
+#dashtodockContainer #dash .list-search-result:selected .overview-icon {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+  color: #FFFFFF !important;
+}
+
+#dashtodockContainer #dash .show-apps:active .overview-icon, #dashtodockContainer #dash .show-apps:checked .overview-icon,
+#dashtodockContainer #dash .overview-tile:active .overview-icon,
+#dashtodockContainer #dash .grid-search-result:active .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:active .overview-icon,
+#dashtodockContainer #dash .list-search-result:active .overview-icon,
+#dashtodockContainer #dash .overview-tile:checked .overview-icon,
+#dashtodockContainer #dash .grid-search-result:checked .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:checked .overview-icon,
+#dashtodockContainer #dash .list-search-result:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+  color: #FFFFFF !important;
+}
+
+#dashtodockContainer .dash-separator {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#dashtodockContainer .app-grid-running-dot {
+  background-color: rgba(255, 255, 255, 0.55) !important;
+  margin: 0 0 3px !important;
+  offset-y: 0 !important;
+}
+
+#dashtodockContainer StWidget.focused .overview-icon {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+}
+
+#dashtodockContainer StWidget.focused:hover .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#dashtodockContainer StWidget.focused .app-grid-running-dot {
+  background-color: #3281ea !important;
+}
+
+#dashtodockContainer.opaque #dash .dash-background {
+  background-color: #202020;
+}
+
+#dashtodockContainer.transparent #dash .dash-background {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+#dashtodockContainer:overview #dash .dash-background {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+#dashtodockContainer:overview #dash .show-apps .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result .overview-icon {
+  color: rgba(255, 255, 255, 0.7) !important;
+}
+
+#dashtodockContainer:overview #dash .show-apps:hover .overview-icon, #dashtodockContainer:overview #dash .show-apps:focus .overview-icon, #dashtodockContainer:overview #dash .show-apps:selected .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:hover .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:hover .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:hover .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:hover .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:focus .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:focus .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:focus .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:focus .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:selected .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:selected .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:selected .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:selected .overview-icon {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+  color: rgba(255, 255, 255, 0.85) !important;
+}
+
+#dashtodockContainer:overview #dash .show-apps:active .overview-icon, #dashtodockContainer:overview #dash .show-apps:checked .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:active .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:active .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:active .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:active .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:checked .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:checked .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:checked .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+  color: rgba(255, 255, 255, 0.85) !important;
+}
+
+#dashtodockContainer:overview #dash .dash-separator {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#dashtodockContainer:overview #dash .app-grid-running-dot {
+  background-color: rgba(255, 255, 255, 0.5) !important;
+}
+
+#dashtodockContainer:overview #dash StWidget.focused .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#dashtodockContainer:overview #dash StWidget.focused:hover .overview-icon {
+  background-color: rgba(255, 255, 255, 0.3) !important;
+}
+
+#dashtodockContainer:overview #dash StWidget.focused .app-grid-running-dot {
+  background-color: #3281ea !important;
+}
+
+#dashtodockContainer.opaque:overview #dash, #dashtodockContainer.transparent:overview #dash {
+  background-color: transparent !important;
+  box-shadow: none !important;
+}
+
+#dashtodockContainer.opaque:overview #dash .dash-background, #dashtodockContainer.transparent:overview #dash .dash-background {
+  background-color: transparent !important;
+}
+
+#dashtodockContainer.extended:overview #dash, #dashtodockContainer.opaque.extended:overview #dash, #dashtodockContainer.transparent.extended:overview #dash {
+  background: none;
+}
+
+#dashtodockContainer.extended:overview .dash-background, #dashtodockContainer.opaque.extended:overview .dash-background, #dashtodockContainer.transparent.extended:overview .dash-background {
+  background-color: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#dashtodockContainer.running-dots .dash-item-container > StButton, #dashtodockContainer.dashtodock .dash-item-container > StButton {
+  transition-duration: 250ms;
+  background-size: contain;
+}
+
+#dashtodockContainer.extended .show-apps .overview-icon,
+#dashtodockContainer.extended .overview-tile .overview-icon,
+#dashtodockContainer.extended .grid-search-result .overview-icon,
+#dashtodockContainer.extended .search-provider-icon .overview-icon,
+#dashtodockContainer.extended .list-search-result .overview-icon, #dashtodockContainer.extended:overview .show-apps .overview-icon,
+#dashtodockContainer.extended:overview .overview-tile .overview-icon {
+  border-radius: 3px;
+}
+
+#dashtodockContainer .metro .overview-icon {
+  border-radius: 0;
+}
+
+.dashtodock-app-well-preview-menu-item {
+  padding: 1em 1em 0.5em 1em;
+}
+
+#dashtodockPreviewSeparator.popup-separator-menu-item-horizontal {
+  width: 1px;
+  height: auto;
+  border-right-width: 1px;
+  margin: 32px 0;
+}
+
+.dashtopanelMainPanel .show-apps,
+.dashtopanelMainPanel .overview-tile,
+.dashtopanelMainPanel .grid-search-result,
+.dashtopanelMainPanel .search-provider-icon,
+.dashtopanelMainPanel .list-search-result {
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+}
+
+.dashtopanelMainPanel .show-apps .overview-icon,
+.dashtopanelMainPanel .overview-tile .overview-icon,
+.dashtopanelMainPanel .grid-search-result .overview-icon,
+.dashtopanelMainPanel .search-provider-icon .overview-icon,
+.dashtopanelMainPanel .list-search-result .overview-icon {
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+}
+
+.dashtopanelMainPanel .show-apps .overview-icon {
+  border-radius: 3px !important;
+  color: rgba(255, 255, 255, 0.75) !important;
+}
+
+.dashtopanelMainPanel .show-apps:hover .overview-icon, .dashtopanelMainPanel .show-apps:focus .overview-icon, .dashtopanelMainPanel .show-apps:selected .overview-icon {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+  color: #FFFFFF !important;
+  box-shadow: none !important;
+}
+
+.dashtopanelMainPanel .show-apps:active .overview-icon, .dashtopanelMainPanel .show-apps:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+  color: #FFFFFF !important;
+  box-shadow: none !important;
+}
+
+.dashtopanelMainPanel .panel-button {
+  color: rgba(255, 255, 255, 0.75) !important;
+}
+
+.openweather-button, .openweather-button-action, .openweather-menu-button-container, .openweather-button-box {
+  border: 1px solid transparent !important;
+}
+
+.openweather-provider {
+  padding: 0 16px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.openweather-provider:hover {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.06);
+  box-shadow: none;
+}
+
+.openweather-provider:focus {
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: none;
+}
+
+.openweather-provider:active {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(255, 255, 255, 0.15);
+  box-shadow: 0 0 transparent;
+}
+
+.openweather-current-icon, .openweather-current-summary, .openweather-current-summarybox {
+  background: none;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.openweather-current-databox-values {
+  background: none;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.openweather-current-databox-captions {
+  background: none;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.openweather-forecast-icon, .openweather-forecast-summary {
+  background: none;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.openweather-forecast-day, .openweather-forecast-temperature {
+  background: none;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.openweather-sunrise-icon, .openweather-sunset-icon, .openweather-build-icon {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.gsconnect-device-menu .popup-menu-item {
+  height: 20px !important;
+  padding: 3px 0;
+}
+
+.gsconnect-device-menu .popup-menu-item > :last-child:ltr {
+  padding-right: 6px !important;
+  margin-right: 12px !important;
+}
+
+.gsconnect-device-menu .popup-menu-item > :last-child:rtl {
+  padding-left: 6px !important;
+  padding-left: 12px !important;
+}
+
+#panel.light-panel .panel-button,
+#panel.dark-panel .panel-button,
+#panel.transparent-panel .panel-button {
+  color: rgba(255, 255, 255, 0.7) !important;
+}
+
+#panel.light-panel .panel-button.clock-display .clock,
+#panel.dark-panel .panel-button.clock-display .clock,
+#panel.transparent-panel .panel-button.clock-display .clock {
+  color: rgba(255, 255, 255, 0.7) !important;
+}
+
+#panel.light-panel .panel-button:hover,
+#panel.dark-panel .panel-button:hover,
+#panel.transparent-panel .panel-button:hover {
+  color: rgba(255, 255, 255, 0.7) !important;
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#panel.light-panel .panel-button:active, #panel.light-panel .panel-button:checked, #panel.light-panel .panel-button:focus,
+#panel.dark-panel .panel-button:active,
+#panel.dark-panel .panel-button:checked,
+#panel.dark-panel .panel-button:focus,
+#panel.transparent-panel .panel-button:active,
+#panel.transparent-panel .panel-button:checked,
+#panel.transparent-panel .panel-button:focus {
+  color: rgba(255, 255, 255, 0.85) !important;
+  background-color: rgba(255, 255, 255, 0.3) !important;
+}
+
+#panel.light-panel .panel-button:hover.clock-display .clock, #panel.light-panel .panel-button:active.clock-display .clock, #panel.light-panel .panel-button:overview.clock-display .clock, #panel.light-panel .panel-button:focus.clock-display .clock, #panel.light-panel .panel-button:checked.clock-display .clock,
+#panel.dark-panel .panel-button:hover.clock-display .clock,
+#panel.dark-panel .panel-button:active.clock-display .clock,
+#panel.dark-panel .panel-button:overview.clock-display .clock,
+#panel.dark-panel .panel-button:focus.clock-display .clock,
+#panel.dark-panel .panel-button:checked.clock-display .clock,
+#panel.transparent-panel .panel-button:hover.clock-display .clock,
+#panel.transparent-panel .panel-button:active.clock-display .clock,
+#panel.transparent-panel .panel-button:overview.clock-display .clock,
+#panel.transparent-panel .panel-button:focus.clock-display .clock,
+#panel.transparent-panel .panel-button:checked.clock-display .clock {
+  color: rgba(255, 255, 255, 0.85) !important;
+}
+
+.overview-components-transparent .search-entry,
+.overview-components-light .search-entry,
+.overview-components-dark .search-entry {
+  caret-color: rgba(255, 255, 255, 0.75) !important;
+}
+
+.overview-components-transparent .search-entry .search-entry-icon,
+.overview-components-light .search-entry .search-entry-icon,
+.overview-components-dark .search-entry .search-entry-icon {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.overview-components-transparent .search-entry StLabel.hint-text,
+.overview-components-light .search-entry StLabel.hint-text,
+.overview-components-dark .search-entry StLabel.hint-text {
+  color: rgba(255, 255, 255, 0.35) !important;
+}
+
+.arcmenu-menu {
+  border-image: none !important;
+  border-radius: 3px !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+}
+
+.arcmenu-menu .popup-menu-content {
+  padding: 6px !important;
+  margin: 6px !important;
+  border: none !important;
+  background-color: rgba(32, 32, 32, 0.97);
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.1) !important;
+  border-radius: 3px !important;
+}

--- a/src/gnome-shell/shell-48-0/gnome-shell-Dark.scss
+++ b/src/gnome-shell/shell-48-0/gnome-shell-Dark.scss
@@ -1,0 +1,10 @@
+$variant: 'dark';
+$laptop: 'false';
+$panel: 'dark';
+
+@import '../sass/variables';
+@import '../sass/colors';
+@import '../sass/drawing';
+@import '../sass/common-40-0';
+@import '../sass/widgets-48-0';
+@import '../sass/extensions-46-0';

--- a/src/gnome-shell/shell-48-0/gnome-shell-Light-compact.css
+++ b/src/gnome-shell/shell-48-0/gnome-shell-Light-compact.css
@@ -1,0 +1,4945 @@
+/* This stylesheet is generated, DO NOT EDIT */
+stage {
+  font-size: 9.75pt;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.87);
+}
+
+/* Common Stylings */
+#dash .dash-item-container .show-apps,
+#dash .dash-item-container .overview-tile,
+#dash .dash-item-container .grid-search-result,
+#dash .dash-item-container .search-provider-icon,
+#dash .dash-item-container .list-search-result {
+  background: none;
+  box-shadow: none;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  margin: 0;
+}
+
+#dash .dash-item-container .show-apps .overview-icon,
+#dash .dash-item-container .overview-tile .overview-icon,
+#dash .dash-item-container .grid-search-result .overview-icon,
+#dash .dash-item-container .search-provider-icon .overview-icon,
+#dash .dash-item-container .list-search-result .overview-icon {
+  border-radius: 6px;
+  padding: 4px;
+  spacing: 4px;
+  text-align: center;
+  transition-duration: 100ms;
+}
+
+.search-statustext {
+  font-size: 45px;
+  font-weight: 400;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.popup-menu-content {
+  background: rgba(255, 255, 255, 0.97);
+  color: rgba(0, 0, 0, 0.87);
+  border-radius: 3px;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.1);
+}
+
+.modal-dialog {
+  background: rgba(255, 255, 255, 0.97);
+  color: rgba(0, 0, 0, 0.87);
+  border-radius: 6px;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2);
+}
+
+/* General Typography */
+.message-notification-group .message-group-header .message-group-title, .message-list .message-list-placeholder {
+  font-weight: 800;
+  font-size: 1.364em;
+}
+
+.quick-toggle-menu .header .title {
+  font-weight: 700;
+  font-size: 1.364em;
+}
+
+.bt-menu-placeholder.popup-menu-item {
+  font-weight: 700;
+  font-size: 1.182em;
+}
+
+.background-app-item .title, .message-list-controls, .calendar .calendar-month-header .calendar-month-label {
+  font-weight: 700;
+  font-size: 1em;
+}
+
+.quick-toggle-menu .header .subtitle {
+  font-weight: 700;
+  font-size: 0.818em;
+}
+
+.background-app-item .subtitle, .message .message-header .message-header-content .event-time {
+  font-weight: 400;
+  font-size: 0.818em;
+}
+
+/* WIDGETS */
+.shell-link {
+  border-radius: 3px;
+  color: #1A73E8;
+  background-color: transparent;
+}
+
+.shell-link:hover {
+  color: #1A73E8;
+  background-color: rgba(26, 115, 232, 0.15);
+}
+
+.shell-link:active {
+  color: #1A73E8;
+  background-color: rgba(26, 115, 232, 0.3);
+}
+
+.lowres-icon {
+  icon-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+}
+
+.icon-dropshadow {
+  icon-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+}
+
+/* Entries */
+StEntry {
+  min-height: 24px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  border-width: 0;
+  caret-color: rgba(0, 0, 0, 0.54);
+  selection-background-color: #1A73E8;
+  selected-color: #FFFFFF !important;
+  font-size: 11.25pt;
+  font-weight: 400;
+  caret-color: rgba(0, 0, 0, 0.54);
+  color: rgba(0, 0, 0, 0.54);
+  background-color: #ffffff;
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+StEntry:hover {
+  border: 2px solid rgba(0, 0, 0, 0.2) !important;
+}
+
+StEntry:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #1A73E8 !important;
+}
+
+StEntry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+StEntry StIcon.capslock-warning {
+  icon-size: 16px;
+  warning-color: #FF6D00;
+  padding: 0 0;
+}
+
+StEntry StIcon.peek-password {
+  icon-size: 16px;
+  padding: 0 4px;
+}
+
+StEntry StLabel.hint-text {
+  margin-left: 2px;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+/* Buttons */
+.screenshot-ui-show-pointer-button, .screenshot-ui-type-button {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:focus, .screenshot-ui-type-button:focus {
+  color: rgba(255, 255, 255, 0.85);
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:hover, .screenshot-ui-type-button:hover {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.15);
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:active, .screenshot-ui-type-button:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.3);
+  box-shadow: 0 0 transparent;
+}
+
+.screenshot-ui-show-pointer-button:checked, .screenshot-ui-type-button:checked {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #1A73E8;
+  border-color: #1A73E8;
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:checked:hover, .screenshot-ui-type-button:checked:hover, .screenshot-ui-show-pointer-button:checked:focus, .screenshot-ui-type-button:checked:focus {
+  background-color: #1A73E8;
+}
+
+.screenshot-ui-show-pointer-button:insensitive, .screenshot-ui-type-button:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.icon-button.flat, .message .message-header .flat.message-expand-button,
+.message .message-header .flat.message-close-button, .message-notification-group .flat.message-collapse-button, .button.flat {
+  color: rgba(0, 0, 0, 0.54);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.icon-button.flat:focus, .message .message-header .flat.message-expand-button:focus,
+.message .message-header .flat.message-close-button:focus, .message-notification-group .flat.message-collapse-button:focus, .button.flat:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: none;
+}
+
+.icon-button.flat:hover, .message .message-header .flat.message-expand-button:hover,
+.message .message-header .flat.message-close-button:hover, .message-notification-group .flat.message-collapse-button:hover, .button.flat:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+  box-shadow: none;
+}
+
+.icon-button.flat:selected, .message .message-header .flat.message-expand-button:selected,
+.message .message-header .flat.message-close-button:selected, .message-notification-group .flat.message-collapse-button:selected, .button.flat:selected, .icon-button.flat:active, .message .message-header .flat.message-expand-button:active,
+.message .message-header .flat.message-close-button:active, .message-notification-group .flat.message-collapse-button:active, .button.flat:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+.icon-button.flat:checked, .message .message-header .flat.message-expand-button:checked,
+.message .message-header .flat.message-close-button:checked, .message-notification-group .flat.message-collapse-button:checked, .button.flat:checked {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+.icon-button.flat:insensitive, .message .message-header .flat.message-expand-button:insensitive,
+.message .message-header .flat.message-close-button:insensitive, .message-notification-group .flat.message-collapse-button:insensitive, .button.flat:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:checked, .icon-button.default, .message .message-header .default.message-expand-button,
+.message .message-header .default.message-close-button, .message-notification-group .default.message-collapse-button, .button.default {
+  color: #FFFFFF;
+  background-color: #1A73E8;
+  border-color: #1151a5;
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:focus:checked, .icon-button.default:focus, .message .message-header .default.message-expand-button:focus,
+.message .message-header .default.message-close-button:focus, .message-notification-group .default.message-collapse-button:focus, .button.default:focus {
+  color: #1A73E8;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.keyboard-brightness-level .button:focus:hover:checked, .icon-button.default:focus:hover, .message .message-header .default.message-expand-button:focus:hover,
+.message .message-header .default.message-close-button:focus:hover, .message-notification-group .default.message-collapse-button:focus:hover, .button.default:focus:hover, .keyboard-brightness-level .button:focus:active:checked, .icon-button.default:focus:active, .message .message-header .default.message-expand-button:focus:active,
+.message .message-header .default.message-close-button:focus:active, .message-notification-group .default.message-collapse-button:focus:active, .button.default:focus:active {
+  color: #1A73E8;
+}
+
+.keyboard-brightness-level .button:hover:checked, .icon-button.default:hover, .message .message-header .default.message-expand-button:hover,
+.message .message-header .default.message-close-button:hover, .message-notification-group .default.message-collapse-button:hover, .button.default:hover {
+  color: #FFFFFF;
+  background-color: #1A73E8;
+  border-color: #0e458e;
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:insensitive:checked, .icon-button.default:insensitive, .message .message-header .default.message-expand-button:insensitive,
+.message .message-header .default.message-close-button:insensitive, .message-notification-group .default.message-collapse-button:insensitive, .button.default:insensitive {
+  color: #FFFFFF;
+  background-color: #1A73E8;
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:active:checked, .icon-button.default:active, .message .message-header .default.message-expand-button:active,
+.message .message-header .default.message-close-button:active, .message-notification-group .default.message-collapse-button:active, .button.default:active {
+  color: #FFFFFF;
+  background-color: #1567d3;
+  border-color: #0e458e;
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:active:hover:checked, .icon-button.default:active:hover, .message .message-header .default.message-expand-button:active:hover,
+.message .message-header .default.message-close-button:active:hover, .message-notification-group .default.message-collapse-button:active:hover, .button.default:active:hover, .keyboard-brightness-level .button:active:focus:checked, .icon-button.default:active:focus, .message .message-header .default.message-expand-button:active:focus,
+.message .message-header .default.message-close-button:active:focus, .message-notification-group .default.message-collapse-button:active:focus, .button.default:active:focus {
+  background-color: #1567d3;
+}
+
+.icon-button, .background-app-item .icon-button, .background-app-item .message-notification-group .message-collapse-button, .message-notification-group .background-app-item .message-collapse-button, .background-app-item .message .message-header .message-expand-button, .message .message-header .background-app-item .message-expand-button,
+.background-app-item .message .message-header .message-close-button,
+.message .message-header .background-app-item .message-close-button, .message .message-header .message-expand-button,
+.message .message-header .message-close-button, .message-notification-group .message-collapse-button, .button {
+  padding: 4px 8px;
+  border-width: 0;
+  border-radius: 3px;
+  font-size: 9.75pt;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.54);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.icon-button:focus, .message .message-header .message-expand-button:focus,
+.message .message-header .message-close-button:focus, .message-notification-group .message-collapse-button:focus, .button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: none;
+}
+
+.icon-button:hover, .message .message-header .message-expand-button:hover,
+.message .message-header .message-close-button:hover, .message-notification-group .message-collapse-button:hover, .button:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+  box-shadow: none;
+}
+
+.icon-button:selected, .message .message-header .message-expand-button:selected,
+.message .message-header .message-close-button:selected, .message-notification-group .message-collapse-button:selected, .button:selected, .icon-button:active, .message .message-header .message-expand-button:active,
+.message .message-header .message-close-button:active, .message-notification-group .message-collapse-button:active, .button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+.icon-button:checked, .message .message-header .message-expand-button:checked,
+.message .message-header .message-close-button:checked, .message-notification-group .message-collapse-button:checked, .button:checked {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #1A73E8;
+  border-color: #1A73E8;
+  box-shadow: none;
+}
+
+.icon-button:checked:hover, .message .message-header .message-expand-button:checked:hover,
+.message .message-header .message-close-button:checked:hover, .message-notification-group .message-collapse-button:checked:hover, .button:checked:hover, .icon-button:checked:focus, .message .message-header .message-expand-button:checked:focus,
+.message .message-header .message-close-button:checked:focus, .message-notification-group .message-collapse-button:checked:focus, .button:checked:focus {
+  background-color: #1A73E8;
+}
+
+.icon-button:insensitive, .message .message-header .message-expand-button:insensitive,
+.message .message-header .message-close-button:insensitive, .message-notification-group .message-collapse-button:insensitive, .button:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button, .notification-button {
+  border-radius: 3px;
+  border: 1px solid;
+  color: rgba(0, 0, 0, 0.62);
+  background-color: #ffffff;
+  border-color: #d9d9d9;
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button:focus, .notification-button:focus {
+  color: #1A73E8;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.modal-dialog .modal-dialog-button:focus:hover, .notification-button:focus:hover, .modal-dialog .modal-dialog-button:focus:active, .notification-button:focus:active {
+  color: #1A73E8;
+}
+
+.modal-dialog .modal-dialog-button:hover, .notification-button:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #ffffff;
+  border-color: #cccccc;
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button:selected, .notification-button:selected, .modal-dialog .modal-dialog-button:active, .notification-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #f2f2f2;
+  border-color: #cccccc;
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button:selected:hover, .notification-button:selected:hover, .modal-dialog .modal-dialog-button:selected:focus, .notification-button:selected:focus, .modal-dialog .modal-dialog-button:active:hover, .notification-button:active:hover, .modal-dialog .modal-dialog-button:active:focus, .notification-button:active:focus {
+  background-color: #f2f2f2;
+}
+
+.modal-dialog .modal-dialog-button:checked, .notification-button:checked {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #1A73E8;
+  border-color: #1A73E8;
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button:checked:hover, .notification-button:checked:hover, .modal-dialog .modal-dialog-button:checked:focus, .notification-button:checked:focus {
+  background-color: #1A73E8;
+}
+
+.modal-dialog .modal-dialog-button:insensitive, .notification-button:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: rgba(0, 0, 0, 0.06);
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.button {
+  min-height: 1.5em;
+}
+
+.icon-button, .background-app-item .icon-button, .background-app-item .message-notification-group .message-collapse-button, .message-notification-group .background-app-item .message-collapse-button, .background-app-item .message .message-header .message-expand-button, .message .message-header .background-app-item .message-expand-button,
+.background-app-item .message .message-header .message-close-button,
+.message .message-header .background-app-item .message-close-button, .message .message-header .message-expand-button,
+.message .message-header .message-close-button, .message-notification-group .message-collapse-button {
+  border-radius: 9999px;
+  padding: 0.818em;
+  min-height: 1.091em;
+}
+
+.icon-button StIcon, .background-app-item .icon-button StIcon, .background-app-item .message-notification-group .message-collapse-button StIcon, .message-notification-group .background-app-item .message-collapse-button StIcon, .background-app-item .message .message-header .message-expand-button StIcon, .message .message-header .background-app-item .message-expand-button StIcon,
+.background-app-item .message .message-header .message-close-button StIcon,
+.message .message-header .background-app-item .message-close-button StIcon, .message .message-header .message-expand-button StIcon,
+.message .message-header .message-close-button StIcon, .message-notification-group .message-collapse-button StIcon {
+  icon-size: 1.091em;
+  -st-icon-style: symbolic;
+}
+
+/* Check Boxes */
+.check-box StBoxLayout {
+  spacing: .8em;
+}
+
+.check-box StBin {
+  width: 24px;
+  height: 24px;
+  padding: 4px;
+  border-radius: 100px;
+  background-image: url("assets/checkbox-off.svg");
+}
+
+.check-box:focus StBin {
+  background-image: url("assets/checkbox-off.svg");
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.check-box:hover StBin {
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.check-box:active StBin {
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.check-box:checked StBin {
+  background-image: url("assets/checkbox.svg");
+}
+
+.check-box:focus:checked StBin {
+  background-image: url("assets/checkbox.svg");
+}
+
+.check-box:hover:checked StBin {
+  background-color: rgba(40, 124, 233, 0.15);
+}
+
+.check-box:active:checked StBin {
+  background-color: rgba(40, 124, 233, 0.3);
+}
+
+.check-box StIcon {
+  icon-size: 0;
+  padding: 0;
+  border: none;
+  background-color: transparent;
+  color: transparent;
+}
+
+.check-box:checked StIcon {
+  background-color: transparent;
+  color: transparent;
+}
+
+.check-box:checked:hover StIcon {
+  background-color: transparent;
+  color: transparent;
+}
+
+.check-box:checked:active StIcon {
+  background-color: transparent;
+  color: transparent;
+}
+
+/* Switches */
+.toggle-switch {
+  width: 36px;
+  height: 18px;
+  background: transparent;
+  color: rgba(0, 0, 0, 0.87);
+  border: 1px solid rgba(0, 0, 0, 0.38);
+}
+
+.toggle-switch:hover {
+  background: transparent;
+  color: rgba(0, 0, 0, 0.87);
+  border: 1px solid rgba(0, 0, 0, 0.54);
+}
+
+.toggle-switch StIcon {
+  icon-size: 10px;
+}
+
+.toggle-switch .handle {
+  margin: 4px;
+  width: 10px;
+  height: 10px;
+  border-radius: 9999px;
+  background: rgba(0, 0, 0, 0.54);
+  box-shadow: none;
+  transition-duration: 100ms;
+}
+
+.toggle-switch:checked {
+  background: #1A73E8;
+  color: white;
+  border-color: #1A73E8;
+}
+
+.toggle-switch:checked:hover {
+  background-color: #3181ea;
+  color: white;
+  border-color: #3181ea;
+}
+
+.toggle-switch:checked .handle {
+  background: white;
+}
+
+/* Slider */
+.slider {
+  height: 12px;
+  color: #287ce9;
+  -barlevel-height: 2px;
+  -barlevel-background-color: rgba(0, 0, 0, 0.2);
+  -barlevel-active-background-color: #287ce9;
+  -barlevel-overdrive-color: #FF5252;
+  -barlevel-overdrive-separator-width: 2px;
+  -slider-handle-radius: 6px;
+}
+
+.slider:hover {
+  color: #3f8aec;
+}
+
+.slider:active {
+  color: #176ee1;
+}
+
+/* Scrollbars */
+StScrollView.vfade {
+  -st-vfade-offset: 32px;
+}
+
+StScrollView.hfade {
+  -st-hfade-offset: 32px;
+}
+
+StScrollBar {
+  padding: 0;
+}
+
+StScrollView StScrollBar {
+  min-width: 8px;
+  min-height: 8px;
+}
+
+StScrollBar StBin#trough {
+  border-radius: 9999px;
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+StScrollBar StButton#vhandle, StScrollBar StButton#hhandle {
+  border-radius: 9999px;
+  background-color: rgba(0, 0, 0, 0.38);
+  border: 4px solid transparent;
+}
+
+StScrollBar StButton#vhandle:hover, StScrollBar StButton#hhandle:hover {
+  background-color: rgba(0, 0, 0, 0.54);
+}
+
+StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
+  background-color: rgba(0, 0, 0, 0.87);
+}
+
+/* Popovers/Menus */
+.popup-menu-boxpointer, .candidate-popup-boxpointer {
+  -arrow-border-radius: 3px;
+  -arrow-background-color: transparent;
+  -arrow-border-width: 0;
+  -arrow-border-color: transparent;
+  -arrow-base: 27px;
+  -arrow-rise: 0;
+  -arrow-box-shadow: none;
+}
+
+.popup-menu {
+  min-width: 15em;
+  color: rgba(0, 0, 0, 0.87);
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+.popup-menu.panel-menu {
+  -boxpointer-gap: 2px;
+  margin-bottom: 1.75em;
+}
+
+.popup-menu-content {
+  padding: 4px;
+  margin: 2px 4px 10px;
+  border: none;
+}
+
+.popup-menu-item {
+  spacing: 4px;
+  padding: 4px 8px;
+  margin: 0;
+  color: rgba(0, 0, 0, 0.87);
+  transition-duration: 100ms;
+  border-radius: 3px;
+  background-image: none;
+  background-gradient-direction: none !important;
+}
+
+.popup-menu-item:ltr {
+  padding-right: 8px;
+  padding-left: 8px;
+}
+
+.popup-menu-item:rtl {
+  padding-right: 8px;
+  padding-left: 8px;
+}
+
+.popup-menu-item:checked {
+  background-color: rgba(0, 0, 0, 0.08) !important;
+  font-weight: normal;
+  border-radius: 3px 3px 0 0 !important;
+  border: none;
+  box-shadow: none;
+  color: rgba(0, 0, 0, 0.87) !important;
+  background-gradient-direction: none !important;
+}
+
+.popup-menu-item:checked.selected, .popup-menu-item:checked:hover, .popup-menu-item:checked:focus {
+  background-color: rgba(0, 0, 0, 0.1) !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+}
+
+.popup-menu-item:checked:active, .popup-menu-item:checked.selected:active {
+  background-color: rgba(0, 0, 0, 0.08) !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+}
+
+.popup-menu-item:checked:insensitive {
+  color: rgba(0, 0, 0, 0.38) !important;
+}
+
+.popup-menu-item.selected, .popup-menu-item:hover, .popup-menu-item:focus {
+  background-color: rgba(0, 0, 0, 0.06) !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+  transition-duration: 0ms;
+  background-gradient-direction: none !important;
+}
+
+.popup-menu-item:active {
+  background-color: rgba(0, 0, 0, 0.2) !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+  transition-duration: 150ms;
+  background-gradient-direction: none !important;
+}
+
+.popup-menu-item.selected:active {
+  color: rgba(0, 0, 0, 0.87) !important;
+}
+
+.popup-menu-item:insensitive {
+  color: rgba(0, 0, 0, 0.38) !important;
+}
+
+.popup-inactive-menu-item {
+  color: rgba(0, 0, 0, 0.87) !important;
+}
+
+.popup-inactive-menu-item:insensitive {
+  color: rgba(0, 0, 0, 0.38) !important;
+}
+
+.popup-menu-arrow,
+.popup-menu-icon {
+  icon-size: 16px;
+}
+
+.popup-sub-menu {
+  margin: 0;
+  background-color: rgba(0, 0, 0, 0.08) !important;
+  border-radius: 0 0 3px 3px !important;
+  border: none;
+  box-shadow: none;
+  background-image: none !important;
+}
+
+.popup-sub-menu .popup-menu-item {
+  margin: 0;
+  border-radius: 0;
+  background-image: none !important;
+  background-color: transparent !important;
+}
+
+.popup-sub-menu .popup-menu-item.selected, .popup-sub-menu .popup-menu-item:hover, .popup-sub-menu .popup-menu-item:focus {
+  background-color: rgba(0, 0, 0, 0.06) !important;
+}
+
+.popup-sub-menu .popup-menu-item:active {
+  background-color: rgba(0, 0, 0, 0.2) !important;
+}
+
+.popup-sub-menu .popup-menu-item:last-child {
+  border-radius: 0 0 3px 3px !important;
+  border-bottom-width: 0;
+}
+
+.popup-sub-menu .popup-menu-section .popup-menu-item:last-child:hover, .popup-sub-menu .popup-menu-section .popup-menu-item:last-child:focus {
+  border-radius: 0;
+}
+
+.popup-sub-menu .popup-menu-section:last-child .popup-menu-item:last-child {
+  border-radius: 0 0 3px 3px !important;
+}
+
+.popup-menu-ornament {
+  width: 1.2em;
+}
+
+.popup-menu-ornament:ltr {
+  text-align: right;
+}
+
+.popup-menu-ornament:rtl {
+  text-align: left;
+}
+
+.popup-separator-menu-item {
+  background: none;
+  border: none;
+  padding: 0 0;
+  margin: 0 0;
+  height: 2px;
+}
+
+.popup-separator-menu-item .popup-separator-menu-item-separator {
+  height: 1px;
+  margin: 0 0;
+  padding: 0 0;
+  background: none;
+}
+
+.popup-sub-menu .popup-separator-menu-item .popup-separator-menu-item-separator {
+  margin: 0 0;
+  padding: 0 0;
+  background: none;
+}
+
+.background-menu {
+  -boxpointer-gap: 2px;
+  -arrow-rise: 0px;
+}
+
+.aggregate-menu {
+  min-width: 19em;
+}
+
+.aggregate-menu .popup-menu-icon {
+  padding: 0;
+  margin: 0;
+  -st-icon-style: symbolic;
+}
+
+.aggregate-menu .popup-menu-icon:ltr {
+  margin-right: 2px;
+}
+
+.aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
+  padding-left: 8px !important;
+  margin-left: 0 !important;
+}
+
+.aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
+  padding-right: 8px !important;
+  margin-right: 0 !important;
+}
+
+/* Date/Time Menu */
+#calendarArea {
+  padding: 4px 0;
+}
+
+.datemenu-popover {
+  border-radius: 7px !important;
+}
+
+.calendar {
+  padding: 0;
+  margin: 0 6px;
+  border: none;
+  box-shadow: none;
+  background: none;
+  text-shadow: none;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.calendar .calendar-month-header .calendar-change-month-back StIcon,
+.calendar .calendar-month-header .calendar-change-month-forward StIcon {
+  icon-size: 1.091em;
+}
+
+.calendar .calendar-month-header .calendar-month-label {
+  background-color: transparent !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+  padding: 8px 0;
+  width: 10em;
+  text-align: center;
+}
+
+.calendar .calendar-day-heading {
+  width: 28px;
+  height: 21px;
+  margin-top: 2px;
+  padding: 7px 0 0;
+  border-radius: 9999px;
+  background-color: transparent !important;
+  color: rgba(0, 0, 0, 0.38) !important;
+  font-size: 9pt;
+  font-weight: 400;
+  font-weight: bold;
+  text-align: center;
+}
+
+.datemenu-calendar-column {
+  spacing: 4px;
+  border: none;
+  padding: 0;
+  margin: 0;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.datemenu-calendar-column:hover, .datemenu-calendar-column:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.datemenu-calendar-column:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.datemenu-calendar-column:ltr {
+  margin-right: 2px;
+  margin-left: 6px;
+  border-left-width: 0;
+}
+
+.datemenu-calendar-column:rtl {
+  margin-left: 2px;
+  margin-right: 6px;
+  border-right-width: 0;
+}
+
+.datemenu-calendar-column .datemenu-displays-section {
+  padding-bottom: 0;
+}
+
+.datemenu-calendar-column .datemenu-displays-box {
+  spacing: 4px;
+}
+
+.datemenu-today-button {
+  min-height: 48px;
+  padding: 4px;
+  border-radius: 3px;
+  border: none;
+  box-shadow: none;
+  text-shadow: none;
+  background: none;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.datemenu-today-button .day-label {
+  font-size: 15pt;
+  font-weight: 500;
+  font-weight: bold;
+}
+
+.datemenu-today-button .date-label {
+  font-size: 18pt;
+  font-weight: 400;
+}
+
+.datemenu-today-button:hover, .datemenu-today-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.datemenu-today-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.pager-button {
+  width: 28px;
+  height: 28px;
+  margin: 2px !important;
+  padding: 0 !important;
+  border-radius: 9999px;
+  background-color: transparent;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.pager-button:hover, .pager-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.pager-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.calendar-change-month-back {
+  padding: 2px !important;
+  background-image: url("assets/calendar-arrow-left.svg");
+}
+
+.calendar-change-month-back:rtl {
+  background-image: url("assets/calendar-arrow-right.svg");
+}
+
+.calendar-change-month-forward {
+  padding: 2px !important;
+  background-image: url("assets/calendar-arrow-right.svg");
+}
+
+.calendar-change-month-forward:rtl {
+  background-image: url("assets/calendar-arrow-left.svg");
+}
+
+.calendar-day {
+  font-size: 9pt;
+  font-weight: 400;
+  text-align: center;
+  width: 28px !important;
+  height: 28px !important;
+  padding: 2px !important;
+  margin: 2px !important;
+  border-radius: 9999px;
+  color: rgba(0, 0, 0, 0.54) !important;
+  background-color: transparent !important;
+  border: none;
+  font-feature-settings: "tnum";
+  text-shadow: none;
+}
+
+.calendar-day:hover, .calendar-day:focus {
+  background-color: rgba(0, 0, 0, 0.06) !important;
+  box-shadow: none !important;
+}
+
+.calendar-day:active {
+  color: rgba(0, 0, 0, 0.54) !important;
+  background-color: rgba(0, 0, 0, 0.2) !important;
+  border-color: transparent;
+}
+
+.calendar-day:selected {
+  color: rgba(0, 0, 0, 0.87) !important;
+  background-color: rgba(0, 0, 0, 0.2) !important;
+  border-color: transparent;
+  box-shadow: none !important;
+}
+
+.calendar-day {
+  border-width: 0;
+}
+
+.calendar-day-top {
+  border-top-width: 0;
+}
+
+.calendar-day-left {
+  border-left-width: 0;
+}
+
+.calendar-nonwork-day {
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.calendar-today {
+  font-weight: bold !important;
+  color: white !important;
+  background-color: #1A73E8 !important;
+  border: none;
+}
+
+.calendar-today:hover, .calendar-today:focus {
+  background-color: #287ce9 !important;
+  color: white !important;
+  box-shadow: none !important;
+}
+
+.calendar-today:active, .calendar-today:selected {
+  background-color: #1A73E8 !important;
+  color: white !important;
+  box-shadow: none !important;
+}
+
+.calendar-today:active:hover, .calendar-today:active:focus, .calendar-today:selected:hover, .calendar-today:selected:focus {
+  background-color: #287ce9 !important;
+  color: white !important;
+}
+
+.calendar-day-with-events {
+  color: rgba(0, 0, 0, 0.38);
+  background-image: url("assets/calendar-today.svg");
+}
+
+.calendar-day-with-events.calendar-work-day {
+  color: rgba(0, 0, 0, 0.38);
+  font-weight: bold;
+}
+
+.calendar-weekend {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.calendar-other-month {
+  color: rgba(0, 0, 0, 0.26) !important;
+  opacity: 1;
+  font-weight: normal;
+}
+
+.calendar-other-month.calendar-weekend {
+  color: rgba(0, 0, 0, 0.26) !important;
+}
+
+.calendar-week-number {
+  height: 1.8em !important;
+  width: 2.6em !important;
+  padding: 0px 0 !important;
+  margin: 4px 0 !important;
+  border-radius: 9999px;
+  background-color: rgba(0, 0, 0, 0.04);
+  color: rgba(0, 0, 0, 0.38);
+  font-size: inherit;
+  font-weight: bold;
+  text-align: center;
+  text-shadow: none;
+}
+
+.world-clocks-button,
+.weather-button,
+.events-button {
+  padding: 4px 8px;
+  border-radius: 3px;
+  box-shadow: none;
+  text-shadow: none;
+  color: rgba(0, 0, 0, 0.54);
+  background-color: rgba(255, 255, 255, 0.35) !important;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.world-clocks-button:hover, .world-clocks-button:focus,
+.weather-button:hover,
+.weather-button:focus,
+.events-button:hover,
+.events-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06) !important;
+  border-color: rgba(0, 0, 0, 0.15);
+  box-shadow: none;
+}
+
+.world-clocks-button:active,
+.weather-button:active,
+.events-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.08) !important;
+  box-shadow: none;
+}
+
+.world-clocks-header,
+.weather-header,
+.message-list-section-title,
+.events-section-title,
+.events-title {
+  color: rgba(0, 0, 0, 0.38);
+  font-weight: bold;
+  margin-bottom: 4px;
+  text-shadow: none;
+}
+
+.weather-grid,
+.world-clocks-grid {
+  spacing-rows: 8px;
+  spacing-columns: 16px;
+}
+
+.world-clocks-header,
+.weather-header,
+.events-section-title {
+  color: rgba(0, 0, 0, 0.38);
+  font-weight: bold;
+}
+
+.events-button .events-box {
+  spacing: 4px;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.events-button .events-list {
+  spacing: 8px;
+  text-shadow: none;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.events-button .event-time {
+  color: rgba(0, 0, 0, 0.26);
+  font-feature-settings: "tnum";
+}
+
+.world-clocks-button .world-clocks-city {
+  color: rgba(0, 0, 0, 0.38);
+  font-weight: normal;
+  font-size: 1em;
+}
+
+.world-clocks-button .world-clocks-time {
+  color: rgba(0, 0, 0, 0.38);
+  font-feature-settings: "tnum";
+  font-weight: bold;
+  font-size: 1em;
+}
+
+.world-clocks-button .world-clocks-time:ltr {
+  text-align: right;
+}
+
+.world-clocks-button .world-clocks-time:rtl {
+  text-align: left;
+}
+
+.world-clocks-button .world-clocks-timezone {
+  color: rgba(0, 0, 0, 0.38);
+  font-feature-settings: "tnum";
+  font-size: 1em;
+}
+
+.weather-button .weather-box {
+  spacing: 4px;
+}
+
+.weather-button .weather-header-box {
+  spacing: 4px;
+}
+
+.weather-button .weather-header.location {
+  font-weight: normal;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.weather-button .weather-forecast-icon {
+  icon-size: 24px;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.weather-button .weather-forecast-time {
+  color: rgba(0, 0, 0, 0.38);
+  font-size: 0.8em;
+  font-feature-settings: "tnum";
+  font-weight: normal;
+  padding-top: 0.2em;
+  padding-bottom: 0.4em;
+}
+
+.weather-button .weather-forecast-temp {
+  font-weight: bold;
+  color: rgba(0, 0, 0, 0.52);
+  text-shadow: none;
+}
+
+/* Message List */
+.message-list {
+  width: 29em;
+  padding: 0;
+  color: rgba(0, 0, 0, 0.54);
+  text-shadow: none;
+  box-shadow: none;
+  border: 0 solid rgba(0, 0, 0, 0.12);
+}
+
+.message-list:ltr {
+  margin-left: 4px;
+  margin-right: 0;
+  padding-right: 8px;
+  border-right-width: 1px;
+}
+
+.message-list:rtl {
+  margin-right: 4px;
+  margin-left: 0;
+  padding-left: 8px;
+  border-left-width: 1px;
+}
+
+.message-list .message-list-placeholder {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.message-list .message-list-placeholder > StIcon {
+  icon-size: 96px;
+  margin-bottom: 6px;
+  -st-icon-style: symbolic;
+}
+
+.message-view {
+  -st-vfade-offset: 68px;
+}
+
+.message-view:ltr {
+  margin-right: 0;
+}
+
+.message-view:rtl {
+  margin-left: 0;
+}
+
+.message-view .message {
+  margin-bottom: 8px !important;
+}
+
+.message-list-controls {
+  padding: 8px;
+  padding-bottom: 4px;
+  spacing: 4px;
+}
+
+.message-list-controls .dnd-button {
+  border-width: 2px;
+  border-color: transparent;
+  border-radius: 32px;
+  border-style: solid;
+}
+
+.message-list-controls .dnd-button:focus {
+  border-color: rgba(26, 115, 232, 0.6);
+}
+
+.message-notification-group {
+  spacing: 8px;
+}
+
+.message-notification-group .message-group-header {
+  padding: 4px;
+}
+
+.message-notification-group .message-group-header .message-group-title {
+  margin: 0 2px;
+}
+
+.message-notification-group .message-collapse-button {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.07);
+  padding: 4px;
+}
+
+.message-notification-group .message-collapse-button:hover {
+  background-color: rgba(0, 0, 0, 0.17);
+}
+
+.message-notification-group .message-collapse-button:active {
+  background-color: rgba(0, 0, 0, 0.07);
+}
+
+.message {
+  background-color: rgba(255, 255, 255, 0.35);
+  border-radius: 3px;
+  color: rgba(0, 0, 0, 0.54);
+  text-shadow: none;
+  padding: 0;
+  margin: 2px;
+  box-shadow: 0 3px 8px -2px rgba(0, 0, 0, 0.15);
+  background-color: rgba(255, 255, 255, 0.95);
+  border: 1px solid transparent;
+  border-left: none;
+  border-bottom: none;
+}
+
+.message:hover, .message:focus, .message:active {
+  background-color: #ffffff;
+}
+
+.popup-menu .message {
+  margin: 0 0 2px;
+  box-shadow: none;
+  background-color: rgba(255, 255, 255, 0.35);
+  border-radius: 3px;
+  color: rgba(0, 0, 0, 0.54);
+  border: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.popup-menu .message:hover, .popup-menu .message:focus {
+  background-color: rgba(0, 0, 0, 0.06);
+  border-color: rgba(0, 0, 0, 0.15);
+}
+
+.popup-menu .message:active {
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.message:second-in-stack {
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.message:lower-in-stack {
+  box-shadow: none;
+}
+
+.message .message-header {
+  padding: 0 0.409em;
+  spacing: 4px;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.message .message-header:ltr {
+  padding-right: 0;
+}
+
+.message .message-header:rtl {
+  padding-left: 0;
+}
+
+.message .message-header .message-source-icon {
+  icon-size: 1.091em;
+  -st-icon-style: symbolic;
+}
+
+.message .message-header .message-header-content {
+  spacing: 4px;
+  min-height: 1.637em;
+  padding-bottom: 4px;
+}
+
+.message .message-header .message-header-content .message-source-title {
+  font-weight: bold;
+}
+
+.message .message-header .message-header-content .event-time {
+  color: rgba(0, 0, 0, 0.38);
+  padding-bottom: 0.068em;
+}
+
+.message .message-header .message-header-content .event-time:ltr {
+  text-align: right;
+}
+
+.message .message-header .message-header-content .event-time:rtl {
+  text-align: left;
+}
+
+.message .message-header .message-expand-button,
+.message .message-header .message-close-button {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0);
+  padding: 4px;
+}
+
+.message .message-header .message-expand-button:hover,
+.message .message-header .message-close-button:hover {
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.message .message-header .message-expand-button:active, .message .message-header .message-expand-button:active:hover,
+.message .message-header .message-close-button:active,
+.message .message-header .message-close-button:active:hover {
+  background-color: rgba(0, 0, 0, 0.11);
+}
+
+.message .message-header .message-expand-button:insensitive,
+.message .message-header .message-close-button:insensitive {
+  background-color: rgba(0, 0, 0, 0);
+}
+
+.message .message-header .message-expand-button {
+  padding: 6px;
+}
+
+.message .message-header .message-expand-button:ltr {
+  margin-right: 4px;
+}
+
+.message .message-header .message-expand-button:rtl {
+  margin-left: 4px;
+}
+
+.message .message-box {
+  padding: 4px;
+  margin: 4px;
+  margin-top: 0;
+  spacing: 4px;
+}
+
+.message .message-box .message-icon {
+  icon-size: 48px;
+  -st-icon-style: symbolic;
+}
+
+.message .message-box .message-icon:ltr {
+  margin-right: 4px;
+}
+
+.message .message-box .message-icon:rtl {
+  margin-left: 4px;
+}
+
+.message .message-box .message-icon.message-themed-icon {
+  border-radius: 9999px;
+  background-color: rgba(0, 0, 0, 0.07);
+  icon-size: 16px;
+  min-width: 48px;
+  min-height: 48px;
+}
+
+.message .message-box:first-child {
+  margin-top: 8px;
+}
+
+.message .message-box .message-content {
+  spacing: 2px;
+}
+
+.message .message-box .message-content .message-title {
+  font-weight: bold;
+}
+
+.url-highlighter {
+  link-color: #1A73E8;
+}
+
+/* Media Controls */
+.message-media-control {
+  margin: 4px 0;
+  padding: 0 8px;
+  border-radius: 9999px;
+  color: rgba(0, 0, 0, 0.54);
+  border: none;
+}
+
+.message-media-control:hover, .message-media-control:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.message-media-control:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.message-media-control:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.message-media-control StIcon {
+  icon-size: 16px;
+}
+
+.media-message .message-icon {
+  border-radius: 3px !important;
+}
+
+.media-message .message-icon.message-themed-icon {
+  icon-size: 32px !important;
+}
+
+.candidate-popup-content {
+  background-color: rgba(255, 255, 255, 0.97);
+  border-radius: 3px;
+  box-shadow: 0 3px 8px -2px rgba(0, 0, 0, 0.25) !important;
+  margin: 2px 8px 11px;
+  padding: 4px;
+  spacing: 4px;
+  border: 1px solid transparent;
+}
+
+.candidate-index {
+  padding: 0 0.5em 0 0;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.candidate-box {
+  padding: 0.3em 0.5em 0.3em 0.5em;
+  margin-right: 2px;
+  border-radius: 3px;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.candidate-box:hover {
+  background-color: rgba(0, 0, 0, 0.06);
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.candidate-box:active {
+  background-color: rgba(0, 0, 0, 0.2);
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.candidate-box:selected {
+  background-color: rgba(0, 0, 0, 0.06);
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.candidate-box:last-child {
+  margin-right: 0;
+}
+
+.candidate-page-button-box {
+  height: 2em;
+}
+
+.vertical .candidate-page-button-box {
+  padding-top: 0.5em;
+}
+
+.horizontal .candidate-page-button-box {
+  padding-left: 0.5em;
+}
+
+.candidate-page-button {
+  padding: 4px;
+}
+
+.candidate-page-button-previous {
+  border-radius: 3px 0px 0px 3px;
+  border-right-width: 0;
+}
+
+.candidate-page-button-next {
+  border-radius: 0px 3px 3px 0px;
+}
+
+.candidate-page-button-icon {
+  icon-size: 1em;
+}
+
+/* Notifications & Message Tray */
+.notification-banner {
+  min-height: 64px;
+  width: 34em;
+  margin: 4px;
+  border-radius: 6px;
+}
+
+.notification-buttons-bin {
+  spacing: 0;
+  padding: 0 4px 4px;
+  margin: 0;
+  border: none;
+}
+
+.notification-button {
+  min-height: 20px;
+  padding: 4px 8px;
+  font-weight: bold;
+}
+
+.hotplug-notification-item {
+  padding: 2px 10px;
+  border-top: 1px solid rgba(0, 0, 0, 0.12);
+  text-shadow: none;
+  font-size: 9.75pt;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.54);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.hotplug-notification-item:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+  box-shadow: none;
+}
+
+.hotplug-notification-item:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+.hotplug-notification-item:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.hotplug-notification-item:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: none;
+}
+
+.hotplug-notification-item:first-child {
+  border-radius: 0 0 0 3px;
+}
+
+.hotplug-notification-item:last-child {
+  border-radius: 0 0 3px 0;
+}
+
+.hotplug-notification-item:first-child:last-child {
+  border-radius: 0 0 3px 3px;
+}
+
+.hotplug-notification-item-icon {
+  icon-size: 24px;
+  padding: 0 4px;
+}
+
+/* Modal Dialogs */
+.headline {
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+.modal-dialog {
+  padding: 0;
+}
+
+.modal-dialog .modal-dialog-content-box {
+  margin: 32px 40px 42px;
+  spacing: 32px;
+  max-width: 28em;
+}
+
+.modal-dialog .modal-dialog-button-box {
+  padding: 8px;
+  background: rgba(0, 0, 0, 0.06);
+  border-radius: 0 0 6px 6px;
+  border-top: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.modal-dialog .modal-dialog-button {
+  font-weight: bold;
+  background-gradient-direction: none !important;
+  margin: 0 !important;
+}
+
+/* End Session Dialog */
+.end-session-dialog {
+  width: 30em;
+}
+
+.end-session-dialog .end-session-dialog-battery-warning,
+.end-session-dialog .dialog-list-title {
+  color: #FF6D00;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child {
+  background-color: #FF5252 !important;
+  color: white !important;
+  border-color: rgba(224, 72, 72, 0.9805) !important;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child:hover {
+  background-color: #ff8080 !important;
+  border-color: rgba(203, 65, 65, 0.9675) !important;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child:active {
+  background-color: #ff5c5c !important;
+  border-color: rgba(203, 65, 65, 0.9675) !important;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child:insensitive {
+  color: rgba(255, 255, 255, 0.5) !important;
+  background-color: rgba(255, 82, 82, 0.35) !important;
+  border-color: rgba(235, 76, 76, 0.987) !important;
+}
+
+/* Message Dialog */
+.message-dialog-content {
+  spacing: 18px;
+}
+
+.message-dialog-content .message-dialog-title {
+  text-align: center;
+  font-size: 18pt;
+  font-weight: 800;
+}
+
+.message-dialog-content .message-dialog-title.lightweight {
+  font-size: 13pt;
+  font-weight: 800;
+}
+
+.message-dialog-content .message-dialog-description {
+  text-align: center;
+}
+
+/* Dialog List */
+.dialog-list {
+  spacing: 18px;
+}
+
+.dialog-list .dialog-list-title {
+  text-align: center;
+  font-weight: bold;
+}
+
+.dialog-list .dialog-list-scrollview {
+  max-height: 200px;
+}
+
+.dialog-list .dialog-list-box {
+  spacing: 1em;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item {
+  spacing: 1em;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item .dialog-list-item-title {
+  font-weight: bold;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item .dialog-list-item-description {
+  color: rgba(0, 0, 0, 0.54);
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+/* Run Dialog */
+.run-dialog .modal-dialog-content-box {
+  margin-top: 24px;
+  margin-bottom: 14px;
+}
+
+.run-dialog .run-dialog-entry {
+  width: 20em;
+}
+
+.run-dialog .run-dialog-description {
+  font-size: 11.25pt;
+  font-weight: 400;
+  text-align: center;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+/* Password or Authentication Dialog */
+.prompt-dialog {
+  width: 28em;
+}
+
+.prompt-dialog .modal-dialog-content-box {
+  margin-bottom: 24px;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child {
+  background-color: #287ce9 !important;
+  color: white !important;
+  border-color: rgba(35, 109, 205, 0.9805) !important;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:hover {
+  background-color: #5295ee !important;
+  border-color: rgba(32, 98, 186, 0.9675) !important;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:active {
+  background-color: #3181ea !important;
+  border-color: rgba(32, 98, 186, 0.9675) !important;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:insensitive {
+  color: rgba(255, 255, 255, 0.5) !important;
+  background-color: rgba(40, 124, 233, 0.35) !important;
+  border-color: rgba(37, 114, 215, 0.987) !important;
+}
+
+.prompt-dialog-password-grid {
+  spacing-rows: 8px;
+  spacing-columns: 4px;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry {
+  width: auto;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry:ltr {
+  margin-left: 20px;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry:rtl {
+  margin-right: 20px;
+}
+
+.prompt-dialog-password-layout {
+  spacing: 8px;
+}
+
+.prompt-dialog-password-entry {
+  width: 20em;
+}
+
+.prompt-dialog-error-label,
+.prompt-dialog-info-label,
+.prompt-dialog-null-label {
+  text-align: center;
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+.prompt-dialog-error-label {
+  color: #FF6D00;
+}
+
+/* Polkit Dialog */
+.polkit-dialog-user-layout {
+  text-align: center;
+  spacing: 8px;
+  margin-bottom: 6px;
+}
+
+.polkit-dialog-user-layout .polkit-dialog-user-root-label {
+  color: #FF6D00;
+}
+
+/* Audio selection dialog */
+.audio-device-selection-dialog .modal-dialog-content-box {
+  margin-bottom: 28px;
+}
+
+.audio-device-selection-dialog .audio-selection-box {
+  spacing: 20px;
+}
+
+.audio-selection-device {
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 3px;
+}
+
+.audio-selection-device:active, .audio-selection-device:hover, .audio-selection-device:focus {
+  background-color: #1A73E8;
+}
+
+.audio-selection-device-box {
+  padding: 20px;
+  spacing: 20px;
+}
+
+.audio-selection-device-icon {
+  icon-size: 64px;
+}
+
+/* Welcome dialog */
+.welcome-dialog-image {
+  background-image: url("resource:///org/gnome/shell/theme/gnome-shell-start.svg");
+  background-size: contain;
+  /* Reasonable maximum dimensions */
+  height: 300px;
+  width: 300px;
+}
+
+/* Network Dialogs */
+.nm-dialog {
+  max-height: 34em;
+  min-height: 31em;
+  min-width: 32em;
+}
+
+.nm-dialog-content {
+  spacing: 20px;
+  padding: 24px;
+}
+
+.nm-dialog-airplane-box {
+  spacing: 12px;
+}
+
+.nm-dialog-airplane-headline {
+  font-weight: bold;
+  text-align: center;
+}
+
+.nm-dialog-airplane-text {
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.nm-dialog-header {
+  font-weight: bold;
+}
+
+.nm-dialog-header-icon {
+  icon-size: 32px;
+}
+
+.nm-dialog-header-hbox {
+  spacing: 10px;
+}
+
+.nm-dialog-scroll-view {
+  border: none;
+  background-color: rgba(0, 0, 0, 0.06);
+  border-radius: 3px;
+  padding: 8px;
+  padding-right: 0;
+}
+
+.nm-dialog-item {
+  font-size: 1em;
+  border-bottom: none;
+  border-radius: -1px;
+  padding: 8px;
+  spacing: 0px;
+}
+
+.nm-dialog-item:hover, .nm-dialog-item:focus {
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.nm-dialog-item:active {
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.nm-dialog-item:selected {
+  background-color: #1A73E8;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.nm-dialog-icon {
+  icon-size: 16px;
+}
+
+.nm-dialog-icons {
+  spacing: 8px;
+}
+
+.no-networks-label {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.no-networks-box {
+  spacing: 4px;
+}
+
+/* OSD */
+.screenshot-ui-panel, .workspace-switcher-container, .switcher-list, .resize-popup, .osd-window {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #222222;
+  border: none;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.35);
+  border-radius: 3px;
+  padding: 8px;
+}
+
+.osd-window {
+  text-align: center;
+  font-weight: bold;
+  spacing: 8px;
+  padding: 8px 12px;
+  margin-bottom: 4em;
+}
+
+.osd-window > * {
+  spacing: 8px;
+}
+
+.osd-window StIcon {
+  icon-size: 32px;
+}
+
+.osd-window StLabel:ltr {
+  margin-right: 6px;
+}
+
+.osd-window StLabel:rtl {
+  margin-left: 6px;
+}
+
+.osd-window .osd-monitor-label {
+  font-size: 3em;
+}
+
+.osd-window .level {
+  height: 4px;
+  -barlevel-height: 4px;
+  -barlevel-background-color: rgba(26, 115, 232, 0.3);
+  -barlevel-active-background-color: #1A73E8;
+  -barlevel-overdrive-color: #FF5252;
+  -barlevel-overdrive-separator-width: 3px;
+  -barlevel-border-width: 0;
+}
+
+/* Pad OSD */
+.pad-osd-window {
+  padding: 32px;
+  background-color: rgba(0, 0, 0, 0.8);
+  border: none;
+}
+
+.pad-osd-window .pad-osd-title-box {
+  spacing: 12px;
+}
+
+.pad-osd-window .pad-osd-title-menu-box {
+  spacing: 6px;
+}
+
+.combo-box-label {
+  width: 15em;
+}
+
+/* App Switcher */
+.switcher-popup {
+  padding: 8px;
+  spacing: 16px;
+}
+
+.switcher-list .item-box {
+  padding: 8px;
+  border-radius: 3px;
+  border: none;
+}
+
+.switcher-list .item-box:outlined {
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.switcher-list .item-box:selected {
+  background-color: #1A73E8;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.switcher-list .thumbnail-box {
+  padding: 2px;
+  spacing: 4px;
+}
+
+.switcher-list .thumbnail {
+  width: 256px;
+}
+
+.switcher-list .separator {
+  width: 1px;
+  background: rgba(0, 0, 0, 0.12);
+}
+
+.switcher-list .switcher-list-item-container {
+  spacing: 8px;
+}
+
+.switcher-arrow {
+  border-color: rgba(0, 0, 0, 0);
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.switcher-arrow:highlighted {
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.input-source-switcher-symbol {
+  font-size: 34pt;
+  width: 96px;
+  height: 96px;
+}
+
+.cycler-highlight {
+  border: 5px solid #1A73E8;
+}
+
+/* Workspace Switcher */
+.workspace-switcher-group {
+  padding: 8px;
+}
+
+.workspace-switcher {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  spacing: 8px;
+}
+
+.ws-switcher-box {
+  height: 50px;
+  background-size: 32px;
+  border: none;
+  background: rgba(0, 0, 0, 0.06);
+  border-radius: 3px;
+}
+
+.ws-switcher-active-up,
+.ws-switcher-active-down,
+.ws-switcher-active-left,
+.ws-switcher-active-right {
+  height: 52px;
+  background-color: #1A73E8;
+  border: none;
+  border-radius: 5px;
+  color: #FFFFFF;
+}
+
+/* Top Bar */
+#panel .panel-button#panelActivities {
+  -natural-hpadding: 10px;
+}
+
+#panel .panel-button#panelActivities StBoxLayout {
+  spacing: 4px;
+}
+
+#panel .panel-button#panelActivities .workspace-dot {
+  border-radius: 9999px;
+  min-width: 8px;
+  min-height: 8px;
+  background-color: rgba(0, 0, 0, 0.88);
+}
+
+#panel {
+  font-weight: normal;
+  font-feature-settings: "tnum";
+  transition-duration: 250ms;
+  border: none;
+  box-shadow: none;
+  background-color: rgba(255, 255, 255, 0.5);
+  margin: 0;
+  border-radius: 0;
+  height: 30px;
+}
+
+#panel #panelLeft, #panel #panelCenter {
+  spacing: 0;
+}
+
+#panel .panel-corner {
+  -panel-corner-radius: 0;
+  -panel-corner-background-color: rgba(255, 255, 255, 0.5);
+  -panel-corner-border-width: 0;
+  -panel-corner-border-color: transparent;
+  -panel-corner-opacity: 0;
+  transition-duration: 250ms;
+}
+
+#panel .panel-button {
+  -natural-hpadding: 4px;
+  -minimum-hpadding: 4px;
+  font-weight: normal;
+  color: rgba(0, 0, 0, 0.75);
+  transition-duration: 150ms;
+  text-shadow: none;
+  border-radius: 0;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#panel .panel-button StLabel {
+  padding: 0;
+}
+
+#panel .panel-button:hover {
+  color: rgba(0, 0, 0, 0.75);
+  background-color: rgba(255, 255, 255, 0.35);
+}
+
+#panel .panel-button:active, #panel .panel-button:checked, #panel .panel-button:focus {
+  color: rgba(0, 0, 0, 0.88);
+  background-color: rgba(255, 255, 255, 0.5);
+}
+
+#panel .panel-button:hover, #panel .panel-button:active, #panel .panel-button:overview, #panel .panel-button:focus, #panel .panel-button:checked {
+  text-shadow: none;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#panel .panel-button.clock-display {
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#panel .panel-button.clock-display:hover {
+  color: rgba(0, 0, 0, 0.75);
+  background-color: rgba(255, 255, 255, 0.35) !important;
+}
+
+#panel .panel-button.clock-display:active, #panel .panel-button.clock-display:checked, #panel .panel-button.clock-display:focus {
+  color: rgba(0, 0, 0, 0.88);
+  background-color: rgba(255, 255, 255, 0.5) !important;
+}
+
+#panel .panel-button.clock-display:active .clock, #panel .panel-button.clock-display:checked .clock, #panel .panel-button.clock-display:focus .clock {
+  box-shadow: none;
+  background: none;
+  color: rgba(0, 0, 0, 0.88);
+}
+
+#panel .panel-button.clock-display:hover, #panel .panel-button.clock-display:active, #panel .panel-button.clock-display:checked, #panel .panel-button.clock-display:focus {
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#panel .panel-button.clock-display .clock {
+  color: rgba(0, 0, 0, 0.75);
+  transition-duration: 150ms;
+  border: none;
+  border-radius: 0;
+}
+
+#panel .panel-button.clock-display .messages-indicator {
+  icon-size: 1.091em;
+}
+
+#panel .panel-button .system-status-icon {
+  icon-size: 16px;
+  padding: 4px;
+  margin: 0 2px;
+}
+
+#panel .panel-button .panel-status-menu-box .system-status-icon {
+  margin: 0;
+}
+
+#panel .panel-button .panel-status-menu-box StLabel {
+  padding: 0 0 0 2px;
+}
+
+#panel .panel-button .panel-status-menu-box,
+#panel .panel-button .panel-status-indicators-box {
+  spacing: 2px;
+}
+
+#panel .panel-button .appindicator-trayicons-box,
+#panel .panel-button .panel-status-indicators-box.appindicator-box {
+  margin: 0 4px;
+}
+
+#panel .panel-button .clipboard-indicator-icon {
+  margin: 0 4px;
+}
+
+#panel .panel-button .app-menu-icon {
+  -st-icon-style: symbolic;
+}
+
+#panel.unlock-screen, #panel.login-screen, #panel.lock-screen, #panel:overview {
+  background-color: transparent;
+}
+
+#panel.unlock-screen .panel-button, #panel.login-screen .panel-button, #panel.lock-screen .panel-button, #panel:overview .panel-button {
+  border-radius: 3px;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+}
+
+#panel.unlock-screen .panel-button:hover, #panel.login-screen .panel-button:hover, #panel.lock-screen .panel-button:hover, #panel:overview .panel-button:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#panel.unlock-screen .panel-button:active, #panel.unlock-screen .panel-button:checked, #panel.unlock-screen .panel-button:focus, #panel.login-screen .panel-button:active, #panel.login-screen .panel-button:checked, #panel.login-screen .panel-button:focus, #panel.lock-screen .panel-button:active, #panel.lock-screen .panel-button:checked, #panel.lock-screen .panel-button:focus, #panel:overview .panel-button:active, #panel:overview .panel-button:checked, #panel:overview .panel-button:focus {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+#panel.unlock-screen .panel-button.clock-display:hover, #panel.login-screen .panel-button.clock-display:hover, #panel.lock-screen .panel-button.clock-display:hover, #panel:overview .panel-button.clock-display:hover {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#panel.unlock-screen .panel-button.clock-display:active, #panel.unlock-screen .panel-button.clock-display:checked, #panel.unlock-screen .panel-button.clock-display:focus, #panel.login-screen .panel-button.clock-display:active, #panel.login-screen .panel-button.clock-display:checked, #panel.login-screen .panel-button.clock-display:focus, #panel.lock-screen .panel-button.clock-display:active, #panel.lock-screen .panel-button.clock-display:checked, #panel.lock-screen .panel-button.clock-display:focus, #panel:overview .panel-button.clock-display:active, #panel:overview .panel-button.clock-display:checked, #panel:overview .panel-button.clock-display:focus {
+  background-color: rgba(255, 255, 255, 0.3) !important;
+}
+
+#panel.unlock-screen .panel-button.clock-display .clock, #panel.login-screen .panel-button.clock-display .clock, #panel.lock-screen .panel-button.clock-display .clock, #panel:overview .panel-button.clock-display .clock {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+#panel.unlock-screen .panel-button#panelActivities, #panel.login-screen .panel-button#panelActivities, #panel.lock-screen .panel-button#panelActivities, #panel:overview .panel-button#panelActivities {
+  box-shadow: none;
+  border: none;
+  background-color: transparent;
+}
+
+#panel.unlock-screen .panel-button#panelActivities:hover, #panel.login-screen .panel-button#panelActivities:hover, #panel.lock-screen .panel-button#panelActivities:hover, #panel:overview .panel-button#panelActivities:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#panel.unlock-screen .panel-button#panelActivities .workspace-dot, #panel.login-screen .panel-button#panelActivities .workspace-dot, #panel.lock-screen .panel-button#panelActivities .workspace-dot, #panel:overview .panel-button#panelActivities .workspace-dot {
+  background-color: rgba(255, 255, 255, 0.85);
+}
+
+#panel.unlock-screen .panel-corner, #panel.login-screen .panel-corner, #panel.lock-screen .panel-corner, #panel:overview .panel-corner {
+  -panel-corner-opacity: 0;
+  -panel-corner-radius: 0;
+  -panel-corner-background-color: transparent;
+  -panel-corner-border-color: transparent;
+}
+
+#panel Gjs_ui_panel_AggregateMenu.panel-button .system-status-icon {
+  margin: 0 !important;
+  padding: 4px !important;
+}
+
+#panel Gjs_kimpanel_kde_org_indicator_KimIndicator.panel-button .panel-status-menu-box {
+  margin: 0 4px;
+}
+
+#panel .screencast-indicator,
+#panel .remote-access-indicator {
+  color: #FF6D00;
+}
+
+#appMenu {
+  spacing: 4px;
+}
+
+#appMenu .label-shadow {
+  color: transparent;
+}
+
+#appMenu .panel-status-menu-box {
+  padding: 0 4px;
+  spacing: 4px;
+}
+
+/* Activities Ripple */
+.ripple-box {
+  background-color: rgba(26, 115, 232, 0.35);
+  width: 52px;
+  height: 52px;
+  border-radius: 0 0 52px 0;
+}
+
+.ripple-box:rtl {
+  border-radius: 0 0 0 52px;
+}
+
+/* OVERVIEW */
+.controls-manager, .secondary-monitor-workspaces {
+  spacing: 8px;
+}
+
+#overviewGroup {
+  background-color: #222222;
+}
+
+.overview-controls {
+  padding-bottom: 32px;
+}
+
+/* Window Picker */
+.window-picker {
+  spacing: 4px;
+}
+
+.window-caption {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(32, 32, 32, 0.9);
+  border-radius: 6px;
+  padding: 4px 8px;
+}
+
+.window-close, .screenshot-ui-close-button {
+  background-color: #1A73E8;
+  color: white;
+  border-radius: 9999px;
+  padding: 3px;
+  height: 30px;
+  width: 30px;
+  box-shadow: -1px 1px 5px 0px rgba(0, 0, 0, 0.5);
+  transition-duration: 300ms;
+}
+
+.window-close StIcon, .screenshot-ui-close-button StIcon {
+  icon-size: 24px;
+}
+
+.window-close:hover, .screenshot-ui-close-button:hover {
+  background-color: #609eef;
+}
+
+.window-close:active, .screenshot-ui-close-button:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #1567d3;
+}
+
+.workspace-background {
+  border-radius: 30px;
+  background-color: #222222;
+  box-shadow: 0 4px 16px 4px rgba(0, 0, 0, 0.3);
+  border: none;
+}
+
+.search-entry {
+  min-height: 24px;
+  padding: 2px 4px;
+  width: 320px;
+  border: none !important;
+  border-radius: 3px;
+  selection-background-color: #1A73E8;
+  selected-color: #FFFFFF !important;
+  caret-color: rgba(0, 0, 0, 0.54);
+  color: rgba(0, 0, 0, 0.54);
+  background-color: #ffffff;
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+.search-entry:hover {
+  border: 2px solid rgba(0, 0, 0, 0.2) !important;
+}
+
+.search-entry:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #1A73E8 !important;
+}
+
+.search-entry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.search-entry .search-entry-icon {
+  icon-size: 16px;
+  padding: 0 4px;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.search-entry StLabel.hint-text {
+  margin-left: 2px;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+#overview .search-entry {
+  min-height: 24px;
+  padding: 4px 6px;
+  margin-top: 8px;
+  margin-bottom: 4px;
+  border-radius: 5px;
+  caret-color: rgba(0, 0, 0, 0.75);
+  color: rgba(0, 0, 0, 0.75);
+  background-color: rgba(255, 255, 255, 0.75) !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#overview .search-entry:hover {
+  color: rgba(0, 0, 0, 0.75);
+  background-color: rgba(255, 255, 255, 0.85) !important;
+}
+
+#overview .search-entry:focus {
+  color: rgba(0, 0, 0, 0.85);
+  background-color: rgba(255, 255, 255, 0.95) !important;
+  border: none !important;
+  selection-background-color: #1A73E8;
+  selected-color: #FFFFFF !important;
+}
+
+#overview .search-entry .search-entry-icon {
+  color: rgba(0, 0, 0, 0.65);
+}
+
+#overview .search-entry:hover .search-entry-icon, #overview .search-entry:focus .search-entry-icon {
+  color: rgba(0, 0, 0, 0.75);
+}
+
+#overview .search-entry StLabel.hint-text {
+  color: rgba(0, 0, 0, 0.35);
+}
+
+/* Search */
+#searchResults {
+  margin: 0 4px;
+}
+
+#searchResultsContent {
+  max-width: 1044px;
+}
+
+.search-section {
+  spacing: 8px;
+}
+
+.search-section .search-section-separator {
+  height: 4px;
+  background-color: transparent;
+}
+
+.search-section-content {
+  background-color: rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.1);
+  text-shadow: none;
+  color: rgba(255, 255, 255, 0.85);
+  padding: 12px;
+  spacing: 4px;
+}
+
+.list-search-result, .search-provider-icon {
+  border-radius: 6px;
+}
+
+.search-statustext {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.grid-search-results {
+  spacing: 24px;
+  margin: 0 6px;
+}
+
+.search-provider-icon:ltr {
+  margin-right: 2px;
+}
+
+.search-provider-icon:rtl {
+  margin-left: 2px;
+}
+
+.search-provider-icon .list-search-provider-content {
+  spacing: 8px;
+}
+
+.search-provider-icon .list-search-provider-content .list-search-provider-details {
+  width: 120px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.list-search-results {
+  spacing: 4px;
+}
+
+.list-search-result .list-search-result-content {
+  spacing: 4px;
+}
+
+.list-search-result .list-search-result-title {
+  spacing: 8px;
+}
+
+.list-search-result .list-search-result-description {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+/* Dash */
+#dash {
+  padding-left: 4px;
+  padding-right: 4px;
+}
+
+#dash .dash-background {
+  background-color: rgba(255, 255, 255, 0.2);
+  border-radius: 11px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 7px;
+  padding-right: 7px;
+}
+
+#dash .dash-item-container .placeholder {
+  background-image: none;
+  background-size: contain;
+  height: 32px;
+}
+
+#dash .dash-item-container .empty-dash-drop-target {
+  width: 32px;
+  height: 32px;
+}
+
+#dash .dash-item-container .show-apps,
+#dash .dash-item-container .overview-tile,
+#dash .dash-item-container .grid-search-result,
+#dash .dash-item-container .search-provider-icon,
+#dash .dash-item-container .list-search-result {
+  margin: 0 1px;
+  padding-bottom: 6px;
+}
+
+#dash .dash-item-container .show-apps .overview-icon,
+#dash .dash-item-container .overview-tile .overview-icon,
+#dash .dash-item-container .grid-search-result .overview-icon,
+#dash .dash-item-container .search-provider-icon .overview-icon,
+#dash .dash-item-container .list-search-result .overview-icon {
+  background-color: transparent;
+}
+
+#dash .dash-item-container .show-apps:focus .overview-icon,
+#dash .dash-item-container .overview-tile:focus .overview-icon,
+#dash .dash-item-container .grid-search-result:focus .overview-icon,
+#dash .dash-item-container .search-provider-icon:focus .overview-icon,
+#dash .dash-item-container .list-search-result:focus .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#dash .dash-item-container .show-apps:hover .overview-icon,
+#dash .dash-item-container .overview-tile:hover .overview-icon,
+#dash .dash-item-container .grid-search-result:hover .overview-icon,
+#dash .dash-item-container .search-provider-icon:hover .overview-icon,
+#dash .dash-item-container .list-search-result:hover .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#dash .dash-item-container .show-apps:active .overview-icon,
+#dash .dash-item-container .overview-tile:active .overview-icon,
+#dash .dash-item-container .grid-search-result:active .overview-icon,
+#dash .dash-item-container .search-provider-icon:active .overview-icon,
+#dash .dash-item-container .list-search-result:active .overview-icon {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+#dash .dash-item-container .show-apps:checked .overview-icon,
+#dash .dash-item-container .overview-tile:checked .overview-icon,
+#dash .dash-item-container .grid-search-result:checked .overview-icon,
+#dash .dash-item-container .search-provider-icon:checked .overview-icon,
+#dash .dash-item-container .list-search-result:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+#dash .dash-item-container .show-apps:insensitive .overview-icon,
+#dash .dash-item-container .overview-tile:insensitive .overview-icon,
+#dash .dash-item-container .grid-search-result:insensitive .overview-icon,
+#dash .dash-item-container .search-provider-icon:insensitive .overview-icon,
+#dash .dash-item-container .list-search-result:insensitive .overview-icon {
+  background-color: transparent;
+}
+
+#dash .dash-item-container .app-grid-running-dot {
+  offset-y: -8px;
+}
+
+#dash .dash-separator {
+  width: 1px;
+  margin-left: 2px;
+  margin-right: 2px;
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#dash .dash-separator,
+#dash .dash-background {
+  margin-bottom: 6px;
+}
+
+.dash-label {
+  border-radius: 3px;
+  padding: 4px 8px;
+  margin: 4px;
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(0, 0, 0, 0.75);
+  border: none;
+  box-shadow: none;
+  text-align: center;
+  -y-offset: 2px;
+}
+
+/* App Grid */
+.icon-grid {
+  row-spacing: 12px;
+  column-spacing: 12px;
+  max-row-spacing: 36px;
+  max-column-spacing: 36px;
+  page-padding-top: 24px;
+  page-padding-bottom: 24px;
+  page-padding-left: 18px;
+  page-padding-right: 18px;
+}
+
+/* App Icons */
+.overview-tile, .grid-search-result, .search-provider-icon, .list-search-result {
+  border-radius: 9px;
+  padding: 12px;
+  spacing: 6px;
+  transition-duration: 150ms;
+  text-align: center;
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.85);
+  border: 1px solid transparent;
+  box-shadow: inset 0 1px transparent;
+}
+
+.overview-tile:hover, .grid-search-result:hover, .search-provider-icon:hover, .list-search-result:hover, .overview-tile:focus, .grid-search-result:focus, .search-provider-icon:focus, .list-search-result:focus, .overview-tile:highlighted, .grid-search-result:highlighted, .search-provider-icon:highlighted, .list-search-result:highlighted, .overview-tile:selected, .grid-search-result:selected, .search-provider-icon:selected, .list-search-result:selected {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+  transition-duration: 0ms;
+  border-image: none;
+  background-image: none;
+}
+
+.overview-tile:active, .grid-search-result:active, .search-provider-icon:active, .list-search-result:active, .overview-tile:checked, .grid-search-result:checked, .search-provider-icon:checked, .list-search-result:checked {
+  background-color: rgba(255, 255, 255, 0.15);
+  transition-duration: 150ms;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.overview-tile .overview-icon.overview-icon-with-label > StBoxLayout, .grid-search-result .overview-icon.overview-icon-with-label > StBoxLayout, .search-provider-icon .overview-icon.overview-icon-with-label > StBoxLayout, .list-search-result .overview-icon.overview-icon-with-label > StBoxLayout {
+  spacing: 4px;
+}
+
+.app-folder {
+  background-color: rgba(255, 255, 255, 0.13);
+}
+
+.app-folder:focus {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.app-folder:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.app-folder:active {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.app-folder:highlighted, .app-folder:selected, .app-folder:checked {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.app-folder:insensitive {
+  background-color: transparent;
+}
+
+.app-grid-running-dot {
+  width: 6px;
+  height: 3px;
+  border-radius: 2px;
+  background-color: rgba(255, 255, 255, 0.5);
+  margin-bottom: 1px;
+}
+
+StWidget.focused .app-grid-running-dot {
+  width: 18px;
+  background-color: #1A73E8;
+}
+
+.app-folder-dialog-container {
+  padding-top: 30px;
+}
+
+.app-folder-dialog {
+  width: 720px;
+  height: 720px;
+  border-radius: 12px;
+  background-color: rgba(34, 34, 34, 0.95);
+  color: white;
+  border: none;
+  box-shadow: none;
+}
+
+.app-folder-dialog .folder-name-container {
+  padding: 24px 36px 0;
+  spacing: 12px;
+  /* FIXME: this is to keep the label in sync with the entry */
+}
+
+.app-folder-dialog .folder-name-container .folder-name-label, .app-folder-dialog .folder-name-container .folder-name-entry {
+  font-size: 18pt;
+  font-weight: 800;
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry {
+  border: none;
+  color: #FFFFFF;
+  background-color: rgba(255, 255, 255, 0.15);
+  caret-color: #FFFFFF;
+  selection-background-color: #1A73E8;
+  selected-color: #FFFFFF;
+  width: 300px;
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:focus {
+  color: #FFFFFF;
+  background-color: rgba(255, 255, 255, 0.25);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry .search-entry-icon {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:hover .search-entry-icon, .app-folder-dialog .folder-name-container .folder-name-entry:focus .search-entry-icon {
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:insensitive, .app-folder-dialog .folder-name-container .folder-name-entry StLabel.hint-text {
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-label {
+  padding: 5px 7px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.app-folder-dialog .folder-name-container .icon-button, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button {
+  background-color: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.7);
+  border: none;
+  padding: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 18px;
+}
+
+.app-folder-dialog .folder-name-container .icon-button > StIcon, .app-folder-dialog .folder-name-container .background-app-item .icon-button > StIcon, .app-folder-dialog .folder-name-container .message-notification-group .background-app-item .message-collapse-button > StIcon, .app-folder-dialog .folder-name-container .message .message-header .background-app-item .message-expand-button > StIcon,
+.app-folder-dialog .folder-name-container .message .message-header .background-app-item .message-close-button > StIcon, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button > StIcon, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button > StIcon, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button > StIcon, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button > StIcon,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button > StIcon,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button > StIcon {
+  icon-size: 16px;
+}
+
+.app-folder-dialog .folder-name-container .icon-button:hover, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button:hover, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button:hover, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:hover, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:hover,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:hover,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.app-folder-dialog .folder-name-container .icon-button:focus, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button:focus, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button:focus, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:focus, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:focus,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:focus,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:focus {
+  border: none !important;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.app-folder-dialog .folder-name-container .icon-button:checked, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button:checked, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button:checked, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:checked, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:checked,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:checked,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:checked, .app-folder-dialog .folder-name-container .icon-button:active, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button:active, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button:active, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:active, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:active,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:active,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:active {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.app-folder-dialog .icon-grid {
+  row-spacing: 12px;
+  column-spacing: 30px;
+  page-padding-top: 0;
+  page-padding-bottom: 0;
+  page-padding-left: 0;
+  page-padding-right: 0;
+}
+
+.app-folder-dialog .page-indicators {
+  margin-bottom: 18px;
+}
+
+.rename-folder-popup .rename-folder-popup-item {
+  spacing: 4px;
+}
+
+.rename-folder-popup .rename-folder-popup-item:ltr, .rename-folder-popup .rename-folder-popup-item:rtl {
+  padding: 0 8px;
+}
+
+.app-menu,
+.app-well-menu {
+  max-width: 27.25em;
+}
+
+.page-indicator {
+  padding: 4px 8px 0;
+}
+
+.page-indicator .page-indicator-icon {
+  width: 10px;
+  height: 10px;
+  border-radius: 10px;
+  background-color: white;
+  transition-duration: 400ms;
+}
+
+.apps-scroll-view {
+  padding: 0;
+}
+
+.system-action-icon {
+  background-color: rgba(0, 0, 0, 0.8);
+  color: white;
+  border-radius: 9999px;
+  icon-size: 8px;
+}
+
+.page-navigation-hint.dnd {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.page-navigation-hint.next:ltr, .page-navigation-hint.previous:rtl {
+  background-gradient-start: rgba(255, 255, 255, 0.05);
+  background-gradient-end: transparent;
+  background-gradient-direction: horizontal;
+  border-radius: 15px 0px 0px 15px;
+}
+
+.page-navigation-hint.previous:ltr, .page-navigation-hint.next:rtl {
+  background-gradient-start: transparent;
+  background-gradient-end: rgba(255, 255, 255, 0.05);
+  background-gradient-direction: horizontal;
+  border-radius: 0px 15px 15px 0px;
+}
+
+.page-navigation-arrow {
+  margin: 6px;
+  padding: 18px;
+  width: 24px;
+  height: 24px;
+  border-radius: 9999px;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+}
+
+.page-navigation-arrow > StIcon {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.page-navigation-arrow:insensitive {
+  background-color: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.page-navigation-arrow:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+  color: white;
+}
+
+.page-navigation-arrow:active {
+  background-color: rgba(255, 255, 255, 0.2);
+  color: white;
+}
+
+/* Workspace pager */
+.workspace-thumbnails .workspace-thumbnail {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.13);
+  border: none;
+}
+
+.workspace-thumbnails {
+  visible-width: 32px;
+  spacing: 4px;
+  padding: 4px;
+}
+
+.workspace-thumbnails .workspace-thumbnail {
+  border-radius: 3px;
+}
+
+.workspace-thumbnails .placeholder {
+  background-image: url("resource:///org/gnome/shell/theme/dash-placeholder.svg");
+  background-size: contain;
+  width: 18px;
+}
+
+.workspace-thumbnail-indicator {
+  border: 3px solid #1A73E8;
+  border-radius: 6px;
+  padding: 0px;
+}
+
+.ripple-pointer-location {
+  width: 48px;
+  height: 48px;
+  border-radius: 24px;
+  background-color: rgba(165, 200, 246, 0.3);
+  box-shadow: 0 0 2px 2px #77acf1;
+}
+
+.pie-timer {
+  width: 60px;
+  height: 60px;
+  -pie-border-width: 3px;
+  -pie-border-color: #1A73E8;
+  -pie-background-color: rgba(211, 228, 251, 0.3);
+}
+
+.magnifier-zoom-region {
+  border: 2px solid #1A73E8;
+}
+
+.magnifier-zoom-region.full-screen {
+  border-width: 0;
+}
+
+.select-area-rubberband {
+  background-color: rgba(26, 115, 232, 0.3);
+  border: 1px solid #1A73E8;
+}
+
+.user-icon {
+  background-size: contain;
+  color: rgba(255, 255, 255, 0.7);
+  border-radius: 9999px;
+  icon-size: 64px;
+}
+
+.user-icon:hover {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.user-icon StIcon {
+  background-color: rgba(255, 255, 255, 0.05);
+  border-radius: 99px;
+  padding: 8px;
+  width: 40px;
+  height: 40px;
+}
+
+.user-icon.user-avatar {
+  border: 2px rgba(255, 255, 255, 0.7);
+}
+
+.user-widget.vertical .user-icon {
+  icon-size: 128px;
+}
+
+.user-widget.vertical .user-icon StIcon {
+  padding: 14px;
+  padding-top: 12px;
+  padding-bottom: 16px;
+  width: 88px;
+  height: 88px;
+}
+
+.lightbox {
+  background-color: black;
+}
+
+.flashspot {
+  background-color: white;
+}
+
+.hidden {
+  color: rgba(0, 0, 0, 0);
+}
+
+.caps-lock-warning-label {
+  text-align: center;
+  padding-bottom: 8px;
+  font-size: 9.75pt;
+  font-weight: 400;
+  color: #FF6D00;
+}
+
+/* Workspace animation */
+.workspace-animation {
+  background-color: #222222;
+}
+
+/* Tiled window previews */
+.tile-preview {
+  background-color: rgba(22, 108, 221, 0.3);
+  border: 1px solid #166cdd;
+}
+
+.tile-preview-left.on-primary {
+  border-radius: 4px 0 0 0;
+}
+
+.tile-preview-right.on-primary {
+  border-radius: 0 4px 0 0;
+}
+
+.tile-preview-left.tile-preview-right.on-primary {
+  border-radius: 4px 4px 0 0;
+}
+
+/* On-screen Keyboard */
+#keyboard {
+  background-color: rgba(238, 238, 238, 0.95);
+  border: none;
+  border-top-width: 0;
+  box-shadow: none;
+}
+
+#keyboard .page-indicator {
+  padding: 4px;
+}
+
+#keyboard .page-indicator .page-indicator-icon {
+  width: 8px;
+  height: 8px;
+}
+
+.key-container {
+  padding: 2px;
+  spacing: 2px;
+}
+
+.keyboard-key {
+  min-height: 2em;
+  min-width: 2em;
+  font-size: 14pt;
+  font-weight: bold;
+  border-radius: 3px;
+  border: none;
+  color: inherit;
+  background-color: #FAFAFA;
+  box-shadow: inset 0 -1px rgba(0, 0, 0, 0.25);
+}
+
+.keyboard-key:focus, .keyboard-key:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #e1e1e1;
+}
+
+.keyboard-key:checked, .keyboard-key:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #c7c7c7;
+}
+
+.keyboard-key:grayed {
+  background-color: rgba(32, 32, 32, 0.75);
+  color: rgba(255, 255, 255, 0.85);
+  border-color: rgba(32, 32, 32, 0.75);
+}
+
+.keyboard-key.default-key {
+  background-color: #c7c7c7;
+}
+
+.keyboard-key.default-key:focus, .keyboard-key.default-key:hover {
+  color: rgba(0, 0, 0, 0.62);
+  background-color: #b7b7b7;
+}
+
+.keyboard-key.default-key:checked, .keyboard-key.default-key:active {
+  color: rgba(0, 0, 0, 0.62);
+  background-color: #adadad;
+}
+
+.keyboard-key.enter-key {
+  background-color: #1A73E8;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.keyboard-key.enter-key:focus, .keyboard-key.enter-key:hover {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #3181ea;
+}
+
+.keyboard-key.enter-key:checked, .keyboard-key.enter-key:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #135cbc;
+}
+
+.keyboard-key.shift-key-uppercase {
+  color: #1A73E8;
+}
+
+.keyboard-key StIcon {
+  icon-size: 1.125em;
+}
+
+.keyboard-subkeys {
+  color: inherit;
+  -arrow-border-radius: 3px;
+  -arrow-background-color: rgba(0, 0, 0, 0.45);
+  -arrow-border-width: 0;
+  -arrow-border-color: transparent;
+  -arrow-base: 20px;
+  -arrow-rise: 10px;
+  -boxpointer-gap: 5px;
+}
+
+.emoji-page .keyboard-key {
+  background-color: transparent;
+  border: none;
+  color: initial;
+}
+
+.emoji-panel .keyboard-key:latched {
+  border-color: #3181ea;
+  background-color: #1A73E8;
+}
+
+.word-suggestions {
+  font-size: 14pt;
+  spacing: 12px;
+  min-height: 20pt;
+}
+
+/* Looking Glass */
+#LookingGlassDialog {
+  color: rgba(0, 0, 0, 0.54);
+  background-color: #ffffff;
+  spacing: 4px;
+  padding: 6px;
+  border: none;
+  border-radius: 3px;
+  box-shadow: 0 14px 14px rgba(0, 0, 0, 0.5);
+}
+
+#LookingGlassDialog > #Toolbar {
+  padding: 0 8px;
+  border: none;
+  border-radius: 0;
+  background-color: rgba(255, 255, 255, 0.01);
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.12);
+  color: rgba(0, 0, 0, 0.54);
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button {
+  color: rgba(0, 0, 0, 0.54);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+  box-shadow: none;
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: none;
+}
+
+#LookingGlassDialog .labels {
+  spacing: 0;
+}
+
+#LookingGlassDialog .notebook-tab {
+  -natural-hpadding: 12px;
+  -minimum-hpadding: 6px;
+  font-weight: bold;
+  color: rgba(0, 0, 0, 0.38);
+  transition-duration: 150ms;
+  padding-left: 16px;
+  padding-right: 16px;
+  min-height: 32px;
+  padding: 0 32px;
+  border-radius: 0;
+}
+
+#LookingGlassDialog .notebook-tab:hover {
+  box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.2);
+  color: rgba(0, 0, 0, 0.87);
+  text-shadow: none;
+}
+
+#LookingGlassDialog .notebook-tab:selected {
+  background-color: rgba(255, 255, 255, 0.01);
+  box-shadow: inset 0 -2px 0 #1A73E8;
+  color: rgba(0, 0, 0, 0.87);
+  text-shadow: none;
+}
+
+#LookingGlassDialog StBoxLayout#EvalBox {
+  padding: 4px;
+  spacing: 4px;
+}
+
+#LookingGlassDialog StBoxLayout#ResultsArea {
+  spacing: 4px;
+}
+
+.lg-dialog StEntry {
+  selection-background-color: #1A73E8;
+  selected-color: rgba(255, 255, 255, 0.85) !important;
+}
+
+.lg-dialog .shell-link {
+  color: #1A73E8;
+}
+
+.lg-dialog .shell-link:hover {
+  color: #1A73E8;
+}
+
+.lg-completions-text {
+  font-size: 1em;
+  font-style: italic;
+}
+
+.lg-obj-inspector-title {
+  spacing: 4px;
+}
+
+.lg-obj-inspector-button {
+  min-height: 32px;
+  padding: 0 16px;
+  border: none;
+  border-radius: 3px;
+  font-size: 9.75pt;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.54);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.lg-obj-inspector-button:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+  box-shadow: none;
+}
+
+.lg-obj-inspector-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+.lg-obj-inspector-button:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.lg-obj-inspector-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: none;
+}
+
+.lg-obj-inspector-button:hover {
+  border: none;
+}
+
+#lookingGlassExtensions {
+  padding: 4px;
+}
+
+.lg-extensions-list {
+  padding: 4px;
+  spacing: 6px;
+}
+
+.lg-extension {
+  border: none;
+  border-radius: 3px;
+  background-color: #bfbfbf;
+  padding: 4px;
+}
+
+.lg-extension-name {
+  font-size: 18pt;
+  font-weight: 400;
+}
+
+.lg-extension-meta {
+  spacing: 6px;
+}
+
+#LookingGlassPropertyInspector {
+  background: #ffffff;
+  border: none;
+  border-radius: 3px;
+  padding: 6px;
+  box-shadow: 0 14px 14px rgba(0, 0, 0, 0.5);
+}
+
+.quick-settings {
+  border-radius: 3px !important;
+  margin: 4px !important;
+  padding: 8px 10px 12px !important;
+}
+
+.quick-settings .icon-button, .quick-settings .message-notification-group .message-collapse-button, .message-notification-group .quick-settings .message-collapse-button, .quick-settings .message .message-header .message-expand-button, .message .message-header .quick-settings .message-expand-button,
+.quick-settings .message .message-header .message-close-button,
+.message .message-header .quick-settings .message-close-button, .quick-settings .button {
+  padding: 6px;
+}
+
+.quick-settings .icon-button > StIcon, .quick-settings .background-app-item .icon-button > StIcon, .quick-settings .message-notification-group .background-app-item .message-collapse-button > StIcon, .quick-settings .message .message-header .background-app-item .message-expand-button > StIcon,
+.quick-settings .message .message-header .background-app-item .message-close-button > StIcon, .quick-settings .message-notification-group .message-collapse-button > StIcon, .message-notification-group .quick-settings .message-collapse-button > StIcon, .quick-settings .message .message-header .message-expand-button > StIcon, .message .message-header .quick-settings .message-expand-button > StIcon,
+.quick-settings .message .message-header .message-close-button > StIcon,
+.message .message-header .quick-settings .message-close-button > StIcon, .quick-settings .button > StIcon {
+  icon-size: 16px;
+}
+
+.quick-settings-grid {
+  spacing-rows: 8px;
+  spacing-columns: 8px;
+}
+
+.quick-toggle, .quick-menu-toggle {
+  border-radius: 3px;
+  min-width: 12em;
+  max-width: 12em;
+  min-height: 38px;
+  padding: 0;
+  border: none;
+}
+
+.quick-toggle {
+  background-color: rgba(0, 0, 0, 0.06) !important;
+  /* Move padding into the box; this is to allow menu arrows
+       to extend to the border */
+}
+
+.quick-toggle:hover {
+  background-color: rgba(0, 0, 0, 0.12) !important;
+}
+
+.quick-toggle:active {
+  background-color: rgba(0, 0, 0, 0.15) !important;
+}
+
+.quick-toggle:checked {
+  background-color: #1A73E8 !important;
+  color: white;
+}
+
+.quick-toggle:checked:hover {
+  background-color: rgba(25, 110, 221, 0.9922) !important;
+  color: white;
+}
+
+.quick-toggle:checked:active {
+  background-color: rgba(23, 101, 204, 0.9805) !important;
+  color: white;
+}
+
+.quick-toggle > StBoxLayout {
+  spacing: 6px;
+}
+
+.quick-toggle.button {
+  padding: 0;
+}
+
+.quick-toggle > StBoxLayout {
+  padding: 0 8px;
+}
+
+.quick-toggle:ltr > StBoxLayout {
+  padding-left: 16px;
+}
+
+.quick-toggle:rtl > StBoxLayout {
+  padding-right: 16px;
+}
+
+.quick-toggle .quick-toggle-title {
+  font-weight: bold;
+}
+
+.quick-toggle StBoxLayout > .quick-toggle-subtitle {
+  font-weight: normal;
+  font-size: 12px;
+}
+
+.quick-toggle .quick-toggle-icon {
+  icon-size: 16px;
+}
+
+.quick-toggle-has-menu .quick-toggle {
+  min-width: auto;
+  max-width: auto;
+}
+
+.quick-toggle-has-menu .quick-toggle:ltr {
+  border-radius: 3px 0 0 3px;
+}
+
+.quick-toggle-has-menu .quick-toggle:ltr > StBoxLayout {
+  padding-right: 8px;
+}
+
+.quick-toggle-has-menu .quick-toggle:rtl {
+  border-radius: 0 3px 3px 0;
+}
+
+.quick-toggle-has-menu .quick-toggle:rtr > StBoxLayout {
+  padding-left: 8px;
+}
+
+.quick-toggle-has-menu .quick-toggle:ltr:last-child {
+  border-radius: 3px;
+}
+
+.quick-toggle-has-menu .quick-toggle:rtl:last-child {
+  border-radius: 3px;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button {
+  padding: 4px 8px;
+  border: none;
+  background-color: rgba(0, 0, 0, 0.06) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:hover {
+  background-color: rgba(0, 0, 0, 0.12) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:active {
+  background-color: rgba(0, 0, 0, 0.15) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:checked {
+  background-color: #1A73E8 !important;
+  color: white;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:checked:hover {
+  color: white;
+  background-color: st-mix(rgba(0, 0, 0, 0.87), #1A73E8, 6%) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:checked:active {
+  color: white;
+  background-color: st-mix(rgba(0, 0, 0, 0.87), #1A73E8, 15%) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:ltr {
+  border-radius: 0 3px 3px 0;
+  border-left-width: 0;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:rtl {
+  border-radius: 3px 0 0 3px;
+  border-right-width: 0;
+}
+
+.quick-toggle-has-menu .quick-toggle-separator {
+  width: 0;
+}
+
+.quick-slider > StBoxLayout {
+  spacing: 4px;
+}
+
+.quick-slider .slider-bin {
+  min-height: 16px;
+  padding: 4px;
+  border-radius: 9999px;
+}
+
+.quick-slider .slider-bin:focus {
+  color: #1A73E8;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.quick-slider .slider-bin:focus:hover, .quick-slider .slider-bin:focus:active {
+  color: #1A73E8;
+}
+
+.quick-slider .quick-toggle-icon {
+  icon-size: 16px;
+}
+
+.quick-slider .icon-button, .quick-slider .message-notification-group .message-collapse-button, .message-notification-group .quick-slider .message-collapse-button, .quick-slider .message .message-header .message-expand-button, .message .message-header .quick-slider .message-expand-button,
+.quick-slider .message .message-header .message-close-button,
+.message .message-header .quick-slider .message-close-button {
+  min-width: 22px;
+  min-height: 22px;
+  background-color: transparent;
+  color: rgba(0, 0, 0, 0.87) !important;
+}
+
+.quick-slider .icon-button:hover, .quick-slider .message-notification-group .message-collapse-button:hover, .message-notification-group .quick-slider .message-collapse-button:hover, .quick-slider .message .message-header .message-expand-button:hover, .message .message-header .quick-slider .message-expand-button:hover,
+.quick-slider .message .message-header .message-close-button:hover,
+.message .message-header .quick-slider .message-close-button:hover {
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.quick-slider .icon-button:active, .quick-slider .message-notification-group .message-collapse-button:active, .message-notification-group .quick-slider .message-collapse-button:active, .quick-slider .message .message-header .message-expand-button:active, .message .message-header .quick-slider .message-expand-button:active,
+.quick-slider .message .message-header .message-close-button:active,
+.message .message-header .quick-slider .message-close-button:active {
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+.quick-toggle-menu {
+  background-color: white !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+  border-radius: 3px !important;
+  padding: 12px;
+  margin: 8px 24px 0;
+  border: none !important;
+}
+
+.quick-toggle-menu .popup-menu-item {
+  border-radius: 3px !important;
+  min-height: 20px;
+}
+
+.quick-toggle-menu .popup-menu-item:focus, .quick-toggle-menu .popup-menu-item:hover, .quick-toggle-menu .popup-menu-item.selected {
+  color: rgba(0, 0, 0, 0.87) !important;
+  background-color: rgba(0, 0, 0, 0.1) !important;
+}
+
+.quick-toggle-menu .popup-menu-item:active {
+  color: rgba(0, 0, 0, 0.87) !important;
+  background-color: rgba(0, 0, 0, 0.2) !important;
+}
+
+.quick-toggle-menu .popup-menu-item > StIcon {
+  -st-icon-style: symbolic;
+}
+
+.quick-toggle-menu .header {
+  spacing-rows: 2px;
+  spacing-columns: 8px;
+  padding-bottom: 8px;
+}
+
+.quick-toggle-menu .header .icon {
+  icon-size: 24px;
+  border-radius: 3px;
+  padding: 6px;
+  background-color: rgba(0, 0, 0, 0.06) !important;
+}
+
+.quick-toggle-menu .header .icon.active {
+  background-color: #1A73E8 !important;
+  color: white;
+}
+
+.quick-settings-system-item > StBoxLayout {
+  spacing: 8px;
+}
+
+.quick-settings-system-item .icon-button, .quick-settings-system-item .message-notification-group .message-collapse-button, .message-notification-group .quick-settings-system-item .message-collapse-button, .quick-settings-system-item .message .message-header .message-expand-button, .message .message-header .quick-settings-system-item .message-expand-button,
+.quick-settings-system-item .message .message-header .message-close-button,
+.message .message-header .quick-settings-system-item .message-close-button {
+  background-color: rgba(0, 0, 0, 0.06);
+  color: rgba(0, 0, 0, 0.87);
+  border-radius: 3px;
+  min-height: 22px;
+  min-width: 22px !important;
+}
+
+.quick-settings-system-item .icon-button:hover, .quick-settings-system-item .message-notification-group .message-collapse-button:hover, .message-notification-group .quick-settings-system-item .message-collapse-button:hover, .quick-settings-system-item .message .message-header .message-expand-button:hover, .message .message-header .quick-settings-system-item .message-expand-button:hover,
+.quick-settings-system-item .message .message-header .message-close-button:hover,
+.message .message-header .quick-settings-system-item .message-close-button:hover {
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+.quick-settings-system-item .icon-button:active, .quick-settings-system-item .message-notification-group .message-collapse-button:active, .message-notification-group .quick-settings-system-item .message-collapse-button:active, .quick-settings-system-item .message .message-header .message-expand-button:active, .message .message-header .quick-settings-system-item .message-expand-button:active,
+.quick-settings-system-item .message .message-header .message-close-button:active,
+.message .message-header .quick-settings-system-item .message-close-button:active {
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.quick-settings-system-item .icon-button > StIcon, .quick-settings-system-item .background-app-item .icon-button > StIcon, .quick-settings-system-item .message-notification-group .background-app-item .message-collapse-button > StIcon, .quick-settings-system-item .message .message-header .background-app-item .message-expand-button > StIcon,
+.quick-settings-system-item .message .message-header .background-app-item .message-close-button > StIcon, .quick-settings-system-item .message-notification-group .message-collapse-button > StIcon, .message-notification-group .quick-settings-system-item .message-collapse-button > StIcon, .quick-settings-system-item .message .message-header .message-expand-button > StIcon, .message .message-header .quick-settings-system-item .message-expand-button > StIcon,
+.quick-settings-system-item .message .message-header .message-close-button > StIcon,
+.message .message-header .quick-settings-system-item .message-close-button > StIcon {
+  -st-icon-style: symbolic;
+  icon-size: 16px;
+}
+
+.quick-settings-system-item .power-item {
+  min-height: 0;
+  min-width: 0;
+}
+
+.quick-settings-system-item .power-item:insensitive {
+  color: rgba(0, 0, 0, 0.62);
+  background-color: #ffffff;
+  border-color: #d9d9d9;
+  box-shadow: none;
+  background-color: transparent;
+}
+
+.nm-network-item .wireless-secure-icon {
+  icon-size: 8px;
+}
+
+.bt-device-item .popup-menu-icon {
+  -st-icon-style: symbolic;
+}
+
+.bt-menu-placeholder.popup-menu-item {
+  text-align: center;
+  padding: 2em 4em;
+}
+
+.device-subtitle {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.keyboard-brightness-level {
+  spacing: 4px;
+}
+
+.background-apps-quick-toggle {
+  min-height: 40px;
+  background-color: transparent;
+}
+
+.background-apps-quick-toggle StIcon {
+  icon-size: 16px !important;
+}
+
+.background-app-item .popup-menu-icon {
+  icon-size: 24px !important;
+  -st-icon-style: regular !important;
+}
+
+.background-app-item .icon-button, .background-app-item .message-notification-group .message-collapse-button, .message-notification-group .background-app-item .message-collapse-button, .background-app-item .message .message-header .message-expand-button, .message .message-header .background-app-item .message-expand-button,
+.background-app-item .message .message-header .message-close-button,
+.message .message-header .background-app-item .message-close-button {
+  padding: 4px;
+}
+
+.background-app-item .spinner {
+  padding: 4px;
+}
+
+.background-app-item.popup-inactive-menu-item {
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.icon-label-button-container {
+  spacing: 4px;
+  font-size: 9pt;
+  font-weight: 400;
+}
+
+.icon-label-button-container StIcon {
+  icon-size: 32px;
+}
+
+.screenshot-ui-panel {
+  border-radius: 27px;
+  padding: 12px;
+  padding-bottom: 6px;
+  margin-bottom: 4em;
+  spacing: 8px;
+}
+
+.screenshot-ui-close-button {
+  padding: 4px;
+}
+
+.screenshot-ui-close-button.left {
+  margin-left: 8px;
+}
+
+.screenshot-ui-close-button.right {
+  margin-right: 8px;
+}
+
+.screenshot-ui-type-button {
+  padding: 8px 12px !important;
+  border-radius: 15px;
+}
+
+.screenshot-ui-capture-button {
+  width: 36px;
+  height: 36px;
+  border-radius: 9999px;
+  border: 4px rgba(255, 255, 255, 0.85);
+  padding: 4px;
+}
+
+.screenshot-ui-capture-button .screenshot-ui-capture-button-circle {
+  background-color: rgba(255, 255, 255, 0.85);
+  transition-duration: 200ms;
+  border-radius: 9999px;
+}
+
+.screenshot-ui-capture-button .screenshot-ui-capture-button-circle:hover, .screenshot-ui-capture-button .screenshot-ui-capture-button-circle:focus {
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+.screenshot-ui-capture-button:hover .screenshot-ui-capture-button-circle, .screenshot-ui-capture-button:focus .screenshot-ui-capture-button-circle {
+  background-color: rgba(217, 217, 217, 0.85);
+}
+
+.screenshot-ui-capture-button:active .screenshot-ui-capture-button-circle {
+  background-color: rgba(128, 128, 128, 0.85);
+}
+
+.screenshot-ui-capture-button:cast .screenshot-ui-capture-button-circle {
+  background-color: #DD2C00;
+}
+
+.screenshot-ui-capture-button:cast:hover .screenshot-ui-capture-button-circle, .screenshot-ui-capture-button:cast:focus .screenshot-ui-capture-button-circle {
+  background-color: #911d00;
+}
+
+.screenshot-ui-capture-button:cast:active .screenshot-ui-capture-button-circle {
+  background-color: #440e00;
+}
+
+.screenshot-ui-shot-cast-container {
+  background-color: rgba(0, 0, 0, 0.12);
+  border-radius: 6px;
+  padding: 3px;
+  spacing: 3px;
+}
+
+.screenshot-ui-shot-cast-container:ltr {
+  margin-left: 9px;
+}
+
+.screenshot-ui-shot-cast-container:rtl {
+  margin-right: 9px;
+}
+
+.screenshot-ui-shot-cast-button {
+  padding: 4px 8px;
+  background-color: transparent;
+  border-radius: 3px;
+}
+
+.screenshot-ui-shot-cast-button:hover, .screenshot-ui-shot-cast-button:focus {
+  background-color: rgba(13, 13, 13, 0.12);
+}
+
+.screenshot-ui-shot-cast-button:active {
+  background-color: rgba(13, 13, 13, 0.2);
+}
+
+.screenshot-ui-shot-cast-button:checked {
+  background-color: white;
+  color: black;
+}
+
+.screenshot-ui-shot-cast-button StIcon {
+  icon-size: 16px;
+}
+
+.screenshot-ui-show-pointer-button {
+  border-radius: 9999px;
+  padding: 8px !important;
+}
+
+.screenshot-ui-show-pointer-button StIcon {
+  icon-size: 16px;
+}
+
+.screenshot-ui-area-indicator-shade {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.screenshot-ui-area-selector .screenshot-ui-area-indicator-shade {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.screenshot-ui-area-selector .screenshot-ui-area-indicator-selection {
+  border: 2px white;
+}
+
+.screenshot-ui-area-selector-handle {
+  border-radius: 9999px;
+  background-color: white;
+  box-shadow: 0 1px 3px 2px rgba(0, 0, 0, 0.2);
+  width: 24px;
+  height: 24px;
+}
+
+.screenshot-ui-window-selector {
+  background-color: #222222;
+}
+
+.screenshot-ui-window-selector .screenshot-ui-window-selector-window-container {
+  margin: 100px;
+}
+
+.screenshot-ui-window-selector:primary-monitor .screenshot-ui-window-selector-window-container {
+  margin-bottom: 200px;
+}
+
+.screenshot-ui-window-selector-window-border {
+  transition-duration: 200ms;
+  border-radius: 6px;
+  border: 6px transparent;
+}
+
+.screenshot-ui-window-selector-check {
+  transition-duration: 200ms;
+  color: transparent;
+  border-radius: 9999px;
+  border-width: 12px;
+  icon-size: 24px;
+}
+
+.screenshot-ui-window-selector-window:hover .screenshot-ui-window-selector-window-border {
+  border-color: #1151a5;
+}
+
+.screenshot-ui-window-selector-window:checked .screenshot-ui-window-selector-window-border {
+  border-color: #1A73E8;
+  background-color: rgba(26, 115, 232, 0.2);
+}
+
+.screenshot-ui-window-selector-window:checked .screenshot-ui-window-selector-check {
+  color: white;
+  background-color: #1A73E8;
+}
+
+.screenshot-ui-screen-selector {
+  transition-duration: 200ms;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.screenshot-ui-screen-selector:hover {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.screenshot-ui-screen-selector:active {
+  background-color: rgba(0, 0, 0, 0.7);
+}
+
+.screenshot-ui-screen-selector:checked {
+  background-color: transparent;
+  border: 2px white;
+}
+
+.screenshot-ui-tooltip {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #222222;
+  border-radius: 99px;
+  padding: 4px 8px;
+  text-align: center;
+  -y-offset: 24px;
+}
+
+/* Login Dialog */
+.login-dialog-banner-view {
+  padding-top: 24px;
+  max-width: 23em;
+}
+
+.login-dialog,
+.unlock-dialog {
+  border: none;
+  background-color: transparent;
+}
+
+.login-dialog StEntry,
+.unlock-dialog StEntry {
+  selection-background-color: #1A73E8;
+  selected-color: rgba(255, 255, 255, 0.85) !important;
+  caret-color: rgba(0, 0, 0, 0.54);
+  color: rgba(0, 0, 0, 0.54);
+  background-color: #ffffff;
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+.login-dialog StEntry:focus,
+.unlock-dialog StEntry:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #1A73E8 !important;
+}
+
+.login-dialog StEntry:insensitive,
+.unlock-dialog StEntry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog .modal-dialog-button-box,
+.unlock-dialog .modal-dialog-button-box {
+  spacing: 3px;
+}
+
+.login-dialog .modal-dialog-button,
+.unlock-dialog .modal-dialog-button {
+  padding: 4px 18px;
+  box-shadow: none;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:hover, .login-dialog .modal-dialog-button:focus,
+.unlock-dialog .modal-dialog-button:hover,
+.unlock-dialog .modal-dialog-button:focus {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.15);
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:active,
+.unlock-dialog .modal-dialog-button:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.3);
+  box-shadow: 0 0 transparent;
+}
+
+.login-dialog .modal-dialog-button:insensitive,
+.unlock-dialog .modal-dialog-button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default,
+.unlock-dialog .modal-dialog-button:default {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #287ce9;
+  border-color: #1257b3;
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:hover, .login-dialog .modal-dialog-button:default:focus,
+.unlock-dialog .modal-dialog-button:default:hover,
+.unlock-dialog .modal-dialog-button:default:focus {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #287ce9;
+  border-color: #104c9c;
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:active,
+.unlock-dialog .modal-dialog-button:default:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #176ee1;
+  border-color: #104c9c;
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:active:hover, .login-dialog .modal-dialog-button:default:active:focus,
+.unlock-dialog .modal-dialog-button:default:active:hover,
+.unlock-dialog .modal-dialog-button:default:active:focus {
+  background-color: #176ee1;
+}
+
+.login-dialog .modal-dialog-button:default:insensitive,
+.unlock-dialog .modal-dialog-button:default:insensitive {
+  color: rgba(255, 255, 255, 0.5);
+  background-color: rgba(255, 255, 255, 0.15);
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.login-dialog .cancel-button,
+.login-dialog .switch-user-button,
+.login-dialog .login-dialog-session-list-button,
+.unlock-dialog .cancel-button,
+.unlock-dialog .switch-user-button,
+.unlock-dialog .login-dialog-session-list-button {
+  padding: 0;
+  border-radius: 99px;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog .cancel-button:hover, .login-dialog .cancel-button:focus,
+.login-dialog .switch-user-button:hover,
+.login-dialog .switch-user-button:focus,
+.login-dialog .login-dialog-session-list-button:hover,
+.login-dialog .login-dialog-session-list-button:focus,
+.unlock-dialog .cancel-button:hover,
+.unlock-dialog .cancel-button:focus,
+.unlock-dialog .switch-user-button:hover,
+.unlock-dialog .switch-user-button:focus,
+.unlock-dialog .login-dialog-session-list-button:hover,
+.unlock-dialog .login-dialog-session-list-button:focus {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog .cancel-button:active,
+.login-dialog .switch-user-button:active,
+.login-dialog .login-dialog-session-list-button:active,
+.unlock-dialog .cancel-button:active,
+.unlock-dialog .switch-user-button:active,
+.unlock-dialog .login-dialog-session-list-button:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.login-dialog .cancel-button StIcon,
+.login-dialog .switch-user-button StIcon,
+.login-dialog .login-dialog-session-list-button StIcon,
+.unlock-dialog .cancel-button StIcon,
+.unlock-dialog .switch-user-button StIcon,
+.unlock-dialog .login-dialog-session-list-button StIcon {
+  icon-size: 16px;
+}
+
+.login-dialog .caps-lock-warning-label,
+.login-dialog .login-dialog-message-warning,
+.unlock-dialog .caps-lock-warning-label,
+.unlock-dialog .login-dialog-message-warning {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-logo-bin {
+  padding: 24px 0px;
+}
+
+.login-dialog-banner {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog-button-box {
+  width: 23em;
+  spacing: 5px;
+}
+
+.login-dialog-message {
+  text-align: center;
+}
+
+.login-dialog-user-selection-box {
+  padding: 100px 0px;
+}
+
+.login-dialog-not-listed-label {
+  padding-left: 2px;
+  font-size: 1em;
+  font-weight: bold;
+  color: rgba(255, 255, 255, 0.7);
+  padding-top: 1em;
+}
+
+.login-dialog-not-listed-label:hover {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-not-listed-label:focus {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.login-dialog-not-listed-button:focus .login-dialog-not-listed-label, .login-dialog-not-listed-button:hover .login-dialog-not-listed-label {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-view {
+  -st-vfade-offset: 1em;
+}
+
+.login-dialog-user-list {
+  spacing: 12px;
+  width: 23em;
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:selected {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:active {
+  background-color: rgba(255, 255, 255, 0.3);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:logged-in {
+  border-right: 2px solid rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-item {
+  border-radius: 3px;
+  padding: 6px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog-user-list-item:ltr {
+  padding-right: 1em;
+}
+
+.login-dialog-user-list-item:rtl {
+  padding-left: 1em;
+}
+
+.login-dialog-user-list-item:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-item:active {
+  background-color: rgba(255, 255, 255, 0.3);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-item .login-dialog-timed-login-indicator {
+  height: 2px;
+  margin: 6px 0 0 0;
+  background-color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-item:focus .login-dialog-timed-login-indicator {
+  background-color: rgba(255, 255, 255, 0.85);
+}
+
+.user-widget-label {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.user-widget.horizontal .user-widget-label {
+  font-size: 15pt;
+  font-weight: 500;
+  font-weight: bold;
+  padding-left: 15px;
+}
+
+.user-widget.horizontal .user-widget-label:ltr {
+  padding-left: 14px;
+  text-align: left;
+}
+
+.user-widget.horizontal .user-widget-label:rtl {
+  padding-right: 14px;
+  text-align: right;
+}
+
+.user-widget.vertical .user-widget-label {
+  font-size: 15pt;
+  font-weight: 500;
+  text-align: center;
+  font-weight: normal;
+  padding-top: 16px;
+}
+
+.login-dialog-prompt-layout {
+  padding-top: 24px;
+  padding-bottom: 12px;
+  spacing: 8px;
+  width: 23em;
+}
+
+.login-dialog-prompt-entry {
+  height: 1.5em;
+}
+
+.login-dialog-prompt-label {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 1em;
+  padding-top: 1em;
+}
+
+/* Screen Shield */
+.unlock-dialog-clock {
+  color: white;
+  font-weight: 300;
+  text-align: center;
+  spacing: 24px;
+  padding-bottom: 2.5em;
+}
+
+.unlock-dialog-clock-time {
+  font-size: 64pt;
+  padding-top: 42px;
+  font-feature-settings: "tnum";
+}
+
+.unlock-dialog-clock-date {
+  font-size: 16pt;
+  font-weight: normal;
+}
+
+.unlock-dialog-clock-hint {
+  font-weight: normal;
+  padding-top: 48px;
+}
+
+.unlock-dialog-notifications-container {
+  margin: 12px 0;
+  spacing: 6px;
+  width: 23em;
+  background-color: transparent;
+}
+
+.unlock-dialog-notifications-container .summary-notification-stack-scrollview {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.unlock-dialog-notifications-container .notification,
+.unlock-dialog-notifications-container .unlock-dialog-notification-source {
+  padding: 12px 6px;
+  border: none;
+  background-color: rgba(32, 32, 32, 0.9);
+  color: rgba(255, 255, 255, 0.85);
+  border-radius: 3px;
+}
+
+.unlock-dialog-notifications-container .notification.critical,
+.unlock-dialog-notifications-container .unlock-dialog-notification-source.critical {
+  background-color: rgba(34, 34, 34, 0.9);
+}
+
+.unlock-dialog-notification-label {
+  padding: 0px 0px 0px 12px;
+}
+
+.unlock-dialog-notification-count-text {
+  weight: bold;
+  padding: 0 6px;
+  color: rgba(32, 32, 32, 0.9);
+  background-color: rgba(255, 255, 255, 0.7);
+  border-radius: 99px;
+  margin-right: 12px;
+}
+
+.screen-shield-background {
+  background: black;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.6);
+}
+
+#lockDialogGroup {
+  background-color: #222222;
+}
+
+#unlockDialogNotifications StButton#vhandle, #unlockDialogNotifications StButton#hhandle {
+  background-color: rgba(32, 32, 32, 0.2);
+}
+
+#unlockDialogNotifications StButton#vhandle:hover, #unlockDialogNotifications StButton#vhandle:focus, #unlockDialogNotifications StButton#hhandle:hover, #unlockDialogNotifications StButton#hhandle:focus {
+  background-color: rgba(32, 32, 32, 0.4);
+}
+
+#unlockDialogNotifications StButton#vhandle:active, #unlockDialogNotifications StButton#hhandle:active {
+  background-color: rgba(26, 115, 232, 0.5);
+}
+
+.bottom #dashtodockDashScrollview,
+.top #dashtodockDashScrollview {
+  -st-hfade-offset: 24px;
+}
+
+.left #dashtodockDashScrollview,
+.right #dashtodockDashScrollview {
+  -st-vfade-offset: 24px;
+}
+
+#dashtodockContainer {
+  background-color: transparent;
+  box-shadow: none;
+}
+
+#dashtodockContainer .number-overlay {
+  color: #FFFFFF;
+  background-color: rgba(0, 0, 0, 0.75);
+  text-align: center;
+}
+
+#dashtodockContainer .notification-badge {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #1A73E8;
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.25);
+  border-radius: 9999px;
+  margin: 2px 3px 5px;
+  padding: 0.2em 0.6em;
+  font-weight: bold;
+  text-align: center;
+}
+
+#dashtodockContainer.top.straight-corner #dash, #dashtodockContainer.top.shrink.straight-corner #dash, #dashtodockContainer.top.extended #dash, #dashtodockContainer.top.extended:overview #dash {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.straight-corner #dash .dash-background, #dashtodockContainer.top.shrink.straight-corner #dash .dash-background, #dashtodockContainer.top.extended #dash .dash-background, #dashtodockContainer.top.extended:overview #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.top.straight-corner #dash .show-apps,
+#dashtodockContainer.top.straight-corner #dash .overview-tile,
+#dashtodockContainer.top.straight-corner #dash .grid-search-result,
+#dashtodockContainer.top.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.top.straight-corner #dash .list-search-result, #dashtodockContainer.top.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.top.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.top.extended #dash .show-apps,
+#dashtodockContainer.top.extended #dash .overview-tile,
+#dashtodockContainer.top.extended #dash .grid-search-result,
+#dashtodockContainer.top.extended #dash .search-provider-icon,
+#dashtodockContainer.top.extended #dash .list-search-result, #dashtodockContainer.top.extended:overview #dash .show-apps,
+#dashtodockContainer.top.extended:overview #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash, #dashtodockContainer.bottom.shrink.straight-corner #dash, #dashtodockContainer.bottom.extended #dash, #dashtodockContainer.bottom.extended:overview #dash {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash .dash-background, #dashtodockContainer.bottom.shrink.straight-corner #dash .dash-background, #dashtodockContainer.bottom.extended #dash .dash-background, #dashtodockContainer.bottom.extended:overview #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash .show-apps,
+#dashtodockContainer.bottom.straight-corner #dash .overview-tile,
+#dashtodockContainer.bottom.straight-corner #dash .grid-search-result,
+#dashtodockContainer.bottom.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.bottom.straight-corner #dash .list-search-result, #dashtodockContainer.bottom.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.bottom.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.bottom.extended #dash .show-apps,
+#dashtodockContainer.bottom.extended #dash .overview-tile,
+#dashtodockContainer.bottom.extended #dash .grid-search-result,
+#dashtodockContainer.bottom.extended #dash .search-provider-icon,
+#dashtodockContainer.bottom.extended #dash .list-search-result, #dashtodockContainer.bottom.extended:overview #dash .show-apps,
+#dashtodockContainer.bottom.extended:overview #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash, #dashtodockContainer.left.shrink.straight-corner #dash, #dashtodockContainer.left.extended #dash, #dashtodockContainer.left.extended:overview #dash {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash .dash-background, #dashtodockContainer.left.shrink.straight-corner #dash .dash-background, #dashtodockContainer.left.extended #dash .dash-background, #dashtodockContainer.left.extended:overview #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash .show-apps,
+#dashtodockContainer.left.straight-corner #dash .overview-tile,
+#dashtodockContainer.left.straight-corner #dash .grid-search-result,
+#dashtodockContainer.left.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.left.straight-corner #dash .list-search-result, #dashtodockContainer.left.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.left.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.left.extended #dash .show-apps,
+#dashtodockContainer.left.extended #dash .overview-tile,
+#dashtodockContainer.left.extended #dash .grid-search-result,
+#dashtodockContainer.left.extended #dash .search-provider-icon,
+#dashtodockContainer.left.extended #dash .list-search-result, #dashtodockContainer.left.extended:overview #dash .show-apps,
+#dashtodockContainer.left.extended:overview #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash, #dashtodockContainer.right.shrink.straight-corner #dash, #dashtodockContainer.right.extended #dash, #dashtodockContainer.right.extended:overview #dash {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash .dash-background, #dashtodockContainer.right.shrink.straight-corner #dash .dash-background, #dashtodockContainer.right.extended #dash .dash-background, #dashtodockContainer.right.extended:overview #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash .show-apps,
+#dashtodockContainer.right.straight-corner #dash .overview-tile,
+#dashtodockContainer.right.straight-corner #dash .grid-search-result,
+#dashtodockContainer.right.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.right.straight-corner #dash .list-search-result, #dashtodockContainer.right.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.right.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.right.extended #dash .show-apps,
+#dashtodockContainer.right.extended #dash .overview-tile,
+#dashtodockContainer.right.extended #dash .grid-search-result,
+#dashtodockContainer.right.extended #dash .search-provider-icon,
+#dashtodockContainer.right.extended #dash .list-search-result, #dashtodockContainer.right.extended:overview #dash .show-apps,
+#dashtodockContainer.right.extended:overview #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.extended #dash .dash-background, #dashtodockContainer.straight-corner #dash .dash-background {
+  border-radius: 0;
+}
+
+#dashtodockContainer.shrink #dash .dash-background {
+  padding: 0 !important;
+  border-radius: 3px;
+}
+
+#dashtodockContainer.shrink #dash .show-apps,
+#dashtodockContainer.shrink #dash .overview-tile,
+#dashtodockContainer.shrink #dash .grid-search-result,
+#dashtodockContainer.shrink #dash .search-provider-icon,
+#dashtodockContainer.shrink #dash .list-search-result {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left #dash .overview-tile, #dashtodockContainer.left #dash .grid-search-result, #dashtodockContainer.left #dash .search-provider-icon, #dashtodockContainer.left #dash .list-search-result, #dashtodockContainer.right #dash .overview-tile, #dashtodockContainer.right #dash .grid-search-result, #dashtodockContainer.right #dash .search-provider-icon, #dashtodockContainer.right #dash .list-search-result {
+  padding: 1px 4px !important;
+}
+
+#dashtodockContainer.left #dash .show-apps, #dashtodockContainer.right #dash .show-apps {
+  padding-bottom: 4px !important;
+}
+
+#dashtodockContainer.left.shrink #dash .show-apps,
+#dashtodockContainer.left.shrink #dash .overview-tile,
+#dashtodockContainer.left.shrink #dash .grid-search-result,
+#dashtodockContainer.left.shrink #dash .search-provider-icon,
+#dashtodockContainer.left.shrink #dash .list-search-result, #dashtodockContainer.right.shrink #dash .show-apps,
+#dashtodockContainer.right.shrink #dash .overview-tile,
+#dashtodockContainer.right.shrink #dash .grid-search-result,
+#dashtodockContainer.right.shrink #dash .search-provider-icon,
+#dashtodockContainer.right.shrink #dash .list-search-result {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.extended #dash .show-apps,
+#dashtodockContainer.left.extended #dash .overview-tile,
+#dashtodockContainer.left.extended #dash .grid-search-result,
+#dashtodockContainer.left.extended #dash .search-provider-icon,
+#dashtodockContainer.left.extended #dash .list-search-result, #dashtodockContainer.left.straight-corner #dash .show-apps,
+#dashtodockContainer.left.straight-corner #dash .overview-tile,
+#dashtodockContainer.left.straight-corner #dash .grid-search-result,
+#dashtodockContainer.left.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.left.straight-corner #dash .list-search-result, #dashtodockContainer.right.extended #dash .show-apps,
+#dashtodockContainer.right.extended #dash .overview-tile,
+#dashtodockContainer.right.extended #dash .grid-search-result,
+#dashtodockContainer.right.extended #dash .search-provider-icon,
+#dashtodockContainer.right.extended #dash .list-search-result, #dashtodockContainer.right.straight-corner #dash .show-apps,
+#dashtodockContainer.right.straight-corner #dash .overview-tile,
+#dashtodockContainer.right.straight-corner #dash .grid-search-result,
+#dashtodockContainer.right.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.right.straight-corner #dash .list-search-result {
+  padding: 1px 8px !important;
+}
+
+#dashtodockContainer.top.shrink #dash .dash-background, #dashtodockContainer.bottom.shrink #dash .dash-background {
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.shrink #dash .show-apps,
+#dashtodockContainer.top.shrink #dash .overview-tile,
+#dashtodockContainer.top.shrink #dash .grid-search-result,
+#dashtodockContainer.top.shrink #dash .search-provider-icon,
+#dashtodockContainer.top.shrink #dash .list-search-result, #dashtodockContainer.bottom.shrink #dash .show-apps,
+#dashtodockContainer.bottom.shrink #dash .overview-tile,
+#dashtodockContainer.bottom.shrink #dash .grid-search-result,
+#dashtodockContainer.bottom.shrink #dash .search-provider-icon,
+#dashtodockContainer.bottom.shrink #dash .list-search-result {
+  margin: 0 !important;
+  padding: 0 0 18px !important;
+}
+
+#dashtodockContainer.top.extended #dash .dash-separator, #dashtodockContainer.top.straight-corner #dash .dash-separator, #dashtodockContainer.bottom.extended #dash .dash-separator, #dashtodockContainer.bottom.straight-corner #dash .dash-separator {
+  margin: 0 5px !important;
+}
+
+#dashtodockContainer.top.extended #dash .show-apps,
+#dashtodockContainer.top.extended #dash .overview-tile,
+#dashtodockContainer.top.extended #dash .grid-search-result,
+#dashtodockContainer.top.extended #dash .search-provider-icon,
+#dashtodockContainer.top.extended #dash .list-search-result, #dashtodockContainer.top.straight-corner #dash .show-apps,
+#dashtodockContainer.top.straight-corner #dash .overview-tile,
+#dashtodockContainer.top.straight-corner #dash .grid-search-result,
+#dashtodockContainer.top.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.top.straight-corner #dash .list-search-result, #dashtodockContainer.bottom.extended #dash .show-apps,
+#dashtodockContainer.bottom.extended #dash .overview-tile,
+#dashtodockContainer.bottom.extended #dash .grid-search-result,
+#dashtodockContainer.bottom.extended #dash .search-provider-icon,
+#dashtodockContainer.bottom.extended #dash .list-search-result, #dashtodockContainer.bottom.straight-corner #dash .show-apps,
+#dashtodockContainer.bottom.straight-corner #dash .overview-tile,
+#dashtodockContainer.bottom.straight-corner #dash .grid-search-result,
+#dashtodockContainer.bottom.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.bottom.straight-corner #dash .list-search-result {
+  padding: 8px 1px !important;
+}
+
+#dashtodockContainer #dash {
+  background: none;
+  box-shadow: none;
+}
+
+#dashtodockContainer #dash .dash-background {
+  background-color: rgba(255, 255, 255, 0.5);
+  background-clip: padding-box;
+}
+
+#dashtodockContainer #dash .show-apps .overview-icon,
+#dashtodockContainer #dash .overview-tile .overview-icon,
+#dashtodockContainer #dash .grid-search-result .overview-icon,
+#dashtodockContainer #dash .search-provider-icon .overview-icon,
+#dashtodockContainer #dash .list-search-result .overview-icon {
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+
+#dashtodockContainer #dash .show-apps:hover .overview-icon, #dashtodockContainer #dash .show-apps:focus .overview-icon, #dashtodockContainer #dash .show-apps:selected .overview-icon,
+#dashtodockContainer #dash .overview-tile:hover .overview-icon,
+#dashtodockContainer #dash .grid-search-result:hover .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:hover .overview-icon,
+#dashtodockContainer #dash .list-search-result:hover .overview-icon,
+#dashtodockContainer #dash .overview-tile:focus .overview-icon,
+#dashtodockContainer #dash .grid-search-result:focus .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:focus .overview-icon,
+#dashtodockContainer #dash .list-search-result:focus .overview-icon,
+#dashtodockContainer #dash .overview-tile:selected .overview-icon,
+#dashtodockContainer #dash .grid-search-result:selected .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:selected .overview-icon,
+#dashtodockContainer #dash .list-search-result:selected .overview-icon {
+  background-color: rgba(255, 255, 255, 0.35) !important;
+  color: rgba(0, 0, 0, 0.88) !important;
+}
+
+#dashtodockContainer #dash .show-apps:active .overview-icon, #dashtodockContainer #dash .show-apps:checked .overview-icon,
+#dashtodockContainer #dash .overview-tile:active .overview-icon,
+#dashtodockContainer #dash .grid-search-result:active .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:active .overview-icon,
+#dashtodockContainer #dash .list-search-result:active .overview-icon,
+#dashtodockContainer #dash .overview-tile:checked .overview-icon,
+#dashtodockContainer #dash .grid-search-result:checked .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:checked .overview-icon,
+#dashtodockContainer #dash .list-search-result:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.5) !important;
+  color: rgba(0, 0, 0, 0.88) !important;
+}
+
+#dashtodockContainer .dash-separator {
+  background-color: rgba(0, 0, 0, 0.15) !important;
+}
+
+#dashtodockContainer .app-grid-running-dot {
+  background-color: rgba(0, 0, 0, 0.55) !important;
+  margin: 0 0 3px !important;
+  offset-y: 0 !important;
+}
+
+#dashtodockContainer StWidget.focused .overview-icon {
+  background-color: rgba(255, 255, 255, 0.35) !important;
+}
+
+#dashtodockContainer StWidget.focused:hover .overview-icon {
+  background-color: rgba(255, 255, 255, 0.5) !important;
+}
+
+#dashtodockContainer StWidget.focused .app-grid-running-dot {
+  background-color: #1A73E8 !important;
+}
+
+#dashtodockContainer.opaque #dash .dash-background {
+  background-color: #f3f3f3;
+}
+
+#dashtodockContainer.transparent #dash .dash-background {
+  background-color: rgba(255, 255, 255, 0.5);
+}
+
+#dashtodockContainer:overview #dash .dash-background {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+#dashtodockContainer:overview #dash .show-apps .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result .overview-icon {
+  color: rgba(255, 255, 255, 0.7) !important;
+}
+
+#dashtodockContainer:overview #dash .show-apps:hover .overview-icon, #dashtodockContainer:overview #dash .show-apps:focus .overview-icon, #dashtodockContainer:overview #dash .show-apps:selected .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:hover .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:hover .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:hover .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:hover .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:focus .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:focus .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:focus .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:focus .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:selected .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:selected .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:selected .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:selected .overview-icon {
+  background-color: rgba(255, 255, 255, 0.35) !important;
+  color: rgba(255, 255, 255, 0.85) !important;
+}
+
+#dashtodockContainer:overview #dash .show-apps:active .overview-icon, #dashtodockContainer:overview #dash .show-apps:checked .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:active .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:active .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:active .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:active .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:checked .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:checked .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:checked .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.35) !important;
+  color: rgba(255, 255, 255, 0.85) !important;
+}
+
+#dashtodockContainer:overview #dash .dash-separator {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#dashtodockContainer:overview #dash .app-grid-running-dot {
+  background-color: rgba(255, 255, 255, 0.5) !important;
+}
+
+#dashtodockContainer:overview #dash StWidget.focused .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#dashtodockContainer:overview #dash StWidget.focused:hover .overview-icon {
+  background-color: rgba(255, 255, 255, 0.3) !important;
+}
+
+#dashtodockContainer:overview #dash StWidget.focused .app-grid-running-dot {
+  background-color: #1A73E8 !important;
+}
+
+#dashtodockContainer.opaque:overview #dash, #dashtodockContainer.transparent:overview #dash {
+  background-color: transparent !important;
+  box-shadow: none !important;
+}
+
+#dashtodockContainer.opaque:overview #dash .dash-background, #dashtodockContainer.transparent:overview #dash .dash-background {
+  background-color: transparent !important;
+}
+
+#dashtodockContainer.extended:overview #dash, #dashtodockContainer.opaque.extended:overview #dash, #dashtodockContainer.transparent.extended:overview #dash {
+  background: none;
+}
+
+#dashtodockContainer.extended:overview .dash-background, #dashtodockContainer.opaque.extended:overview .dash-background, #dashtodockContainer.transparent.extended:overview .dash-background {
+  background-color: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#dashtodockContainer.running-dots .dash-item-container > StButton, #dashtodockContainer.dashtodock .dash-item-container > StButton {
+  transition-duration: 250ms;
+  background-size: contain;
+}
+
+#dashtodockContainer.extended .show-apps .overview-icon,
+#dashtodockContainer.extended .overview-tile .overview-icon,
+#dashtodockContainer.extended .grid-search-result .overview-icon,
+#dashtodockContainer.extended .search-provider-icon .overview-icon,
+#dashtodockContainer.extended .list-search-result .overview-icon, #dashtodockContainer.extended:overview .show-apps .overview-icon,
+#dashtodockContainer.extended:overview .overview-tile .overview-icon {
+  border-radius: 3px;
+}
+
+#dashtodockContainer .metro .overview-icon {
+  border-radius: 0;
+}
+
+.dashtodock-app-well-preview-menu-item {
+  padding: 1em 1em 0.5em 1em;
+}
+
+#dashtodockPreviewSeparator.popup-separator-menu-item-horizontal {
+  width: 1px;
+  height: auto;
+  border-right-width: 1px;
+  margin: 32px 0;
+}
+
+.dashtopanelMainPanel .show-apps,
+.dashtopanelMainPanel .overview-tile,
+.dashtopanelMainPanel .grid-search-result,
+.dashtopanelMainPanel .search-provider-icon,
+.dashtopanelMainPanel .list-search-result {
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+}
+
+.dashtopanelMainPanel .show-apps .overview-icon,
+.dashtopanelMainPanel .overview-tile .overview-icon,
+.dashtopanelMainPanel .grid-search-result .overview-icon,
+.dashtopanelMainPanel .search-provider-icon .overview-icon,
+.dashtopanelMainPanel .list-search-result .overview-icon {
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+}
+
+.dashtopanelMainPanel .show-apps .overview-icon {
+  border-radius: 3px !important;
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+
+.dashtopanelMainPanel .show-apps:hover .overview-icon, .dashtopanelMainPanel .show-apps:focus .overview-icon, .dashtopanelMainPanel .show-apps:selected .overview-icon {
+  background-color: rgba(255, 255, 255, 0.35) !important;
+  color: rgba(0, 0, 0, 0.88) !important;
+  box-shadow: none !important;
+}
+
+.dashtopanelMainPanel .show-apps:active .overview-icon, .dashtopanelMainPanel .show-apps:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.5) !important;
+  color: rgba(0, 0, 0, 0.88) !important;
+  box-shadow: none !important;
+}
+
+.dashtopanelMainPanel .panel-button {
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+
+.openweather-button, .openweather-button-action, .openweather-menu-button-container, .openweather-button-box {
+  border: 1px solid transparent !important;
+}
+
+.openweather-provider {
+  padding: 0 16px;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.54);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.openweather-provider:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+  box-shadow: none;
+}
+
+.openweather-provider:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: none;
+}
+
+.openweather-provider:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+.openweather-current-icon, .openweather-current-summary, .openweather-current-summarybox {
+  background: none;
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.openweather-current-databox-values {
+  background: none;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.openweather-current-databox-captions {
+  background: none;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.openweather-forecast-icon, .openweather-forecast-summary {
+  background: none;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.openweather-forecast-day, .openweather-forecast-temperature {
+  background: none;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.openweather-sunrise-icon, .openweather-sunset-icon, .openweather-build-icon {
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.gsconnect-device-menu .popup-menu-item {
+  height: 20px !important;
+  padding: 2px 0;
+}
+
+.gsconnect-device-menu .popup-menu-item > :last-child:ltr {
+  padding-right: 4px !important;
+  margin-right: 8px !important;
+}
+
+.gsconnect-device-menu .popup-menu-item > :last-child:rtl {
+  padding-left: 4px !important;
+  padding-left: 8px !important;
+}
+
+#panel.light-panel .panel-button,
+#panel.dark-panel .panel-button,
+#panel.transparent-panel .panel-button {
+  color: rgba(255, 255, 255, 0.7) !important;
+}
+
+#panel.light-panel .panel-button.clock-display .clock,
+#panel.dark-panel .panel-button.clock-display .clock,
+#panel.transparent-panel .panel-button.clock-display .clock {
+  color: rgba(255, 255, 255, 0.7) !important;
+}
+
+#panel.light-panel .panel-button:hover,
+#panel.dark-panel .panel-button:hover,
+#panel.transparent-panel .panel-button:hover {
+  color: rgba(255, 255, 255, 0.7) !important;
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#panel.light-panel .panel-button:active, #panel.light-panel .panel-button:checked, #panel.light-panel .panel-button:focus,
+#panel.dark-panel .panel-button:active,
+#panel.dark-panel .panel-button:checked,
+#panel.dark-panel .panel-button:focus,
+#panel.transparent-panel .panel-button:active,
+#panel.transparent-panel .panel-button:checked,
+#panel.transparent-panel .panel-button:focus {
+  color: rgba(255, 255, 255, 0.85) !important;
+  background-color: rgba(255, 255, 255, 0.3) !important;
+}
+
+#panel.light-panel .panel-button:hover.clock-display .clock, #panel.light-panel .panel-button:active.clock-display .clock, #panel.light-panel .panel-button:overview.clock-display .clock, #panel.light-panel .panel-button:focus.clock-display .clock, #panel.light-panel .panel-button:checked.clock-display .clock,
+#panel.dark-panel .panel-button:hover.clock-display .clock,
+#panel.dark-panel .panel-button:active.clock-display .clock,
+#panel.dark-panel .panel-button:overview.clock-display .clock,
+#panel.dark-panel .panel-button:focus.clock-display .clock,
+#panel.dark-panel .panel-button:checked.clock-display .clock,
+#panel.transparent-panel .panel-button:hover.clock-display .clock,
+#panel.transparent-panel .panel-button:active.clock-display .clock,
+#panel.transparent-panel .panel-button:overview.clock-display .clock,
+#panel.transparent-panel .panel-button:focus.clock-display .clock,
+#panel.transparent-panel .panel-button:checked.clock-display .clock {
+  color: rgba(255, 255, 255, 0.85) !important;
+}
+
+.overview-components-transparent .search-entry,
+.overview-components-light .search-entry,
+.overview-components-dark .search-entry {
+  caret-color: rgba(255, 255, 255, 0.75) !important;
+}
+
+.overview-components-transparent .search-entry .search-entry-icon,
+.overview-components-light .search-entry .search-entry-icon,
+.overview-components-dark .search-entry .search-entry-icon {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.overview-components-transparent .search-entry StLabel.hint-text,
+.overview-components-light .search-entry StLabel.hint-text,
+.overview-components-dark .search-entry StLabel.hint-text {
+  color: rgba(255, 255, 255, 0.35) !important;
+}
+
+.arcmenu-menu {
+  border-image: none !important;
+  border-radius: 3px !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+}
+
+.arcmenu-menu .popup-menu-content {
+  padding: 4px !important;
+  margin: 4px !important;
+  border: none !important;
+  background-color: rgba(255, 255, 255, 0.97);
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.1) !important;
+  border-radius: 3px !important;
+}

--- a/src/gnome-shell/shell-48-0/gnome-shell-Light-compact.scss
+++ b/src/gnome-shell/shell-48-0/gnome-shell-Light-compact.scss
@@ -1,0 +1,10 @@
+$variant: 'light';
+$laptop: 'true';
+$panel: 'light';
+
+@import '../sass/variables';
+@import '../sass/colors';
+@import '../sass/drawing';
+@import '../sass/common-40-0';
+@import '../sass/widgets-48-0';
+@import '../sass/extensions-46-0';

--- a/src/gnome-shell/shell-48-0/gnome-shell-Light.css
+++ b/src/gnome-shell/shell-48-0/gnome-shell-Light.css
@@ -1,0 +1,4945 @@
+/* This stylesheet is generated, DO NOT EDIT */
+stage {
+  font-size: 10.5pt;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.87);
+}
+
+/* Common Stylings */
+#dash .dash-item-container .show-apps,
+#dash .dash-item-container .overview-tile,
+#dash .dash-item-container .grid-search-result,
+#dash .dash-item-container .search-provider-icon,
+#dash .dash-item-container .list-search-result {
+  background: none;
+  box-shadow: none;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  margin: 0;
+}
+
+#dash .dash-item-container .show-apps .overview-icon,
+#dash .dash-item-container .overview-tile .overview-icon,
+#dash .dash-item-container .grid-search-result .overview-icon,
+#dash .dash-item-container .search-provider-icon .overview-icon,
+#dash .dash-item-container .list-search-result .overview-icon {
+  border-radius: 6px;
+  padding: 6px;
+  spacing: 6px;
+  text-align: center;
+  transition-duration: 100ms;
+}
+
+.search-statustext {
+  font-size: 45px;
+  font-weight: 400;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.popup-menu-content {
+  background: rgba(255, 255, 255, 0.97);
+  color: rgba(0, 0, 0, 0.87);
+  border-radius: 3px;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.1);
+}
+
+.modal-dialog {
+  background: rgba(255, 255, 255, 0.97);
+  color: rgba(0, 0, 0, 0.87);
+  border-radius: 6px;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2);
+}
+
+/* General Typography */
+.message-notification-group .message-group-header .message-group-title, .message-list .message-list-placeholder {
+  font-weight: 800;
+  font-size: 1.364em;
+}
+
+.quick-toggle-menu .header .title {
+  font-weight: 700;
+  font-size: 1.364em;
+}
+
+.bt-menu-placeholder.popup-menu-item {
+  font-weight: 700;
+  font-size: 1.182em;
+}
+
+.background-app-item .title, .message-list-controls, .calendar .calendar-month-header .calendar-month-label {
+  font-weight: 700;
+  font-size: 1em;
+}
+
+.quick-toggle-menu .header .subtitle {
+  font-weight: 700;
+  font-size: 0.818em;
+}
+
+.background-app-item .subtitle, .message .message-header .message-header-content .event-time {
+  font-weight: 400;
+  font-size: 0.818em;
+}
+
+/* WIDGETS */
+.shell-link {
+  border-radius: 3px;
+  color: #1A73E8;
+  background-color: transparent;
+}
+
+.shell-link:hover {
+  color: #1A73E8;
+  background-color: rgba(26, 115, 232, 0.15);
+}
+
+.shell-link:active {
+  color: #1A73E8;
+  background-color: rgba(26, 115, 232, 0.3);
+}
+
+.lowres-icon {
+  icon-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+}
+
+.icon-dropshadow {
+  icon-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+}
+
+/* Entries */
+StEntry {
+  min-height: 24px;
+  padding: 3px 9px;
+  border-radius: 3px;
+  border-width: 0;
+  caret-color: rgba(0, 0, 0, 0.54);
+  selection-background-color: #1A73E8;
+  selected-color: #FFFFFF !important;
+  font-size: 12pt;
+  font-weight: 400;
+  caret-color: rgba(0, 0, 0, 0.54);
+  color: rgba(0, 0, 0, 0.54);
+  background-color: #ffffff;
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+StEntry:hover {
+  border: 2px solid rgba(0, 0, 0, 0.2) !important;
+}
+
+StEntry:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #1A73E8 !important;
+}
+
+StEntry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+StEntry StIcon.capslock-warning {
+  icon-size: 16px;
+  warning-color: #FF6D00;
+  padding: 0 0;
+}
+
+StEntry StIcon.peek-password {
+  icon-size: 16px;
+  padding: 0 4px;
+}
+
+StEntry StLabel.hint-text {
+  margin-left: 2px;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+/* Buttons */
+.screenshot-ui-show-pointer-button, .screenshot-ui-type-button {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:focus, .screenshot-ui-type-button:focus {
+  color: rgba(255, 255, 255, 0.85);
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:hover, .screenshot-ui-type-button:hover {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.15);
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:active, .screenshot-ui-type-button:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.3);
+  box-shadow: 0 0 transparent;
+}
+
+.screenshot-ui-show-pointer-button:checked, .screenshot-ui-type-button:checked {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #1A73E8;
+  border-color: #1A73E8;
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:checked:hover, .screenshot-ui-type-button:checked:hover, .screenshot-ui-show-pointer-button:checked:focus, .screenshot-ui-type-button:checked:focus {
+  background-color: #1A73E8;
+}
+
+.screenshot-ui-show-pointer-button:insensitive, .screenshot-ui-type-button:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.icon-button.flat, .message .message-header .flat.message-expand-button,
+.message .message-header .flat.message-close-button, .message-notification-group .flat.message-collapse-button, .button.flat {
+  color: rgba(0, 0, 0, 0.54);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.icon-button.flat:focus, .message .message-header .flat.message-expand-button:focus,
+.message .message-header .flat.message-close-button:focus, .message-notification-group .flat.message-collapse-button:focus, .button.flat:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: none;
+}
+
+.icon-button.flat:hover, .message .message-header .flat.message-expand-button:hover,
+.message .message-header .flat.message-close-button:hover, .message-notification-group .flat.message-collapse-button:hover, .button.flat:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+  box-shadow: none;
+}
+
+.icon-button.flat:selected, .message .message-header .flat.message-expand-button:selected,
+.message .message-header .flat.message-close-button:selected, .message-notification-group .flat.message-collapse-button:selected, .button.flat:selected, .icon-button.flat:active, .message .message-header .flat.message-expand-button:active,
+.message .message-header .flat.message-close-button:active, .message-notification-group .flat.message-collapse-button:active, .button.flat:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+.icon-button.flat:checked, .message .message-header .flat.message-expand-button:checked,
+.message .message-header .flat.message-close-button:checked, .message-notification-group .flat.message-collapse-button:checked, .button.flat:checked {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+.icon-button.flat:insensitive, .message .message-header .flat.message-expand-button:insensitive,
+.message .message-header .flat.message-close-button:insensitive, .message-notification-group .flat.message-collapse-button:insensitive, .button.flat:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:checked, .icon-button.default, .message .message-header .default.message-expand-button,
+.message .message-header .default.message-close-button, .message-notification-group .default.message-collapse-button, .button.default {
+  color: #FFFFFF;
+  background-color: #1A73E8;
+  border-color: #1151a5;
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:focus:checked, .icon-button.default:focus, .message .message-header .default.message-expand-button:focus,
+.message .message-header .default.message-close-button:focus, .message-notification-group .default.message-collapse-button:focus, .button.default:focus {
+  color: #1A73E8;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.keyboard-brightness-level .button:focus:hover:checked, .icon-button.default:focus:hover, .message .message-header .default.message-expand-button:focus:hover,
+.message .message-header .default.message-close-button:focus:hover, .message-notification-group .default.message-collapse-button:focus:hover, .button.default:focus:hover, .keyboard-brightness-level .button:focus:active:checked, .icon-button.default:focus:active, .message .message-header .default.message-expand-button:focus:active,
+.message .message-header .default.message-close-button:focus:active, .message-notification-group .default.message-collapse-button:focus:active, .button.default:focus:active {
+  color: #1A73E8;
+}
+
+.keyboard-brightness-level .button:hover:checked, .icon-button.default:hover, .message .message-header .default.message-expand-button:hover,
+.message .message-header .default.message-close-button:hover, .message-notification-group .default.message-collapse-button:hover, .button.default:hover {
+  color: #FFFFFF;
+  background-color: #1A73E8;
+  border-color: #0e458e;
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:insensitive:checked, .icon-button.default:insensitive, .message .message-header .default.message-expand-button:insensitive,
+.message .message-header .default.message-close-button:insensitive, .message-notification-group .default.message-collapse-button:insensitive, .button.default:insensitive {
+  color: #FFFFFF;
+  background-color: #1A73E8;
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:active:checked, .icon-button.default:active, .message .message-header .default.message-expand-button:active,
+.message .message-header .default.message-close-button:active, .message-notification-group .default.message-collapse-button:active, .button.default:active {
+  color: #FFFFFF;
+  background-color: #1567d3;
+  border-color: #0e458e;
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:active:hover:checked, .icon-button.default:active:hover, .message .message-header .default.message-expand-button:active:hover,
+.message .message-header .default.message-close-button:active:hover, .message-notification-group .default.message-collapse-button:active:hover, .button.default:active:hover, .keyboard-brightness-level .button:active:focus:checked, .icon-button.default:active:focus, .message .message-header .default.message-expand-button:active:focus,
+.message .message-header .default.message-close-button:active:focus, .message-notification-group .default.message-collapse-button:active:focus, .button.default:active:focus {
+  background-color: #1567d3;
+}
+
+.icon-button, .background-app-item .icon-button, .background-app-item .message-notification-group .message-collapse-button, .message-notification-group .background-app-item .message-collapse-button, .background-app-item .message .message-header .message-expand-button, .message .message-header .background-app-item .message-expand-button,
+.background-app-item .message .message-header .message-close-button,
+.message .message-header .background-app-item .message-close-button, .message .message-header .message-expand-button,
+.message .message-header .message-close-button, .message-notification-group .message-collapse-button, .button {
+  padding: 6px 12px;
+  border-width: 0;
+  border-radius: 3px;
+  font-size: 10.5pt;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.54);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.icon-button:focus, .message .message-header .message-expand-button:focus,
+.message .message-header .message-close-button:focus, .message-notification-group .message-collapse-button:focus, .button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: none;
+}
+
+.icon-button:hover, .message .message-header .message-expand-button:hover,
+.message .message-header .message-close-button:hover, .message-notification-group .message-collapse-button:hover, .button:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+  box-shadow: none;
+}
+
+.icon-button:selected, .message .message-header .message-expand-button:selected,
+.message .message-header .message-close-button:selected, .message-notification-group .message-collapse-button:selected, .button:selected, .icon-button:active, .message .message-header .message-expand-button:active,
+.message .message-header .message-close-button:active, .message-notification-group .message-collapse-button:active, .button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+.icon-button:checked, .message .message-header .message-expand-button:checked,
+.message .message-header .message-close-button:checked, .message-notification-group .message-collapse-button:checked, .button:checked {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #1A73E8;
+  border-color: #1A73E8;
+  box-shadow: none;
+}
+
+.icon-button:checked:hover, .message .message-header .message-expand-button:checked:hover,
+.message .message-header .message-close-button:checked:hover, .message-notification-group .message-collapse-button:checked:hover, .button:checked:hover, .icon-button:checked:focus, .message .message-header .message-expand-button:checked:focus,
+.message .message-header .message-close-button:checked:focus, .message-notification-group .message-collapse-button:checked:focus, .button:checked:focus {
+  background-color: #1A73E8;
+}
+
+.icon-button:insensitive, .message .message-header .message-expand-button:insensitive,
+.message .message-header .message-close-button:insensitive, .message-notification-group .message-collapse-button:insensitive, .button:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button, .notification-button {
+  border-radius: 3px;
+  border: 1px solid;
+  color: rgba(0, 0, 0, 0.62);
+  background-color: #ffffff;
+  border-color: #d9d9d9;
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button:focus, .notification-button:focus {
+  color: #1A73E8;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.modal-dialog .modal-dialog-button:focus:hover, .notification-button:focus:hover, .modal-dialog .modal-dialog-button:focus:active, .notification-button:focus:active {
+  color: #1A73E8;
+}
+
+.modal-dialog .modal-dialog-button:hover, .notification-button:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #ffffff;
+  border-color: #cccccc;
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button:selected, .notification-button:selected, .modal-dialog .modal-dialog-button:active, .notification-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #f2f2f2;
+  border-color: #cccccc;
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button:selected:hover, .notification-button:selected:hover, .modal-dialog .modal-dialog-button:selected:focus, .notification-button:selected:focus, .modal-dialog .modal-dialog-button:active:hover, .notification-button:active:hover, .modal-dialog .modal-dialog-button:active:focus, .notification-button:active:focus {
+  background-color: #f2f2f2;
+}
+
+.modal-dialog .modal-dialog-button:checked, .notification-button:checked {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #1A73E8;
+  border-color: #1A73E8;
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button:checked:hover, .notification-button:checked:hover, .modal-dialog .modal-dialog-button:checked:focus, .notification-button:checked:focus {
+  background-color: #1A73E8;
+}
+
+.modal-dialog .modal-dialog-button:insensitive, .notification-button:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: rgba(0, 0, 0, 0.06);
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.button {
+  min-height: 1.5em;
+}
+
+.icon-button, .background-app-item .icon-button, .background-app-item .message-notification-group .message-collapse-button, .message-notification-group .background-app-item .message-collapse-button, .background-app-item .message .message-header .message-expand-button, .message .message-header .background-app-item .message-expand-button,
+.background-app-item .message .message-header .message-close-button,
+.message .message-header .background-app-item .message-close-button, .message .message-header .message-expand-button,
+.message .message-header .message-close-button, .message-notification-group .message-collapse-button {
+  border-radius: 9999px;
+  padding: 0.818em;
+  min-height: 1.091em;
+}
+
+.icon-button StIcon, .background-app-item .icon-button StIcon, .background-app-item .message-notification-group .message-collapse-button StIcon, .message-notification-group .background-app-item .message-collapse-button StIcon, .background-app-item .message .message-header .message-expand-button StIcon, .message .message-header .background-app-item .message-expand-button StIcon,
+.background-app-item .message .message-header .message-close-button StIcon,
+.message .message-header .background-app-item .message-close-button StIcon, .message .message-header .message-expand-button StIcon,
+.message .message-header .message-close-button StIcon, .message-notification-group .message-collapse-button StIcon {
+  icon-size: 1.091em;
+  -st-icon-style: symbolic;
+}
+
+/* Check Boxes */
+.check-box StBoxLayout {
+  spacing: .8em;
+}
+
+.check-box StBin {
+  width: 24px;
+  height: 24px;
+  padding: 6px;
+  border-radius: 100px;
+  background-image: url("assets/checkbox-off.svg");
+}
+
+.check-box:focus StBin {
+  background-image: url("assets/checkbox-off.svg");
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.check-box:hover StBin {
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.check-box:active StBin {
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.check-box:checked StBin {
+  background-image: url("assets/checkbox.svg");
+}
+
+.check-box:focus:checked StBin {
+  background-image: url("assets/checkbox.svg");
+}
+
+.check-box:hover:checked StBin {
+  background-color: rgba(40, 124, 233, 0.15);
+}
+
+.check-box:active:checked StBin {
+  background-color: rgba(40, 124, 233, 0.3);
+}
+
+.check-box StIcon {
+  icon-size: 0;
+  padding: 0;
+  border: none;
+  background-color: transparent;
+  color: transparent;
+}
+
+.check-box:checked StIcon {
+  background-color: transparent;
+  color: transparent;
+}
+
+.check-box:checked:hover StIcon {
+  background-color: transparent;
+  color: transparent;
+}
+
+.check-box:checked:active StIcon {
+  background-color: transparent;
+  color: transparent;
+}
+
+/* Switches */
+.toggle-switch {
+  width: 40px;
+  height: 20px;
+  background: transparent;
+  color: rgba(0, 0, 0, 0.87);
+  border: 1px solid rgba(0, 0, 0, 0.38);
+}
+
+.toggle-switch:hover {
+  background: transparent;
+  color: rgba(0, 0, 0, 0.87);
+  border: 1px solid rgba(0, 0, 0, 0.54);
+}
+
+.toggle-switch StIcon {
+  icon-size: 10px;
+}
+
+.toggle-switch .handle {
+  margin: 4px;
+  width: 12px;
+  height: 12px;
+  border-radius: 9999px;
+  background: rgba(0, 0, 0, 0.54);
+  box-shadow: none;
+  transition-duration: 100ms;
+}
+
+.toggle-switch:checked {
+  background: #1A73E8;
+  color: white;
+  border-color: #1A73E8;
+}
+
+.toggle-switch:checked:hover {
+  background-color: #3181ea;
+  color: white;
+  border-color: #3181ea;
+}
+
+.toggle-switch:checked .handle {
+  background: white;
+}
+
+/* Slider */
+.slider {
+  height: 12px;
+  color: #287ce9;
+  -barlevel-height: 2px;
+  -barlevel-background-color: rgba(0, 0, 0, 0.2);
+  -barlevel-active-background-color: #287ce9;
+  -barlevel-overdrive-color: #FF5252;
+  -barlevel-overdrive-separator-width: 2px;
+  -slider-handle-radius: 6px;
+}
+
+.slider:hover {
+  color: #3f8aec;
+}
+
+.slider:active {
+  color: #176ee1;
+}
+
+/* Scrollbars */
+StScrollView.vfade {
+  -st-vfade-offset: 32px;
+}
+
+StScrollView.hfade {
+  -st-hfade-offset: 32px;
+}
+
+StScrollBar {
+  padding: 0;
+}
+
+StScrollView StScrollBar {
+  min-width: 8px;
+  min-height: 8px;
+}
+
+StScrollBar StBin#trough {
+  border-radius: 9999px;
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+StScrollBar StButton#vhandle, StScrollBar StButton#hhandle {
+  border-radius: 9999px;
+  background-color: rgba(0, 0, 0, 0.38);
+  border: 4px solid transparent;
+}
+
+StScrollBar StButton#vhandle:hover, StScrollBar StButton#hhandle:hover {
+  background-color: rgba(0, 0, 0, 0.54);
+}
+
+StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
+  background-color: rgba(0, 0, 0, 0.87);
+}
+
+/* Popovers/Menus */
+.popup-menu-boxpointer, .candidate-popup-boxpointer {
+  -arrow-border-radius: 3px;
+  -arrow-background-color: transparent;
+  -arrow-border-width: 0;
+  -arrow-border-color: transparent;
+  -arrow-base: 27px;
+  -arrow-rise: 0;
+  -arrow-box-shadow: none;
+}
+
+.popup-menu {
+  min-width: 15em;
+  color: rgba(0, 0, 0, 0.87);
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+.popup-menu.panel-menu {
+  -boxpointer-gap: 4px;
+  margin-bottom: 1.75em;
+}
+
+.popup-menu-content {
+  padding: 6px;
+  margin: 2px 6px 10px;
+  border: none;
+}
+
+.popup-menu-item {
+  spacing: 6px;
+  padding: 6px 12px;
+  margin: 0;
+  color: rgba(0, 0, 0, 0.87);
+  transition-duration: 100ms;
+  border-radius: 3px;
+  background-image: none;
+  background-gradient-direction: none !important;
+}
+
+.popup-menu-item:ltr {
+  padding-right: 12px;
+  padding-left: 12px;
+}
+
+.popup-menu-item:rtl {
+  padding-right: 12px;
+  padding-left: 12px;
+}
+
+.popup-menu-item:checked {
+  background-color: rgba(0, 0, 0, 0.08) !important;
+  font-weight: normal;
+  border-radius: 3px 3px 0 0 !important;
+  border: none;
+  box-shadow: none;
+  color: rgba(0, 0, 0, 0.87) !important;
+  background-gradient-direction: none !important;
+}
+
+.popup-menu-item:checked.selected, .popup-menu-item:checked:hover, .popup-menu-item:checked:focus {
+  background-color: rgba(0, 0, 0, 0.1) !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+}
+
+.popup-menu-item:checked:active, .popup-menu-item:checked.selected:active {
+  background-color: rgba(0, 0, 0, 0.08) !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+}
+
+.popup-menu-item:checked:insensitive {
+  color: rgba(0, 0, 0, 0.38) !important;
+}
+
+.popup-menu-item.selected, .popup-menu-item:hover, .popup-menu-item:focus {
+  background-color: rgba(0, 0, 0, 0.06) !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+  transition-duration: 0ms;
+  background-gradient-direction: none !important;
+}
+
+.popup-menu-item:active {
+  background-color: rgba(0, 0, 0, 0.2) !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+  transition-duration: 150ms;
+  background-gradient-direction: none !important;
+}
+
+.popup-menu-item.selected:active {
+  color: rgba(0, 0, 0, 0.87) !important;
+}
+
+.popup-menu-item:insensitive {
+  color: rgba(0, 0, 0, 0.38) !important;
+}
+
+.popup-inactive-menu-item {
+  color: rgba(0, 0, 0, 0.87) !important;
+}
+
+.popup-inactive-menu-item:insensitive {
+  color: rgba(0, 0, 0, 0.38) !important;
+}
+
+.popup-menu-arrow,
+.popup-menu-icon {
+  icon-size: 16px;
+}
+
+.popup-sub-menu {
+  margin: 0;
+  background-color: rgba(0, 0, 0, 0.08) !important;
+  border-radius: 0 0 3px 3px !important;
+  border: none;
+  box-shadow: none;
+  background-image: none !important;
+}
+
+.popup-sub-menu .popup-menu-item {
+  margin: 0;
+  border-radius: 0;
+  background-image: none !important;
+  background-color: transparent !important;
+}
+
+.popup-sub-menu .popup-menu-item.selected, .popup-sub-menu .popup-menu-item:hover, .popup-sub-menu .popup-menu-item:focus {
+  background-color: rgba(0, 0, 0, 0.06) !important;
+}
+
+.popup-sub-menu .popup-menu-item:active {
+  background-color: rgba(0, 0, 0, 0.2) !important;
+}
+
+.popup-sub-menu .popup-menu-item:last-child {
+  border-radius: 0 0 3px 3px !important;
+  border-bottom-width: 0;
+}
+
+.popup-sub-menu .popup-menu-section .popup-menu-item:last-child:hover, .popup-sub-menu .popup-menu-section .popup-menu-item:last-child:focus {
+  border-radius: 0;
+}
+
+.popup-sub-menu .popup-menu-section:last-child .popup-menu-item:last-child {
+  border-radius: 0 0 3px 3px !important;
+}
+
+.popup-menu-ornament {
+  width: 1.2em;
+}
+
+.popup-menu-ornament:ltr {
+  text-align: right;
+}
+
+.popup-menu-ornament:rtl {
+  text-align: left;
+}
+
+.popup-separator-menu-item {
+  background: none;
+  border: none;
+  padding: 0 0;
+  margin: 0 0;
+  height: 4px;
+}
+
+.popup-separator-menu-item .popup-separator-menu-item-separator {
+  height: 1px;
+  margin: 0 0;
+  padding: 0 0;
+  background: none;
+}
+
+.popup-sub-menu .popup-separator-menu-item .popup-separator-menu-item-separator {
+  margin: 0 0;
+  padding: 0 0;
+  background: none;
+}
+
+.background-menu {
+  -boxpointer-gap: 4px;
+  -arrow-rise: 0px;
+}
+
+.aggregate-menu {
+  min-width: 21em;
+}
+
+.aggregate-menu .popup-menu-icon {
+  padding: 0;
+  margin: 0;
+  -st-icon-style: symbolic;
+}
+
+.aggregate-menu .popup-menu-icon:ltr {
+  margin-right: 4px;
+}
+
+.aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
+  padding-left: 12px !important;
+  margin-left: 0 !important;
+}
+
+.aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
+  padding-right: 12px !important;
+  margin-right: 0 !important;
+}
+
+/* Date/Time Menu */
+#calendarArea {
+  padding: 6px 0;
+}
+
+.datemenu-popover {
+  border-radius: 9px !important;
+}
+
+.calendar {
+  padding: 0;
+  margin: 0 6px;
+  border: none;
+  box-shadow: none;
+  background: none;
+  text-shadow: none;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.calendar .calendar-month-header .calendar-change-month-back StIcon,
+.calendar .calendar-month-header .calendar-change-month-forward StIcon {
+  icon-size: 1.091em;
+}
+
+.calendar .calendar-month-header .calendar-month-label {
+  background-color: transparent !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+  padding: 8px 0;
+  width: 10em;
+  text-align: center;
+}
+
+.calendar .calendar-day-heading {
+  width: 32px;
+  height: 25px;
+  margin-top: 2px;
+  padding: 7px 0 0;
+  border-radius: 9999px;
+  background-color: transparent !important;
+  color: rgba(0, 0, 0, 0.38) !important;
+  font-size: 9pt;
+  font-weight: 400;
+  font-weight: bold;
+  text-align: center;
+}
+
+.datemenu-calendar-column {
+  spacing: 6px;
+  border: none;
+  padding: 0;
+  margin: 0;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.datemenu-calendar-column:hover, .datemenu-calendar-column:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.datemenu-calendar-column:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.datemenu-calendar-column:ltr {
+  margin-right: 4px;
+  margin-left: 10px;
+  border-left-width: 0;
+}
+
+.datemenu-calendar-column:rtl {
+  margin-left: 4px;
+  margin-right: 10px;
+  border-right-width: 0;
+}
+
+.datemenu-calendar-column .datemenu-displays-section {
+  padding-bottom: 0;
+}
+
+.datemenu-calendar-column .datemenu-displays-box {
+  spacing: 6px;
+}
+
+.datemenu-today-button {
+  min-height: 56px;
+  padding: 6px;
+  border-radius: 3px;
+  border: none;
+  box-shadow: none;
+  text-shadow: none;
+  background: none;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.datemenu-today-button .day-label {
+  font-size: 15pt;
+  font-weight: 500;
+  font-weight: bold;
+}
+
+.datemenu-today-button .date-label {
+  font-size: 18pt;
+  font-weight: 400;
+}
+
+.datemenu-today-button:hover, .datemenu-today-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.datemenu-today-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.pager-button {
+  width: 32px;
+  height: 32px;
+  margin: 2px !important;
+  padding: 0 !important;
+  border-radius: 9999px;
+  background-color: transparent;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.pager-button:hover, .pager-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.pager-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.calendar-change-month-back {
+  padding: 2px !important;
+  background-image: url("assets/calendar-arrow-left.svg");
+}
+
+.calendar-change-month-back:rtl {
+  background-image: url("assets/calendar-arrow-right.svg");
+}
+
+.calendar-change-month-forward {
+  padding: 2px !important;
+  background-image: url("assets/calendar-arrow-right.svg");
+}
+
+.calendar-change-month-forward:rtl {
+  background-image: url("assets/calendar-arrow-left.svg");
+}
+
+.calendar-day {
+  font-size: 9pt;
+  font-weight: 400;
+  text-align: center;
+  width: 32px !important;
+  height: 32px !important;
+  padding: 2px !important;
+  margin: 2px !important;
+  border-radius: 9999px;
+  color: rgba(0, 0, 0, 0.54) !important;
+  background-color: transparent !important;
+  border: none;
+  font-feature-settings: "tnum";
+  text-shadow: none;
+}
+
+.calendar-day:hover, .calendar-day:focus {
+  background-color: rgba(0, 0, 0, 0.06) !important;
+  box-shadow: none !important;
+}
+
+.calendar-day:active {
+  color: rgba(0, 0, 0, 0.54) !important;
+  background-color: rgba(0, 0, 0, 0.2) !important;
+  border-color: transparent;
+}
+
+.calendar-day:selected {
+  color: rgba(0, 0, 0, 0.87) !important;
+  background-color: rgba(0, 0, 0, 0.2) !important;
+  border-color: transparent;
+  box-shadow: none !important;
+}
+
+.calendar-day {
+  border-width: 0;
+}
+
+.calendar-day-top {
+  border-top-width: 0;
+}
+
+.calendar-day-left {
+  border-left-width: 0;
+}
+
+.calendar-nonwork-day {
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.calendar-today {
+  font-weight: bold !important;
+  color: white !important;
+  background-color: #1A73E8 !important;
+  border: none;
+}
+
+.calendar-today:hover, .calendar-today:focus {
+  background-color: #287ce9 !important;
+  color: white !important;
+  box-shadow: none !important;
+}
+
+.calendar-today:active, .calendar-today:selected {
+  background-color: #1A73E8 !important;
+  color: white !important;
+  box-shadow: none !important;
+}
+
+.calendar-today:active:hover, .calendar-today:active:focus, .calendar-today:selected:hover, .calendar-today:selected:focus {
+  background-color: #287ce9 !important;
+  color: white !important;
+}
+
+.calendar-day-with-events {
+  color: rgba(0, 0, 0, 0.38);
+  background-image: url("assets/calendar-today.svg");
+}
+
+.calendar-day-with-events.calendar-work-day {
+  color: rgba(0, 0, 0, 0.38);
+  font-weight: bold;
+}
+
+.calendar-weekend {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.calendar-other-month {
+  color: rgba(0, 0, 0, 0.26) !important;
+  opacity: 1;
+  font-weight: normal;
+}
+
+.calendar-other-month.calendar-weekend {
+  color: rgba(0, 0, 0, 0.26) !important;
+}
+
+.calendar-week-number {
+  height: 1.8em !important;
+  width: 2.6em !important;
+  padding: 1px 0 !important;
+  margin: 6px 0 !important;
+  border-radius: 9999px;
+  background-color: rgba(0, 0, 0, 0.04);
+  color: rgba(0, 0, 0, 0.38);
+  font-size: inherit;
+  font-weight: bold;
+  text-align: center;
+  text-shadow: none;
+}
+
+.world-clocks-button,
+.weather-button,
+.events-button {
+  padding: 6px 8px;
+  border-radius: 3px;
+  box-shadow: none;
+  text-shadow: none;
+  color: rgba(0, 0, 0, 0.54);
+  background-color: rgba(255, 255, 255, 0.35) !important;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.world-clocks-button:hover, .world-clocks-button:focus,
+.weather-button:hover,
+.weather-button:focus,
+.events-button:hover,
+.events-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06) !important;
+  border-color: rgba(0, 0, 0, 0.15);
+  box-shadow: none;
+}
+
+.world-clocks-button:active,
+.weather-button:active,
+.events-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.08) !important;
+  box-shadow: none;
+}
+
+.world-clocks-header,
+.weather-header,
+.message-list-section-title,
+.events-section-title,
+.events-title {
+  color: rgba(0, 0, 0, 0.38);
+  font-weight: bold;
+  margin-bottom: 4px;
+  text-shadow: none;
+}
+
+.weather-grid,
+.world-clocks-grid {
+  spacing-rows: 8px;
+  spacing-columns: 16px;
+}
+
+.world-clocks-header,
+.weather-header,
+.events-section-title {
+  color: rgba(0, 0, 0, 0.38);
+  font-weight: bold;
+}
+
+.events-button .events-box {
+  spacing: 6px;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.events-button .events-list {
+  spacing: 12px;
+  text-shadow: none;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.events-button .event-time {
+  color: rgba(0, 0, 0, 0.26);
+  font-feature-settings: "tnum";
+}
+
+.world-clocks-button .world-clocks-city {
+  color: rgba(0, 0, 0, 0.38);
+  font-weight: normal;
+  font-size: 1em;
+}
+
+.world-clocks-button .world-clocks-time {
+  color: rgba(0, 0, 0, 0.38);
+  font-feature-settings: "tnum";
+  font-weight: bold;
+  font-size: 1em;
+}
+
+.world-clocks-button .world-clocks-time:ltr {
+  text-align: right;
+}
+
+.world-clocks-button .world-clocks-time:rtl {
+  text-align: left;
+}
+
+.world-clocks-button .world-clocks-timezone {
+  color: rgba(0, 0, 0, 0.38);
+  font-feature-settings: "tnum";
+  font-size: 1em;
+}
+
+.weather-button .weather-box {
+  spacing: 6px;
+}
+
+.weather-button .weather-header-box {
+  spacing: 6px;
+}
+
+.weather-button .weather-header.location {
+  font-weight: normal;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.weather-button .weather-forecast-icon {
+  icon-size: 32px;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.weather-button .weather-forecast-time {
+  color: rgba(0, 0, 0, 0.38);
+  font-size: 0.8em;
+  font-feature-settings: "tnum";
+  font-weight: normal;
+  padding-top: 0.2em;
+  padding-bottom: 0.4em;
+}
+
+.weather-button .weather-forecast-temp {
+  font-weight: bold;
+  color: rgba(0, 0, 0, 0.52);
+  text-shadow: none;
+}
+
+/* Message List */
+.message-list {
+  width: 29em;
+  padding: 0;
+  color: rgba(0, 0, 0, 0.54);
+  text-shadow: none;
+  box-shadow: none;
+  border: 0 solid rgba(0, 0, 0, 0.12);
+}
+
+.message-list:ltr {
+  margin-left: 6px;
+  margin-right: 0;
+  padding-right: 12px;
+  border-right-width: 1px;
+}
+
+.message-list:rtl {
+  margin-right: 6px;
+  margin-left: 0;
+  padding-left: 12px;
+  border-left-width: 1px;
+}
+
+.message-list .message-list-placeholder {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.message-list .message-list-placeholder > StIcon {
+  icon-size: 96px;
+  margin-bottom: 12px;
+  -st-icon-style: symbolic;
+}
+
+.message-view {
+  -st-vfade-offset: 68px;
+}
+
+.message-view:ltr {
+  margin-right: 0;
+}
+
+.message-view:rtl {
+  margin-left: 0;
+}
+
+.message-view .message {
+  margin-bottom: 12px !important;
+}
+
+.message-list-controls {
+  padding: 12px;
+  padding-bottom: 6px;
+  spacing: 6px;
+}
+
+.message-list-controls .dnd-button {
+  border-width: 2px;
+  border-color: transparent;
+  border-radius: 32px;
+  border-style: solid;
+}
+
+.message-list-controls .dnd-button:focus {
+  border-color: rgba(26, 115, 232, 0.6);
+}
+
+.message-notification-group {
+  spacing: 12px;
+}
+
+.message-notification-group .message-group-header {
+  padding: 6px;
+}
+
+.message-notification-group .message-group-header .message-group-title {
+  margin: 0 4px;
+}
+
+.message-notification-group .message-collapse-button {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.07);
+  padding: 4px;
+}
+
+.message-notification-group .message-collapse-button:hover {
+  background-color: rgba(0, 0, 0, 0.17);
+}
+
+.message-notification-group .message-collapse-button:active {
+  background-color: rgba(0, 0, 0, 0.07);
+}
+
+.message {
+  background-color: rgba(255, 255, 255, 0.35);
+  border-radius: 3px;
+  color: rgba(0, 0, 0, 0.54);
+  text-shadow: none;
+  padding: 0;
+  margin: 4px;
+  box-shadow: 0 3px 8px -2px rgba(0, 0, 0, 0.15);
+  background-color: rgba(255, 255, 255, 0.95);
+  border: 1px solid transparent;
+  border-left: none;
+  border-bottom: none;
+}
+
+.message:hover, .message:focus, .message:active {
+  background-color: #ffffff;
+}
+
+.popup-menu .message {
+  margin: 0 0 4px;
+  box-shadow: none;
+  background-color: rgba(255, 255, 255, 0.35);
+  border-radius: 3px;
+  color: rgba(0, 0, 0, 0.54);
+  border: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.popup-menu .message:hover, .popup-menu .message:focus {
+  background-color: rgba(0, 0, 0, 0.06);
+  border-color: rgba(0, 0, 0, 0.15);
+}
+
+.popup-menu .message:active {
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.message:second-in-stack {
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.message:lower-in-stack {
+  box-shadow: none;
+}
+
+.message .message-header {
+  padding: 0 0.409em;
+  spacing: 6px;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.message .message-header:ltr {
+  padding-right: 0;
+}
+
+.message .message-header:rtl {
+  padding-left: 0;
+}
+
+.message .message-header .message-source-icon {
+  icon-size: 1.091em;
+  -st-icon-style: symbolic;
+}
+
+.message .message-header .message-header-content {
+  spacing: 6px;
+  min-height: 1.637em;
+  padding-bottom: 6px;
+}
+
+.message .message-header .message-header-content .message-source-title {
+  font-weight: bold;
+}
+
+.message .message-header .message-header-content .event-time {
+  color: rgba(0, 0, 0, 0.38);
+  padding-bottom: 0.068em;
+}
+
+.message .message-header .message-header-content .event-time:ltr {
+  text-align: right;
+}
+
+.message .message-header .message-header-content .event-time:rtl {
+  text-align: left;
+}
+
+.message .message-header .message-expand-button,
+.message .message-header .message-close-button {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0);
+  padding: 4px;
+}
+
+.message .message-header .message-expand-button:hover,
+.message .message-header .message-close-button:hover {
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.message .message-header .message-expand-button:active, .message .message-header .message-expand-button:active:hover,
+.message .message-header .message-close-button:active,
+.message .message-header .message-close-button:active:hover {
+  background-color: rgba(0, 0, 0, 0.11);
+}
+
+.message .message-header .message-expand-button:insensitive,
+.message .message-header .message-close-button:insensitive {
+  background-color: rgba(0, 0, 0, 0);
+}
+
+.message .message-header .message-expand-button {
+  padding: 6px;
+}
+
+.message .message-header .message-expand-button:ltr {
+  margin-right: 6px;
+}
+
+.message .message-header .message-expand-button:rtl {
+  margin-left: 6px;
+}
+
+.message .message-box {
+  padding: 6px;
+  margin: 6px;
+  margin-top: 0;
+  spacing: 6px;
+}
+
+.message .message-box .message-icon {
+  icon-size: 48px;
+  -st-icon-style: symbolic;
+}
+
+.message .message-box .message-icon:ltr {
+  margin-right: 6px;
+}
+
+.message .message-box .message-icon:rtl {
+  margin-left: 6px;
+}
+
+.message .message-box .message-icon.message-themed-icon {
+  border-radius: 9999px;
+  background-color: rgba(0, 0, 0, 0.07);
+  icon-size: 16px;
+  min-width: 48px;
+  min-height: 48px;
+}
+
+.message .message-box:first-child {
+  margin-top: 12px;
+}
+
+.message .message-box .message-content {
+  spacing: 4px;
+}
+
+.message .message-box .message-content .message-title {
+  font-weight: bold;
+}
+
+.url-highlighter {
+  link-color: #1A73E8;
+}
+
+/* Media Controls */
+.message-media-control {
+  margin: 4px 0;
+  padding: 0 12px;
+  border-radius: 9999px;
+  color: rgba(0, 0, 0, 0.54);
+  border: none;
+}
+
+.message-media-control:hover, .message-media-control:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.message-media-control:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.message-media-control:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.message-media-control StIcon {
+  icon-size: 16px;
+}
+
+.media-message .message-icon {
+  border-radius: 3px !important;
+}
+
+.media-message .message-icon.message-themed-icon {
+  icon-size: 32px !important;
+}
+
+.candidate-popup-content {
+  background-color: rgba(255, 255, 255, 0.97);
+  border-radius: 3px;
+  box-shadow: 0 3px 8px -2px rgba(0, 0, 0, 0.25) !important;
+  margin: 3px 8px 11px;
+  padding: 6px;
+  spacing: 6px;
+  border: 1px solid transparent;
+}
+
+.candidate-index {
+  padding: 0 0.5em 0 0;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.candidate-box {
+  padding: 0.3em 0.5em 0.3em 0.5em;
+  margin-right: 3px;
+  border-radius: 3px;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.candidate-box:hover {
+  background-color: rgba(0, 0, 0, 0.06);
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.candidate-box:active {
+  background-color: rgba(0, 0, 0, 0.2);
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.candidate-box:selected {
+  background-color: rgba(0, 0, 0, 0.06);
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.candidate-box:last-child {
+  margin-right: 0;
+}
+
+.candidate-page-button-box {
+  height: 2em;
+}
+
+.vertical .candidate-page-button-box {
+  padding-top: 0.5em;
+}
+
+.horizontal .candidate-page-button-box {
+  padding-left: 0.5em;
+}
+
+.candidate-page-button {
+  padding: 4px;
+}
+
+.candidate-page-button-previous {
+  border-radius: 3px 0px 0px 3px;
+  border-right-width: 0;
+}
+
+.candidate-page-button-next {
+  border-radius: 0px 3px 3px 0px;
+}
+
+.candidate-page-button-icon {
+  icon-size: 1em;
+}
+
+/* Notifications & Message Tray */
+.notification-banner {
+  min-height: 64px;
+  width: 34em;
+  margin: 6px;
+  border-radius: 6px;
+}
+
+.notification-buttons-bin {
+  spacing: 0;
+  padding: 0 6px 6px;
+  margin: 0;
+  border: none;
+}
+
+.notification-button {
+  min-height: 24px;
+  padding: 6px 12px;
+  font-weight: bold;
+}
+
+.hotplug-notification-item {
+  padding: 2px 10px;
+  border-top: 1px solid rgba(0, 0, 0, 0.12);
+  text-shadow: none;
+  font-size: 10.5pt;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.54);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.hotplug-notification-item:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+  box-shadow: none;
+}
+
+.hotplug-notification-item:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+.hotplug-notification-item:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.hotplug-notification-item:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: none;
+}
+
+.hotplug-notification-item:first-child {
+  border-radius: 0 0 0 3px;
+}
+
+.hotplug-notification-item:last-child {
+  border-radius: 0 0 3px 0;
+}
+
+.hotplug-notification-item:first-child:last-child {
+  border-radius: 0 0 3px 3px;
+}
+
+.hotplug-notification-item-icon {
+  icon-size: 24px;
+  padding: 0 4px;
+}
+
+/* Modal Dialogs */
+.headline {
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+.modal-dialog {
+  padding: 0;
+}
+
+.modal-dialog .modal-dialog-content-box {
+  margin: 32px 40px 42px;
+  spacing: 32px;
+  max-width: 28em;
+}
+
+.modal-dialog .modal-dialog-button-box {
+  padding: 12px;
+  background: rgba(0, 0, 0, 0.06);
+  border-radius: 0 0 6px 6px;
+  border-top: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.modal-dialog .modal-dialog-button {
+  font-weight: bold;
+  background-gradient-direction: none !important;
+  margin: 0 !important;
+}
+
+/* End Session Dialog */
+.end-session-dialog {
+  width: 30em;
+}
+
+.end-session-dialog .end-session-dialog-battery-warning,
+.end-session-dialog .dialog-list-title {
+  color: #FF6D00;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child {
+  background-color: #FF5252 !important;
+  color: white !important;
+  border-color: rgba(224, 72, 72, 0.9805) !important;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child:hover {
+  background-color: #ff8080 !important;
+  border-color: rgba(203, 65, 65, 0.9675) !important;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child:active {
+  background-color: #ff5c5c !important;
+  border-color: rgba(203, 65, 65, 0.9675) !important;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child:insensitive {
+  color: rgba(255, 255, 255, 0.5) !important;
+  background-color: rgba(255, 82, 82, 0.35) !important;
+  border-color: rgba(235, 76, 76, 0.987) !important;
+}
+
+/* Message Dialog */
+.message-dialog-content {
+  spacing: 18px;
+}
+
+.message-dialog-content .message-dialog-title {
+  text-align: center;
+  font-size: 18pt;
+  font-weight: 800;
+}
+
+.message-dialog-content .message-dialog-title.lightweight {
+  font-size: 13pt;
+  font-weight: 800;
+}
+
+.message-dialog-content .message-dialog-description {
+  text-align: center;
+}
+
+/* Dialog List */
+.dialog-list {
+  spacing: 18px;
+}
+
+.dialog-list .dialog-list-title {
+  text-align: center;
+  font-weight: bold;
+}
+
+.dialog-list .dialog-list-scrollview {
+  max-height: 200px;
+}
+
+.dialog-list .dialog-list-box {
+  spacing: 1em;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item {
+  spacing: 1em;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item .dialog-list-item-title {
+  font-weight: bold;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item .dialog-list-item-description {
+  color: rgba(0, 0, 0, 0.54);
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+/* Run Dialog */
+.run-dialog .modal-dialog-content-box {
+  margin-top: 24px;
+  margin-bottom: 14px;
+}
+
+.run-dialog .run-dialog-entry {
+  width: 20em;
+}
+
+.run-dialog .run-dialog-description {
+  font-size: 12pt;
+  font-weight: 400;
+  text-align: center;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+/* Password or Authentication Dialog */
+.prompt-dialog {
+  width: 28em;
+}
+
+.prompt-dialog .modal-dialog-content-box {
+  margin-bottom: 24px;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child {
+  background-color: #287ce9 !important;
+  color: white !important;
+  border-color: rgba(35, 109, 205, 0.9805) !important;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:hover {
+  background-color: #5295ee !important;
+  border-color: rgba(32, 98, 186, 0.9675) !important;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:active {
+  background-color: #3181ea !important;
+  border-color: rgba(32, 98, 186, 0.9675) !important;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:insensitive {
+  color: rgba(255, 255, 255, 0.5) !important;
+  background-color: rgba(40, 124, 233, 0.35) !important;
+  border-color: rgba(37, 114, 215, 0.987) !important;
+}
+
+.prompt-dialog-password-grid {
+  spacing-rows: 8px;
+  spacing-columns: 4px;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry {
+  width: auto;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry:ltr {
+  margin-left: 20px;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry:rtl {
+  margin-right: 20px;
+}
+
+.prompt-dialog-password-layout {
+  spacing: 8px;
+}
+
+.prompt-dialog-password-entry {
+  width: 20em;
+}
+
+.prompt-dialog-error-label,
+.prompt-dialog-info-label,
+.prompt-dialog-null-label {
+  text-align: center;
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+.prompt-dialog-error-label {
+  color: #FF6D00;
+}
+
+/* Polkit Dialog */
+.polkit-dialog-user-layout {
+  text-align: center;
+  spacing: 8px;
+  margin-bottom: 6px;
+}
+
+.polkit-dialog-user-layout .polkit-dialog-user-root-label {
+  color: #FF6D00;
+}
+
+/* Audio selection dialog */
+.audio-device-selection-dialog .modal-dialog-content-box {
+  margin-bottom: 28px;
+}
+
+.audio-device-selection-dialog .audio-selection-box {
+  spacing: 20px;
+}
+
+.audio-selection-device {
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 3px;
+}
+
+.audio-selection-device:active, .audio-selection-device:hover, .audio-selection-device:focus {
+  background-color: #1A73E8;
+}
+
+.audio-selection-device-box {
+  padding: 20px;
+  spacing: 20px;
+}
+
+.audio-selection-device-icon {
+  icon-size: 64px;
+}
+
+/* Welcome dialog */
+.welcome-dialog-image {
+  background-image: url("resource:///org/gnome/shell/theme/gnome-shell-start.svg");
+  background-size: contain;
+  /* Reasonable maximum dimensions */
+  height: 300px;
+  width: 300px;
+}
+
+/* Network Dialogs */
+.nm-dialog {
+  max-height: 34em;
+  min-height: 31em;
+  min-width: 32em;
+}
+
+.nm-dialog-content {
+  spacing: 20px;
+  padding: 24px;
+}
+
+.nm-dialog-airplane-box {
+  spacing: 12px;
+}
+
+.nm-dialog-airplane-headline {
+  font-weight: bold;
+  text-align: center;
+}
+
+.nm-dialog-airplane-text {
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.nm-dialog-header {
+  font-weight: bold;
+}
+
+.nm-dialog-header-icon {
+  icon-size: 32px;
+}
+
+.nm-dialog-header-hbox {
+  spacing: 10px;
+}
+
+.nm-dialog-scroll-view {
+  border: none;
+  background-color: rgba(0, 0, 0, 0.06);
+  border-radius: 3px;
+  padding: 12px;
+  padding-right: 0;
+}
+
+.nm-dialog-item {
+  font-size: 1em;
+  border-bottom: none;
+  border-radius: -3px;
+  padding: 12px;
+  spacing: 0px;
+}
+
+.nm-dialog-item:hover, .nm-dialog-item:focus {
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.nm-dialog-item:active {
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.nm-dialog-item:selected {
+  background-color: #1A73E8;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.nm-dialog-icon {
+  icon-size: 16px;
+}
+
+.nm-dialog-icons {
+  spacing: 12px;
+}
+
+.no-networks-label {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.no-networks-box {
+  spacing: 6px;
+}
+
+/* OSD */
+.screenshot-ui-panel, .workspace-switcher-container, .switcher-list, .resize-popup, .osd-window {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #222222;
+  border: none;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.35);
+  border-radius: 3px;
+  padding: 12px;
+}
+
+.osd-window {
+  text-align: center;
+  font-weight: bold;
+  spacing: 12px;
+  padding: 12px 18px;
+  margin-bottom: 4em;
+}
+
+.osd-window > * {
+  spacing: 8px;
+}
+
+.osd-window StIcon {
+  icon-size: 32px;
+}
+
+.osd-window StLabel:ltr {
+  margin-right: 6px;
+}
+
+.osd-window StLabel:rtl {
+  margin-left: 6px;
+}
+
+.osd-window .osd-monitor-label {
+  font-size: 3em;
+}
+
+.osd-window .level {
+  height: 4px;
+  -barlevel-height: 4px;
+  -barlevel-background-color: rgba(26, 115, 232, 0.3);
+  -barlevel-active-background-color: #1A73E8;
+  -barlevel-overdrive-color: #FF5252;
+  -barlevel-overdrive-separator-width: 3px;
+  -barlevel-border-width: 0;
+}
+
+/* Pad OSD */
+.pad-osd-window {
+  padding: 32px;
+  background-color: rgba(0, 0, 0, 0.8);
+  border: none;
+}
+
+.pad-osd-window .pad-osd-title-box {
+  spacing: 12px;
+}
+
+.pad-osd-window .pad-osd-title-menu-box {
+  spacing: 6px;
+}
+
+.combo-box-label {
+  width: 15em;
+}
+
+/* App Switcher */
+.switcher-popup {
+  padding: 8px;
+  spacing: 24px;
+}
+
+.switcher-list .item-box {
+  padding: 8px;
+  border-radius: 3px;
+  border: none;
+}
+
+.switcher-list .item-box:outlined {
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.switcher-list .item-box:selected {
+  background-color: #1A73E8;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.switcher-list .thumbnail-box {
+  padding: 2px;
+  spacing: 6px;
+}
+
+.switcher-list .thumbnail {
+  width: 256px;
+}
+
+.switcher-list .separator {
+  width: 1px;
+  background: rgba(0, 0, 0, 0.12);
+}
+
+.switcher-list .switcher-list-item-container {
+  spacing: 12px;
+}
+
+.switcher-arrow {
+  border-color: rgba(0, 0, 0, 0);
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.switcher-arrow:highlighted {
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.input-source-switcher-symbol {
+  font-size: 34pt;
+  width: 96px;
+  height: 96px;
+}
+
+.cycler-highlight {
+  border: 5px solid #1A73E8;
+}
+
+/* Workspace Switcher */
+.workspace-switcher-group {
+  padding: 12px;
+}
+
+.workspace-switcher {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  spacing: 12px;
+}
+
+.ws-switcher-box {
+  height: 50px;
+  background-size: 32px;
+  border: none;
+  background: rgba(0, 0, 0, 0.06);
+  border-radius: 3px;
+}
+
+.ws-switcher-active-up,
+.ws-switcher-active-down,
+.ws-switcher-active-left,
+.ws-switcher-active-right {
+  height: 52px;
+  background-color: #1A73E8;
+  border: none;
+  border-radius: 6px;
+  color: #FFFFFF;
+}
+
+/* Top Bar */
+#panel .panel-button#panelActivities {
+  -natural-hpadding: 15px;
+}
+
+#panel .panel-button#panelActivities StBoxLayout {
+  spacing: 6px;
+}
+
+#panel .panel-button#panelActivities .workspace-dot {
+  border-radius: 9999px;
+  min-width: 8px;
+  min-height: 8px;
+  background-color: rgba(0, 0, 0, 0.88);
+}
+
+#panel {
+  font-weight: normal;
+  font-feature-settings: "tnum";
+  transition-duration: 250ms;
+  border: none;
+  box-shadow: none;
+  background-color: rgba(255, 255, 255, 0.5);
+  margin: 0;
+  border-radius: 0;
+  height: 34px;
+}
+
+#panel #panelLeft, #panel #panelCenter {
+  spacing: 0;
+}
+
+#panel .panel-corner {
+  -panel-corner-radius: 0;
+  -panel-corner-background-color: rgba(255, 255, 255, 0.5);
+  -panel-corner-border-width: 0;
+  -panel-corner-border-color: transparent;
+  -panel-corner-opacity: 0;
+  transition-duration: 250ms;
+}
+
+#panel .panel-button {
+  -natural-hpadding: 8px;
+  -minimum-hpadding: 8px;
+  font-weight: normal;
+  color: rgba(0, 0, 0, 0.75);
+  transition-duration: 150ms;
+  text-shadow: none;
+  border-radius: 0;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#panel .panel-button StLabel {
+  padding: 0;
+}
+
+#panel .panel-button:hover {
+  color: rgba(0, 0, 0, 0.75);
+  background-color: rgba(255, 255, 255, 0.35);
+}
+
+#panel .panel-button:active, #panel .panel-button:checked, #panel .panel-button:focus {
+  color: rgba(0, 0, 0, 0.88);
+  background-color: rgba(255, 255, 255, 0.5);
+}
+
+#panel .panel-button:hover, #panel .panel-button:active, #panel .panel-button:overview, #panel .panel-button:focus, #panel .panel-button:checked {
+  text-shadow: none;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#panel .panel-button.clock-display {
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#panel .panel-button.clock-display:hover {
+  color: rgba(0, 0, 0, 0.75);
+  background-color: rgba(255, 255, 255, 0.35) !important;
+}
+
+#panel .panel-button.clock-display:active, #panel .panel-button.clock-display:checked, #panel .panel-button.clock-display:focus {
+  color: rgba(0, 0, 0, 0.88);
+  background-color: rgba(255, 255, 255, 0.5) !important;
+}
+
+#panel .panel-button.clock-display:active .clock, #panel .panel-button.clock-display:checked .clock, #panel .panel-button.clock-display:focus .clock {
+  box-shadow: none;
+  background: none;
+  color: rgba(0, 0, 0, 0.88);
+}
+
+#panel .panel-button.clock-display:hover, #panel .panel-button.clock-display:active, #panel .panel-button.clock-display:checked, #panel .panel-button.clock-display:focus {
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#panel .panel-button.clock-display .clock {
+  color: rgba(0, 0, 0, 0.75);
+  transition-duration: 150ms;
+  border: none;
+  border-radius: 0;
+}
+
+#panel .panel-button.clock-display .messages-indicator {
+  icon-size: 1.091em;
+}
+
+#panel .panel-button .system-status-icon {
+  icon-size: 16px;
+  padding: 6px;
+  margin: 0 3px;
+}
+
+#panel .panel-button .panel-status-menu-box .system-status-icon {
+  margin: 0;
+}
+
+#panel .panel-button .panel-status-menu-box StLabel {
+  padding: 0 0 0 3px;
+}
+
+#panel .panel-button .panel-status-menu-box,
+#panel .panel-button .panel-status-indicators-box {
+  spacing: 3px;
+}
+
+#panel .panel-button .appindicator-trayicons-box,
+#panel .panel-button .panel-status-indicators-box.appindicator-box {
+  margin: 0 6px;
+}
+
+#panel .panel-button .clipboard-indicator-icon {
+  margin: 0 6px;
+}
+
+#panel .panel-button .app-menu-icon {
+  -st-icon-style: symbolic;
+}
+
+#panel.unlock-screen, #panel.login-screen, #panel.lock-screen, #panel:overview {
+  background-color: transparent;
+}
+
+#panel.unlock-screen .panel-button, #panel.login-screen .panel-button, #panel.lock-screen .panel-button, #panel:overview .panel-button {
+  border-radius: 3px;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+}
+
+#panel.unlock-screen .panel-button:hover, #panel.login-screen .panel-button:hover, #panel.lock-screen .panel-button:hover, #panel:overview .panel-button:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#panel.unlock-screen .panel-button:active, #panel.unlock-screen .panel-button:checked, #panel.unlock-screen .panel-button:focus, #panel.login-screen .panel-button:active, #panel.login-screen .panel-button:checked, #panel.login-screen .panel-button:focus, #panel.lock-screen .panel-button:active, #panel.lock-screen .panel-button:checked, #panel.lock-screen .panel-button:focus, #panel:overview .panel-button:active, #panel:overview .panel-button:checked, #panel:overview .panel-button:focus {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+#panel.unlock-screen .panel-button.clock-display:hover, #panel.login-screen .panel-button.clock-display:hover, #panel.lock-screen .panel-button.clock-display:hover, #panel:overview .panel-button.clock-display:hover {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#panel.unlock-screen .panel-button.clock-display:active, #panel.unlock-screen .panel-button.clock-display:checked, #panel.unlock-screen .panel-button.clock-display:focus, #panel.login-screen .panel-button.clock-display:active, #panel.login-screen .panel-button.clock-display:checked, #panel.login-screen .panel-button.clock-display:focus, #panel.lock-screen .panel-button.clock-display:active, #panel.lock-screen .panel-button.clock-display:checked, #panel.lock-screen .panel-button.clock-display:focus, #panel:overview .panel-button.clock-display:active, #panel:overview .panel-button.clock-display:checked, #panel:overview .panel-button.clock-display:focus {
+  background-color: rgba(255, 255, 255, 0.3) !important;
+}
+
+#panel.unlock-screen .panel-button.clock-display .clock, #panel.login-screen .panel-button.clock-display .clock, #panel.lock-screen .panel-button.clock-display .clock, #panel:overview .panel-button.clock-display .clock {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+#panel.unlock-screen .panel-button#panelActivities, #panel.login-screen .panel-button#panelActivities, #panel.lock-screen .panel-button#panelActivities, #panel:overview .panel-button#panelActivities {
+  box-shadow: none;
+  border: none;
+  background-color: transparent;
+}
+
+#panel.unlock-screen .panel-button#panelActivities:hover, #panel.login-screen .panel-button#panelActivities:hover, #panel.lock-screen .panel-button#panelActivities:hover, #panel:overview .panel-button#panelActivities:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#panel.unlock-screen .panel-button#panelActivities .workspace-dot, #panel.login-screen .panel-button#panelActivities .workspace-dot, #panel.lock-screen .panel-button#panelActivities .workspace-dot, #panel:overview .panel-button#panelActivities .workspace-dot {
+  background-color: rgba(255, 255, 255, 0.85);
+}
+
+#panel.unlock-screen .panel-corner, #panel.login-screen .panel-corner, #panel.lock-screen .panel-corner, #panel:overview .panel-corner {
+  -panel-corner-opacity: 0;
+  -panel-corner-radius: 0;
+  -panel-corner-background-color: transparent;
+  -panel-corner-border-color: transparent;
+}
+
+#panel Gjs_ui_panel_AggregateMenu.panel-button .system-status-icon {
+  margin: 0 !important;
+  padding: 6px !important;
+}
+
+#panel Gjs_kimpanel_kde_org_indicator_KimIndicator.panel-button .panel-status-menu-box {
+  margin: 0 6px;
+}
+
+#panel .screencast-indicator,
+#panel .remote-access-indicator {
+  color: #FF6D00;
+}
+
+#appMenu {
+  spacing: 6px;
+}
+
+#appMenu .label-shadow {
+  color: transparent;
+}
+
+#appMenu .panel-status-menu-box {
+  padding: 0 6px;
+  spacing: 6px;
+}
+
+/* Activities Ripple */
+.ripple-box {
+  background-color: rgba(26, 115, 232, 0.35);
+  width: 52px;
+  height: 52px;
+  border-radius: 0 0 52px 0;
+}
+
+.ripple-box:rtl {
+  border-radius: 0 0 0 52px;
+}
+
+/* OVERVIEW */
+.controls-manager, .secondary-monitor-workspaces {
+  spacing: 12px;
+}
+
+#overviewGroup {
+  background-color: #222222;
+}
+
+.overview-controls {
+  padding-bottom: 32px;
+}
+
+/* Window Picker */
+.window-picker {
+  spacing: 6px;
+}
+
+.window-caption {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(32, 32, 32, 0.9);
+  border-radius: 6px;
+  padding: 6px 12px;
+}
+
+.window-close, .screenshot-ui-close-button {
+  background-color: #1A73E8;
+  color: white;
+  border-radius: 9999px;
+  padding: 3px;
+  height: 30px;
+  width: 30px;
+  box-shadow: -1px 1px 5px 0px rgba(0, 0, 0, 0.5);
+  transition-duration: 300ms;
+}
+
+.window-close StIcon, .screenshot-ui-close-button StIcon {
+  icon-size: 24px;
+}
+
+.window-close:hover, .screenshot-ui-close-button:hover {
+  background-color: #609eef;
+}
+
+.window-close:active, .screenshot-ui-close-button:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #1567d3;
+}
+
+.workspace-background {
+  border-radius: 30px;
+  background-color: #222222;
+  box-shadow: 0 4px 16px 4px rgba(0, 0, 0, 0.3);
+  border: none;
+}
+
+.search-entry {
+  min-height: 24px;
+  padding: 3px 6px;
+  width: 320px;
+  border: none !important;
+  border-radius: 3px;
+  selection-background-color: #1A73E8;
+  selected-color: #FFFFFF !important;
+  caret-color: rgba(0, 0, 0, 0.54);
+  color: rgba(0, 0, 0, 0.54);
+  background-color: #ffffff;
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+.search-entry:hover {
+  border: 2px solid rgba(0, 0, 0, 0.2) !important;
+}
+
+.search-entry:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #1A73E8 !important;
+}
+
+.search-entry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.search-entry .search-entry-icon {
+  icon-size: 16px;
+  padding: 0 4px;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.search-entry StLabel.hint-text {
+  margin-left: 2px;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+#overview .search-entry {
+  min-height: 24px;
+  padding: 6px 9px;
+  margin-top: 12px;
+  margin-bottom: 6px;
+  border-radius: 5px;
+  caret-color: rgba(0, 0, 0, 0.75);
+  color: rgba(0, 0, 0, 0.75);
+  background-color: rgba(255, 255, 255, 0.75) !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#overview .search-entry:hover {
+  color: rgba(0, 0, 0, 0.75);
+  background-color: rgba(255, 255, 255, 0.85) !important;
+}
+
+#overview .search-entry:focus {
+  color: rgba(0, 0, 0, 0.85);
+  background-color: rgba(255, 255, 255, 0.95) !important;
+  border: none !important;
+  selection-background-color: #1A73E8;
+  selected-color: #FFFFFF !important;
+}
+
+#overview .search-entry .search-entry-icon {
+  color: rgba(0, 0, 0, 0.65);
+}
+
+#overview .search-entry:hover .search-entry-icon, #overview .search-entry:focus .search-entry-icon {
+  color: rgba(0, 0, 0, 0.75);
+}
+
+#overview .search-entry StLabel.hint-text {
+  color: rgba(0, 0, 0, 0.35);
+}
+
+/* Search */
+#searchResults {
+  margin: 0 8px;
+}
+
+#searchResultsContent {
+  max-width: 1044px;
+}
+
+.search-section {
+  spacing: 12px;
+}
+
+.search-section .search-section-separator {
+  height: 8px;
+  background-color: transparent;
+}
+
+.search-section-content {
+  background-color: rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.1);
+  text-shadow: none;
+  color: rgba(255, 255, 255, 0.85);
+  padding: 18px;
+  spacing: 8px;
+}
+
+.list-search-result, .search-provider-icon {
+  border-radius: 6px;
+}
+
+.search-statustext {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.grid-search-results {
+  spacing: 36px;
+  margin: 0 12px;
+}
+
+.search-provider-icon:ltr {
+  margin-right: 4px;
+}
+
+.search-provider-icon:rtl {
+  margin-left: 4px;
+}
+
+.search-provider-icon .list-search-provider-content {
+  spacing: 12px;
+}
+
+.search-provider-icon .list-search-provider-content .list-search-provider-details {
+  width: 120px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.list-search-results {
+  spacing: 6px;
+}
+
+.list-search-result .list-search-result-content {
+  spacing: 6px;
+}
+
+.list-search-result .list-search-result-title {
+  spacing: 12px;
+}
+
+.list-search-result .list-search-result-description {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+/* Dash */
+#dash {
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+#dash .dash-background {
+  background-color: rgba(255, 255, 255, 0.2);
+  border-radius: 15px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+#dash .dash-item-container .placeholder {
+  background-image: none;
+  background-size: contain;
+  height: 32px;
+}
+
+#dash .dash-item-container .empty-dash-drop-target {
+  width: 32px;
+  height: 32px;
+}
+
+#dash .dash-item-container .show-apps,
+#dash .dash-item-container .overview-tile,
+#dash .dash-item-container .grid-search-result,
+#dash .dash-item-container .search-provider-icon,
+#dash .dash-item-container .list-search-result {
+  margin: 0 2px;
+  padding-bottom: 12px;
+}
+
+#dash .dash-item-container .show-apps .overview-icon,
+#dash .dash-item-container .overview-tile .overview-icon,
+#dash .dash-item-container .grid-search-result .overview-icon,
+#dash .dash-item-container .search-provider-icon .overview-icon,
+#dash .dash-item-container .list-search-result .overview-icon {
+  background-color: transparent;
+}
+
+#dash .dash-item-container .show-apps:focus .overview-icon,
+#dash .dash-item-container .overview-tile:focus .overview-icon,
+#dash .dash-item-container .grid-search-result:focus .overview-icon,
+#dash .dash-item-container .search-provider-icon:focus .overview-icon,
+#dash .dash-item-container .list-search-result:focus .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#dash .dash-item-container .show-apps:hover .overview-icon,
+#dash .dash-item-container .overview-tile:hover .overview-icon,
+#dash .dash-item-container .grid-search-result:hover .overview-icon,
+#dash .dash-item-container .search-provider-icon:hover .overview-icon,
+#dash .dash-item-container .list-search-result:hover .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#dash .dash-item-container .show-apps:active .overview-icon,
+#dash .dash-item-container .overview-tile:active .overview-icon,
+#dash .dash-item-container .grid-search-result:active .overview-icon,
+#dash .dash-item-container .search-provider-icon:active .overview-icon,
+#dash .dash-item-container .list-search-result:active .overview-icon {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+#dash .dash-item-container .show-apps:checked .overview-icon,
+#dash .dash-item-container .overview-tile:checked .overview-icon,
+#dash .dash-item-container .grid-search-result:checked .overview-icon,
+#dash .dash-item-container .search-provider-icon:checked .overview-icon,
+#dash .dash-item-container .list-search-result:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+#dash .dash-item-container .show-apps:insensitive .overview-icon,
+#dash .dash-item-container .overview-tile:insensitive .overview-icon,
+#dash .dash-item-container .grid-search-result:insensitive .overview-icon,
+#dash .dash-item-container .search-provider-icon:insensitive .overview-icon,
+#dash .dash-item-container .list-search-result:insensitive .overview-icon {
+  background-color: transparent;
+}
+
+#dash .dash-item-container .app-grid-running-dot {
+  offset-y: -12px;
+}
+
+#dash .dash-separator {
+  width: 1px;
+  margin-left: 4px;
+  margin-right: 4px;
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#dash .dash-separator,
+#dash .dash-background {
+  margin-bottom: 12px;
+}
+
+.dash-label {
+  border-radius: 3px;
+  padding: 6px 12px;
+  margin: 6px;
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(0, 0, 0, 0.75);
+  border: none;
+  box-shadow: none;
+  text-align: center;
+  -y-offset: 4px;
+}
+
+/* App Grid */
+.icon-grid {
+  row-spacing: 12px;
+  column-spacing: 12px;
+  max-row-spacing: 36px;
+  max-column-spacing: 36px;
+  page-padding-top: 24px;
+  page-padding-bottom: 24px;
+  page-padding-left: 18px;
+  page-padding-right: 18px;
+}
+
+/* App Icons */
+.overview-tile, .grid-search-result, .search-provider-icon, .list-search-result {
+  border-radius: 9px;
+  padding: 12px;
+  spacing: 6px;
+  transition-duration: 150ms;
+  text-align: center;
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.85);
+  border: 1px solid transparent;
+  box-shadow: inset 0 1px transparent;
+}
+
+.overview-tile:hover, .grid-search-result:hover, .search-provider-icon:hover, .list-search-result:hover, .overview-tile:focus, .grid-search-result:focus, .search-provider-icon:focus, .list-search-result:focus, .overview-tile:highlighted, .grid-search-result:highlighted, .search-provider-icon:highlighted, .list-search-result:highlighted, .overview-tile:selected, .grid-search-result:selected, .search-provider-icon:selected, .list-search-result:selected {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+  transition-duration: 0ms;
+  border-image: none;
+  background-image: none;
+}
+
+.overview-tile:active, .grid-search-result:active, .search-provider-icon:active, .list-search-result:active, .overview-tile:checked, .grid-search-result:checked, .search-provider-icon:checked, .list-search-result:checked {
+  background-color: rgba(255, 255, 255, 0.15);
+  transition-duration: 150ms;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.overview-tile .overview-icon.overview-icon-with-label > StBoxLayout, .grid-search-result .overview-icon.overview-icon-with-label > StBoxLayout, .search-provider-icon .overview-icon.overview-icon-with-label > StBoxLayout, .list-search-result .overview-icon.overview-icon-with-label > StBoxLayout {
+  spacing: 6px;
+}
+
+.app-folder {
+  background-color: rgba(255, 255, 255, 0.13);
+}
+
+.app-folder:focus {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.app-folder:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.app-folder:active {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.app-folder:highlighted, .app-folder:selected, .app-folder:checked {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.app-folder:insensitive {
+  background-color: transparent;
+}
+
+.app-grid-running-dot {
+  width: 6px;
+  height: 3px;
+  border-radius: 2px;
+  background-color: rgba(255, 255, 255, 0.5);
+  margin-bottom: 1px;
+}
+
+StWidget.focused .app-grid-running-dot {
+  width: 18px;
+  background-color: #1A73E8;
+}
+
+.app-folder-dialog-container {
+  padding-top: 34px;
+}
+
+.app-folder-dialog {
+  width: 720px;
+  height: 720px;
+  border-radius: 12px;
+  background-color: rgba(34, 34, 34, 0.95);
+  color: white;
+  border: none;
+  box-shadow: none;
+}
+
+.app-folder-dialog .folder-name-container {
+  padding: 24px 36px 0;
+  spacing: 12px;
+  /* FIXME: this is to keep the label in sync with the entry */
+}
+
+.app-folder-dialog .folder-name-container .folder-name-label, .app-folder-dialog .folder-name-container .folder-name-entry {
+  font-size: 18pt;
+  font-weight: 800;
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry {
+  border: none;
+  color: #FFFFFF;
+  background-color: rgba(255, 255, 255, 0.15);
+  caret-color: #FFFFFF;
+  selection-background-color: #1A73E8;
+  selected-color: #FFFFFF;
+  width: 300px;
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:focus {
+  color: #FFFFFF;
+  background-color: rgba(255, 255, 255, 0.25);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry .search-entry-icon {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:hover .search-entry-icon, .app-folder-dialog .folder-name-container .folder-name-entry:focus .search-entry-icon {
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:insensitive, .app-folder-dialog .folder-name-container .folder-name-entry StLabel.hint-text {
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-label {
+  padding: 5px 7px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.app-folder-dialog .folder-name-container .icon-button, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button {
+  background-color: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.7);
+  border: none;
+  padding: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 18px;
+}
+
+.app-folder-dialog .folder-name-container .icon-button > StIcon, .app-folder-dialog .folder-name-container .background-app-item .icon-button > StIcon, .app-folder-dialog .folder-name-container .message-notification-group .background-app-item .message-collapse-button > StIcon, .app-folder-dialog .folder-name-container .message .message-header .background-app-item .message-expand-button > StIcon,
+.app-folder-dialog .folder-name-container .message .message-header .background-app-item .message-close-button > StIcon, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button > StIcon, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button > StIcon, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button > StIcon, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button > StIcon,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button > StIcon,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button > StIcon {
+  icon-size: 16px;
+}
+
+.app-folder-dialog .folder-name-container .icon-button:hover, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button:hover, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button:hover, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:hover, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:hover,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:hover,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.app-folder-dialog .folder-name-container .icon-button:focus, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button:focus, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button:focus, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:focus, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:focus,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:focus,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:focus {
+  border: none !important;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.app-folder-dialog .folder-name-container .icon-button:checked, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button:checked, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button:checked, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:checked, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:checked,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:checked,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:checked, .app-folder-dialog .folder-name-container .icon-button:active, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button:active, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button:active, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:active, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:active,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:active,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:active {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.app-folder-dialog .icon-grid {
+  row-spacing: 12px;
+  column-spacing: 30px;
+  page-padding-top: 0;
+  page-padding-bottom: 0;
+  page-padding-left: 0;
+  page-padding-right: 0;
+}
+
+.app-folder-dialog .page-indicators {
+  margin-bottom: 18px;
+}
+
+.rename-folder-popup .rename-folder-popup-item {
+  spacing: 6px;
+}
+
+.rename-folder-popup .rename-folder-popup-item:ltr, .rename-folder-popup .rename-folder-popup-item:rtl {
+  padding: 0 12px;
+}
+
+.app-menu,
+.app-well-menu {
+  max-width: 27.25em;
+}
+
+.page-indicator {
+  padding: 6px 12px 0;
+}
+
+.page-indicator .page-indicator-icon {
+  width: 10px;
+  height: 10px;
+  border-radius: 10px;
+  background-color: white;
+  transition-duration: 400ms;
+}
+
+.apps-scroll-view {
+  padding: 0;
+}
+
+.system-action-icon {
+  background-color: rgba(0, 0, 0, 0.8);
+  color: white;
+  border-radius: 9999px;
+  icon-size: 8px;
+}
+
+.page-navigation-hint.dnd {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.page-navigation-hint.next:ltr, .page-navigation-hint.previous:rtl {
+  background-gradient-start: rgba(255, 255, 255, 0.05);
+  background-gradient-end: transparent;
+  background-gradient-direction: horizontal;
+  border-radius: 15px 0px 0px 15px;
+}
+
+.page-navigation-hint.previous:ltr, .page-navigation-hint.next:rtl {
+  background-gradient-start: transparent;
+  background-gradient-end: rgba(255, 255, 255, 0.05);
+  background-gradient-direction: horizontal;
+  border-radius: 0px 15px 15px 0px;
+}
+
+.page-navigation-arrow {
+  margin: 6px;
+  padding: 18px;
+  width: 24px;
+  height: 24px;
+  border-radius: 9999px;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+}
+
+.page-navigation-arrow > StIcon {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.page-navigation-arrow:insensitive {
+  background-color: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.page-navigation-arrow:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+  color: white;
+}
+
+.page-navigation-arrow:active {
+  background-color: rgba(255, 255, 255, 0.2);
+  color: white;
+}
+
+/* Workspace pager */
+.workspace-thumbnails .workspace-thumbnail {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.13);
+  border: none;
+}
+
+.workspace-thumbnails {
+  visible-width: 32px;
+  spacing: 6px;
+  padding: 6px;
+}
+
+.workspace-thumbnails .workspace-thumbnail {
+  border-radius: 3px;
+}
+
+.workspace-thumbnails .placeholder {
+  background-image: url("resource:///org/gnome/shell/theme/dash-placeholder.svg");
+  background-size: contain;
+  width: 18px;
+}
+
+.workspace-thumbnail-indicator {
+  border: 3px solid #1A73E8;
+  border-radius: 6px;
+  padding: 0px;
+}
+
+.ripple-pointer-location {
+  width: 48px;
+  height: 48px;
+  border-radius: 24px;
+  background-color: rgba(165, 200, 246, 0.3);
+  box-shadow: 0 0 2px 2px #77acf1;
+}
+
+.pie-timer {
+  width: 60px;
+  height: 60px;
+  -pie-border-width: 3px;
+  -pie-border-color: #1A73E8;
+  -pie-background-color: rgba(211, 228, 251, 0.3);
+}
+
+.magnifier-zoom-region {
+  border: 2px solid #1A73E8;
+}
+
+.magnifier-zoom-region.full-screen {
+  border-width: 0;
+}
+
+.select-area-rubberband {
+  background-color: rgba(26, 115, 232, 0.3);
+  border: 1px solid #1A73E8;
+}
+
+.user-icon {
+  background-size: contain;
+  color: rgba(255, 255, 255, 0.7);
+  border-radius: 9999px;
+  icon-size: 64px;
+}
+
+.user-icon:hover {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.user-icon StIcon {
+  background-color: rgba(255, 255, 255, 0.05);
+  border-radius: 99px;
+  padding: 12px;
+  width: 40px;
+  height: 40px;
+}
+
+.user-icon.user-avatar {
+  border: 2px rgba(255, 255, 255, 0.7);
+}
+
+.user-widget.vertical .user-icon {
+  icon-size: 128px;
+}
+
+.user-widget.vertical .user-icon StIcon {
+  padding: 20px;
+  padding-top: 18px;
+  padding-bottom: 22px;
+  width: 88px;
+  height: 88px;
+}
+
+.lightbox {
+  background-color: black;
+}
+
+.flashspot {
+  background-color: white;
+}
+
+.hidden {
+  color: rgba(0, 0, 0, 0);
+}
+
+.caps-lock-warning-label {
+  text-align: center;
+  padding-bottom: 8px;
+  font-size: 10.5pt;
+  font-weight: 400;
+  color: #FF6D00;
+}
+
+/* Workspace animation */
+.workspace-animation {
+  background-color: #222222;
+}
+
+/* Tiled window previews */
+.tile-preview {
+  background-color: rgba(22, 108, 221, 0.3);
+  border: 1px solid #166cdd;
+}
+
+.tile-preview-left.on-primary {
+  border-radius: 4px 0 0 0;
+}
+
+.tile-preview-right.on-primary {
+  border-radius: 0 4px 0 0;
+}
+
+.tile-preview-left.tile-preview-right.on-primary {
+  border-radius: 4px 4px 0 0;
+}
+
+/* On-screen Keyboard */
+#keyboard {
+  background-color: rgba(238, 238, 238, 0.95);
+  border: none;
+  border-top-width: 0;
+  box-shadow: none;
+}
+
+#keyboard .page-indicator {
+  padding: 6px;
+}
+
+#keyboard .page-indicator .page-indicator-icon {
+  width: 8px;
+  height: 8px;
+}
+
+.key-container {
+  padding: 4px;
+  spacing: 4px;
+}
+
+.keyboard-key {
+  min-height: 2em;
+  min-width: 2em;
+  font-size: 14pt;
+  font-weight: bold;
+  border-radius: 3px;
+  border: none;
+  color: inherit;
+  background-color: #FAFAFA;
+  box-shadow: inset 0 -1px rgba(0, 0, 0, 0.25);
+}
+
+.keyboard-key:focus, .keyboard-key:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #e1e1e1;
+}
+
+.keyboard-key:checked, .keyboard-key:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #c7c7c7;
+}
+
+.keyboard-key:grayed {
+  background-color: rgba(32, 32, 32, 0.75);
+  color: rgba(255, 255, 255, 0.85);
+  border-color: rgba(32, 32, 32, 0.75);
+}
+
+.keyboard-key.default-key {
+  background-color: #c7c7c7;
+}
+
+.keyboard-key.default-key:focus, .keyboard-key.default-key:hover {
+  color: rgba(0, 0, 0, 0.62);
+  background-color: #b7b7b7;
+}
+
+.keyboard-key.default-key:checked, .keyboard-key.default-key:active {
+  color: rgba(0, 0, 0, 0.62);
+  background-color: #adadad;
+}
+
+.keyboard-key.enter-key {
+  background-color: #1A73E8;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.keyboard-key.enter-key:focus, .keyboard-key.enter-key:hover {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #3181ea;
+}
+
+.keyboard-key.enter-key:checked, .keyboard-key.enter-key:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #135cbc;
+}
+
+.keyboard-key.shift-key-uppercase {
+  color: #1A73E8;
+}
+
+.keyboard-key StIcon {
+  icon-size: 1.125em;
+}
+
+.keyboard-subkeys {
+  color: inherit;
+  -arrow-border-radius: 3px;
+  -arrow-background-color: rgba(0, 0, 0, 0.45);
+  -arrow-border-width: 0;
+  -arrow-border-color: transparent;
+  -arrow-base: 20px;
+  -arrow-rise: 10px;
+  -boxpointer-gap: 5px;
+}
+
+.emoji-page .keyboard-key {
+  background-color: transparent;
+  border: none;
+  color: initial;
+}
+
+.emoji-panel .keyboard-key:latched {
+  border-color: #3181ea;
+  background-color: #1A73E8;
+}
+
+.word-suggestions {
+  font-size: 14pt;
+  spacing: 12px;
+  min-height: 20pt;
+}
+
+/* Looking Glass */
+#LookingGlassDialog {
+  color: rgba(0, 0, 0, 0.54);
+  background-color: #ffffff;
+  spacing: 4px;
+  padding: 6px;
+  border: none;
+  border-radius: 3px;
+  box-shadow: 0 14px 14px rgba(0, 0, 0, 0.5);
+}
+
+#LookingGlassDialog > #Toolbar {
+  padding: 0 8px;
+  border: none;
+  border-radius: 0;
+  background-color: rgba(255, 255, 255, 0.01);
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.12);
+  color: rgba(0, 0, 0, 0.54);
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button {
+  color: rgba(0, 0, 0, 0.54);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+  box-shadow: none;
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: none;
+}
+
+#LookingGlassDialog .labels {
+  spacing: 0;
+}
+
+#LookingGlassDialog .notebook-tab {
+  -natural-hpadding: 12px;
+  -minimum-hpadding: 6px;
+  font-weight: bold;
+  color: rgba(0, 0, 0, 0.38);
+  transition-duration: 150ms;
+  padding-left: 16px;
+  padding-right: 16px;
+  min-height: 36px;
+  padding: 0 32px;
+  border-radius: 0;
+}
+
+#LookingGlassDialog .notebook-tab:hover {
+  box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.2);
+  color: rgba(0, 0, 0, 0.87);
+  text-shadow: none;
+}
+
+#LookingGlassDialog .notebook-tab:selected {
+  background-color: rgba(255, 255, 255, 0.01);
+  box-shadow: inset 0 -2px 0 #1A73E8;
+  color: rgba(0, 0, 0, 0.87);
+  text-shadow: none;
+}
+
+#LookingGlassDialog StBoxLayout#EvalBox {
+  padding: 4px;
+  spacing: 4px;
+}
+
+#LookingGlassDialog StBoxLayout#ResultsArea {
+  spacing: 4px;
+}
+
+.lg-dialog StEntry {
+  selection-background-color: #1A73E8;
+  selected-color: rgba(255, 255, 255, 0.85) !important;
+}
+
+.lg-dialog .shell-link {
+  color: #1A73E8;
+}
+
+.lg-dialog .shell-link:hover {
+  color: #1A73E8;
+}
+
+.lg-completions-text {
+  font-size: 1em;
+  font-style: italic;
+}
+
+.lg-obj-inspector-title {
+  spacing: 4px;
+}
+
+.lg-obj-inspector-button {
+  min-height: 36px;
+  padding: 0 16px;
+  border: none;
+  border-radius: 3px;
+  font-size: 10.5pt;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.54);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.lg-obj-inspector-button:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+  box-shadow: none;
+}
+
+.lg-obj-inspector-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+.lg-obj-inspector-button:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.lg-obj-inspector-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: none;
+}
+
+.lg-obj-inspector-button:hover {
+  border: none;
+}
+
+#lookingGlassExtensions {
+  padding: 4px;
+}
+
+.lg-extensions-list {
+  padding: 4px;
+  spacing: 6px;
+}
+
+.lg-extension {
+  border: none;
+  border-radius: 3px;
+  background-color: #bfbfbf;
+  padding: 4px;
+}
+
+.lg-extension-name {
+  font-size: 18pt;
+  font-weight: 400;
+}
+
+.lg-extension-meta {
+  spacing: 6px;
+}
+
+#LookingGlassPropertyInspector {
+  background: #ffffff;
+  border: none;
+  border-radius: 3px;
+  padding: 6px;
+  box-shadow: 0 14px 14px rgba(0, 0, 0, 0.5);
+}
+
+.quick-settings {
+  border-radius: 3px !important;
+  margin: 6px !important;
+  padding: 10px 12px 14px !important;
+}
+
+.quick-settings .icon-button, .quick-settings .message-notification-group .message-collapse-button, .message-notification-group .quick-settings .message-collapse-button, .quick-settings .message .message-header .message-expand-button, .message .message-header .quick-settings .message-expand-button,
+.quick-settings .message .message-header .message-close-button,
+.message .message-header .quick-settings .message-close-button, .quick-settings .button {
+  padding: 9px;
+}
+
+.quick-settings .icon-button > StIcon, .quick-settings .background-app-item .icon-button > StIcon, .quick-settings .message-notification-group .background-app-item .message-collapse-button > StIcon, .quick-settings .message .message-header .background-app-item .message-expand-button > StIcon,
+.quick-settings .message .message-header .background-app-item .message-close-button > StIcon, .quick-settings .message-notification-group .message-collapse-button > StIcon, .message-notification-group .quick-settings .message-collapse-button > StIcon, .quick-settings .message .message-header .message-expand-button > StIcon, .message .message-header .quick-settings .message-expand-button > StIcon,
+.quick-settings .message .message-header .message-close-button > StIcon,
+.message .message-header .quick-settings .message-close-button > StIcon, .quick-settings .button > StIcon {
+  icon-size: 16px;
+}
+
+.quick-settings-grid {
+  spacing-rows: 12px;
+  spacing-columns: 12px;
+}
+
+.quick-toggle, .quick-menu-toggle {
+  border-radius: 3px;
+  min-width: 12em;
+  max-width: 12em;
+  min-height: 44px;
+  padding: 0;
+  border: none;
+}
+
+.quick-toggle {
+  background-color: rgba(0, 0, 0, 0.06) !important;
+  /* Move padding into the box; this is to allow menu arrows
+       to extend to the border */
+}
+
+.quick-toggle:hover {
+  background-color: rgba(0, 0, 0, 0.12) !important;
+}
+
+.quick-toggle:active {
+  background-color: rgba(0, 0, 0, 0.15) !important;
+}
+
+.quick-toggle:checked {
+  background-color: #1A73E8 !important;
+  color: white;
+}
+
+.quick-toggle:checked:hover {
+  background-color: rgba(25, 110, 221, 0.9922) !important;
+  color: white;
+}
+
+.quick-toggle:checked:active {
+  background-color: rgba(23, 101, 204, 0.9805) !important;
+  color: white;
+}
+
+.quick-toggle > StBoxLayout {
+  spacing: 9px;
+}
+
+.quick-toggle.button {
+  padding: 0;
+}
+
+.quick-toggle > StBoxLayout {
+  padding: 0 12px;
+}
+
+.quick-toggle:ltr > StBoxLayout {
+  padding-left: 24px;
+}
+
+.quick-toggle:rtl > StBoxLayout {
+  padding-right: 24px;
+}
+
+.quick-toggle .quick-toggle-title {
+  font-weight: bold;
+}
+
+.quick-toggle StBoxLayout > .quick-toggle-subtitle {
+  font-weight: normal;
+  font-size: 12px;
+}
+
+.quick-toggle .quick-toggle-icon {
+  icon-size: 16px;
+}
+
+.quick-toggle-has-menu .quick-toggle {
+  min-width: auto;
+  max-width: auto;
+}
+
+.quick-toggle-has-menu .quick-toggle:ltr {
+  border-radius: 3px 0 0 3px;
+}
+
+.quick-toggle-has-menu .quick-toggle:ltr > StBoxLayout {
+  padding-right: 12px;
+}
+
+.quick-toggle-has-menu .quick-toggle:rtl {
+  border-radius: 0 3px 3px 0;
+}
+
+.quick-toggle-has-menu .quick-toggle:rtr > StBoxLayout {
+  padding-left: 12px;
+}
+
+.quick-toggle-has-menu .quick-toggle:ltr:last-child {
+  border-radius: 3px;
+}
+
+.quick-toggle-has-menu .quick-toggle:rtl:last-child {
+  border-radius: 3px;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button {
+  padding: 6px 12px;
+  border: none;
+  background-color: rgba(0, 0, 0, 0.06) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:hover {
+  background-color: rgba(0, 0, 0, 0.12) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:active {
+  background-color: rgba(0, 0, 0, 0.15) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:checked {
+  background-color: #1A73E8 !important;
+  color: white;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:checked:hover {
+  color: white;
+  background-color: st-mix(rgba(0, 0, 0, 0.87), #1A73E8, 6%) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:checked:active {
+  color: white;
+  background-color: st-mix(rgba(0, 0, 0, 0.87), #1A73E8, 15%) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:ltr {
+  border-radius: 0 3px 3px 0;
+  border-left-width: 0;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:rtl {
+  border-radius: 3px 0 0 3px;
+  border-right-width: 0;
+}
+
+.quick-toggle-has-menu .quick-toggle-separator {
+  width: 0;
+}
+
+.quick-slider > StBoxLayout {
+  spacing: 6px;
+}
+
+.quick-slider .slider-bin {
+  min-height: 16px;
+  padding: 6px;
+  border-radius: 9999px;
+}
+
+.quick-slider .slider-bin:focus {
+  color: #1A73E8;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.quick-slider .slider-bin:focus:hover, .quick-slider .slider-bin:focus:active {
+  color: #1A73E8;
+}
+
+.quick-slider .quick-toggle-icon {
+  icon-size: 16px;
+}
+
+.quick-slider .icon-button, .quick-slider .message-notification-group .message-collapse-button, .message-notification-group .quick-slider .message-collapse-button, .quick-slider .message .message-header .message-expand-button, .message .message-header .quick-slider .message-expand-button,
+.quick-slider .message .message-header .message-close-button,
+.message .message-header .quick-slider .message-close-button {
+  min-width: 22px;
+  min-height: 22px;
+  background-color: transparent;
+  color: rgba(0, 0, 0, 0.87) !important;
+}
+
+.quick-slider .icon-button:hover, .quick-slider .message-notification-group .message-collapse-button:hover, .message-notification-group .quick-slider .message-collapse-button:hover, .quick-slider .message .message-header .message-expand-button:hover, .message .message-header .quick-slider .message-expand-button:hover,
+.quick-slider .message .message-header .message-close-button:hover,
+.message .message-header .quick-slider .message-close-button:hover {
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.quick-slider .icon-button:active, .quick-slider .message-notification-group .message-collapse-button:active, .message-notification-group .quick-slider .message-collapse-button:active, .quick-slider .message .message-header .message-expand-button:active, .message .message-header .quick-slider .message-expand-button:active,
+.quick-slider .message .message-header .message-close-button:active,
+.message .message-header .quick-slider .message-close-button:active {
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+.quick-toggle-menu {
+  background-color: white !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+  border-radius: 3px !important;
+  padding: 18px;
+  margin: 12px 36px 0;
+  border: none !important;
+}
+
+.quick-toggle-menu .popup-menu-item {
+  border-radius: 3px !important;
+  min-height: 20px;
+}
+
+.quick-toggle-menu .popup-menu-item:focus, .quick-toggle-menu .popup-menu-item:hover, .quick-toggle-menu .popup-menu-item.selected {
+  color: rgba(0, 0, 0, 0.87) !important;
+  background-color: rgba(0, 0, 0, 0.1) !important;
+}
+
+.quick-toggle-menu .popup-menu-item:active {
+  color: rgba(0, 0, 0, 0.87) !important;
+  background-color: rgba(0, 0, 0, 0.2) !important;
+}
+
+.quick-toggle-menu .popup-menu-item > StIcon {
+  -st-icon-style: symbolic;
+}
+
+.quick-toggle-menu .header {
+  spacing-rows: 3px;
+  spacing-columns: 12px;
+  padding-bottom: 12px;
+}
+
+.quick-toggle-menu .header .icon {
+  icon-size: 24px;
+  border-radius: 3px;
+  padding: 9px;
+  background-color: rgba(0, 0, 0, 0.06) !important;
+}
+
+.quick-toggle-menu .header .icon.active {
+  background-color: #1A73E8 !important;
+  color: white;
+}
+
+.quick-settings-system-item > StBoxLayout {
+  spacing: 12px;
+}
+
+.quick-settings-system-item .icon-button, .quick-settings-system-item .message-notification-group .message-collapse-button, .message-notification-group .quick-settings-system-item .message-collapse-button, .quick-settings-system-item .message .message-header .message-expand-button, .message .message-header .quick-settings-system-item .message-expand-button,
+.quick-settings-system-item .message .message-header .message-close-button,
+.message .message-header .quick-settings-system-item .message-close-button {
+  background-color: rgba(0, 0, 0, 0.06);
+  color: rgba(0, 0, 0, 0.87);
+  border-radius: 3px;
+  min-height: 22px;
+  min-width: 22px !important;
+}
+
+.quick-settings-system-item .icon-button:hover, .quick-settings-system-item .message-notification-group .message-collapse-button:hover, .message-notification-group .quick-settings-system-item .message-collapse-button:hover, .quick-settings-system-item .message .message-header .message-expand-button:hover, .message .message-header .quick-settings-system-item .message-expand-button:hover,
+.quick-settings-system-item .message .message-header .message-close-button:hover,
+.message .message-header .quick-settings-system-item .message-close-button:hover {
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+.quick-settings-system-item .icon-button:active, .quick-settings-system-item .message-notification-group .message-collapse-button:active, .message-notification-group .quick-settings-system-item .message-collapse-button:active, .quick-settings-system-item .message .message-header .message-expand-button:active, .message .message-header .quick-settings-system-item .message-expand-button:active,
+.quick-settings-system-item .message .message-header .message-close-button:active,
+.message .message-header .quick-settings-system-item .message-close-button:active {
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.quick-settings-system-item .icon-button > StIcon, .quick-settings-system-item .background-app-item .icon-button > StIcon, .quick-settings-system-item .message-notification-group .background-app-item .message-collapse-button > StIcon, .quick-settings-system-item .message .message-header .background-app-item .message-expand-button > StIcon,
+.quick-settings-system-item .message .message-header .background-app-item .message-close-button > StIcon, .quick-settings-system-item .message-notification-group .message-collapse-button > StIcon, .message-notification-group .quick-settings-system-item .message-collapse-button > StIcon, .quick-settings-system-item .message .message-header .message-expand-button > StIcon, .message .message-header .quick-settings-system-item .message-expand-button > StIcon,
+.quick-settings-system-item .message .message-header .message-close-button > StIcon,
+.message .message-header .quick-settings-system-item .message-close-button > StIcon {
+  -st-icon-style: symbolic;
+  icon-size: 16px;
+}
+
+.quick-settings-system-item .power-item {
+  min-height: 0;
+  min-width: 0;
+}
+
+.quick-settings-system-item .power-item:insensitive {
+  color: rgba(0, 0, 0, 0.62);
+  background-color: #ffffff;
+  border-color: #d9d9d9;
+  box-shadow: none;
+  background-color: transparent;
+}
+
+.nm-network-item .wireless-secure-icon {
+  icon-size: 8px;
+}
+
+.bt-device-item .popup-menu-icon {
+  -st-icon-style: symbolic;
+}
+
+.bt-menu-placeholder.popup-menu-item {
+  text-align: center;
+  padding: 2em 4em;
+}
+
+.device-subtitle {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.keyboard-brightness-level {
+  spacing: 6px;
+}
+
+.background-apps-quick-toggle {
+  min-height: 40px;
+  background-color: transparent;
+}
+
+.background-apps-quick-toggle StIcon {
+  icon-size: 16px !important;
+}
+
+.background-app-item .popup-menu-icon {
+  icon-size: 24px !important;
+  -st-icon-style: regular !important;
+}
+
+.background-app-item .icon-button, .background-app-item .message-notification-group .message-collapse-button, .message-notification-group .background-app-item .message-collapse-button, .background-app-item .message .message-header .message-expand-button, .message .message-header .background-app-item .message-expand-button,
+.background-app-item .message .message-header .message-close-button,
+.message .message-header .background-app-item .message-close-button {
+  padding: 6px;
+}
+
+.background-app-item .spinner {
+  padding: 6px;
+}
+
+.background-app-item.popup-inactive-menu-item {
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.icon-label-button-container {
+  spacing: 6px;
+  font-size: 9pt;
+  font-weight: 400;
+}
+
+.icon-label-button-container StIcon {
+  icon-size: 32px;
+}
+
+.screenshot-ui-panel {
+  border-radius: 27px;
+  padding: 18px;
+  padding-bottom: 12px;
+  margin-bottom: 4em;
+  spacing: 12px;
+}
+
+.screenshot-ui-close-button {
+  padding: 6px;
+}
+
+.screenshot-ui-close-button.left {
+  margin-left: 8px;
+}
+
+.screenshot-ui-close-button.right {
+  margin-right: 8px;
+}
+
+.screenshot-ui-type-button {
+  padding: 12px 18px !important;
+  border-radius: 9px;
+}
+
+.screenshot-ui-capture-button {
+  width: 36px;
+  height: 36px;
+  border-radius: 9999px;
+  border: 4px rgba(255, 255, 255, 0.85);
+  padding: 4px;
+}
+
+.screenshot-ui-capture-button .screenshot-ui-capture-button-circle {
+  background-color: rgba(255, 255, 255, 0.85);
+  transition-duration: 200ms;
+  border-radius: 9999px;
+}
+
+.screenshot-ui-capture-button .screenshot-ui-capture-button-circle:hover, .screenshot-ui-capture-button .screenshot-ui-capture-button-circle:focus {
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+.screenshot-ui-capture-button:hover .screenshot-ui-capture-button-circle, .screenshot-ui-capture-button:focus .screenshot-ui-capture-button-circle {
+  background-color: rgba(217, 217, 217, 0.85);
+}
+
+.screenshot-ui-capture-button:active .screenshot-ui-capture-button-circle {
+  background-color: rgba(128, 128, 128, 0.85);
+}
+
+.screenshot-ui-capture-button:cast .screenshot-ui-capture-button-circle {
+  background-color: #DD2C00;
+}
+
+.screenshot-ui-capture-button:cast:hover .screenshot-ui-capture-button-circle, .screenshot-ui-capture-button:cast:focus .screenshot-ui-capture-button-circle {
+  background-color: #911d00;
+}
+
+.screenshot-ui-capture-button:cast:active .screenshot-ui-capture-button-circle {
+  background-color: #440e00;
+}
+
+.screenshot-ui-shot-cast-container {
+  background-color: rgba(0, 0, 0, 0.12);
+  border-radius: 6px;
+  padding: 3px;
+  spacing: 3px;
+}
+
+.screenshot-ui-shot-cast-container:ltr {
+  margin-left: 3px;
+}
+
+.screenshot-ui-shot-cast-container:rtl {
+  margin-right: 3px;
+}
+
+.screenshot-ui-shot-cast-button {
+  padding: 6px 12px;
+  background-color: transparent;
+  border-radius: 3px;
+}
+
+.screenshot-ui-shot-cast-button:hover, .screenshot-ui-shot-cast-button:focus {
+  background-color: rgba(13, 13, 13, 0.12);
+}
+
+.screenshot-ui-shot-cast-button:active {
+  background-color: rgba(13, 13, 13, 0.2);
+}
+
+.screenshot-ui-shot-cast-button:checked {
+  background-color: white;
+  color: black;
+}
+
+.screenshot-ui-shot-cast-button StIcon {
+  icon-size: 16px;
+}
+
+.screenshot-ui-show-pointer-button {
+  border-radius: 9999px;
+  padding: 12px !important;
+}
+
+.screenshot-ui-show-pointer-button StIcon {
+  icon-size: 16px;
+}
+
+.screenshot-ui-area-indicator-shade {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.screenshot-ui-area-selector .screenshot-ui-area-indicator-shade {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.screenshot-ui-area-selector .screenshot-ui-area-indicator-selection {
+  border: 2px white;
+}
+
+.screenshot-ui-area-selector-handle {
+  border-radius: 9999px;
+  background-color: white;
+  box-shadow: 0 1px 3px 2px rgba(0, 0, 0, 0.2);
+  width: 24px;
+  height: 24px;
+}
+
+.screenshot-ui-window-selector {
+  background-color: #222222;
+}
+
+.screenshot-ui-window-selector .screenshot-ui-window-selector-window-container {
+  margin: 100px;
+}
+
+.screenshot-ui-window-selector:primary-monitor .screenshot-ui-window-selector-window-container {
+  margin-bottom: 200px;
+}
+
+.screenshot-ui-window-selector-window-border {
+  transition-duration: 200ms;
+  border-radius: 6px;
+  border: 6px transparent;
+}
+
+.screenshot-ui-window-selector-check {
+  transition-duration: 200ms;
+  color: transparent;
+  border-radius: 9999px;
+  border-width: 12px;
+  icon-size: 24px;
+}
+
+.screenshot-ui-window-selector-window:hover .screenshot-ui-window-selector-window-border {
+  border-color: #1151a5;
+}
+
+.screenshot-ui-window-selector-window:checked .screenshot-ui-window-selector-window-border {
+  border-color: #1A73E8;
+  background-color: rgba(26, 115, 232, 0.2);
+}
+
+.screenshot-ui-window-selector-window:checked .screenshot-ui-window-selector-check {
+  color: white;
+  background-color: #1A73E8;
+}
+
+.screenshot-ui-screen-selector {
+  transition-duration: 200ms;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.screenshot-ui-screen-selector:hover {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.screenshot-ui-screen-selector:active {
+  background-color: rgba(0, 0, 0, 0.7);
+}
+
+.screenshot-ui-screen-selector:checked {
+  background-color: transparent;
+  border: 2px white;
+}
+
+.screenshot-ui-tooltip {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #222222;
+  border-radius: 99px;
+  padding: 6px 12px;
+  text-align: center;
+  -y-offset: 24px;
+}
+
+/* Login Dialog */
+.login-dialog-banner-view {
+  padding-top: 24px;
+  max-width: 23em;
+}
+
+.login-dialog,
+.unlock-dialog {
+  border: none;
+  background-color: transparent;
+}
+
+.login-dialog StEntry,
+.unlock-dialog StEntry {
+  selection-background-color: #1A73E8;
+  selected-color: rgba(255, 255, 255, 0.85) !important;
+  caret-color: rgba(0, 0, 0, 0.54);
+  color: rgba(0, 0, 0, 0.54);
+  background-color: #ffffff;
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+.login-dialog StEntry:focus,
+.unlock-dialog StEntry:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #1A73E8 !important;
+}
+
+.login-dialog StEntry:insensitive,
+.unlock-dialog StEntry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog .modal-dialog-button-box,
+.unlock-dialog .modal-dialog-button-box {
+  spacing: 3px;
+}
+
+.login-dialog .modal-dialog-button,
+.unlock-dialog .modal-dialog-button {
+  padding: 4px 18px;
+  box-shadow: none;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:hover, .login-dialog .modal-dialog-button:focus,
+.unlock-dialog .modal-dialog-button:hover,
+.unlock-dialog .modal-dialog-button:focus {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.15);
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:active,
+.unlock-dialog .modal-dialog-button:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.3);
+  box-shadow: 0 0 transparent;
+}
+
+.login-dialog .modal-dialog-button:insensitive,
+.unlock-dialog .modal-dialog-button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default,
+.unlock-dialog .modal-dialog-button:default {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #287ce9;
+  border-color: #1257b3;
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:hover, .login-dialog .modal-dialog-button:default:focus,
+.unlock-dialog .modal-dialog-button:default:hover,
+.unlock-dialog .modal-dialog-button:default:focus {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #287ce9;
+  border-color: #104c9c;
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:active,
+.unlock-dialog .modal-dialog-button:default:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #176ee1;
+  border-color: #104c9c;
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:active:hover, .login-dialog .modal-dialog-button:default:active:focus,
+.unlock-dialog .modal-dialog-button:default:active:hover,
+.unlock-dialog .modal-dialog-button:default:active:focus {
+  background-color: #176ee1;
+}
+
+.login-dialog .modal-dialog-button:default:insensitive,
+.unlock-dialog .modal-dialog-button:default:insensitive {
+  color: rgba(255, 255, 255, 0.5);
+  background-color: rgba(255, 255, 255, 0.15);
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.login-dialog .cancel-button,
+.login-dialog .switch-user-button,
+.login-dialog .login-dialog-session-list-button,
+.unlock-dialog .cancel-button,
+.unlock-dialog .switch-user-button,
+.unlock-dialog .login-dialog-session-list-button {
+  padding: 0;
+  border-radius: 99px;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog .cancel-button:hover, .login-dialog .cancel-button:focus,
+.login-dialog .switch-user-button:hover,
+.login-dialog .switch-user-button:focus,
+.login-dialog .login-dialog-session-list-button:hover,
+.login-dialog .login-dialog-session-list-button:focus,
+.unlock-dialog .cancel-button:hover,
+.unlock-dialog .cancel-button:focus,
+.unlock-dialog .switch-user-button:hover,
+.unlock-dialog .switch-user-button:focus,
+.unlock-dialog .login-dialog-session-list-button:hover,
+.unlock-dialog .login-dialog-session-list-button:focus {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog .cancel-button:active,
+.login-dialog .switch-user-button:active,
+.login-dialog .login-dialog-session-list-button:active,
+.unlock-dialog .cancel-button:active,
+.unlock-dialog .switch-user-button:active,
+.unlock-dialog .login-dialog-session-list-button:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.login-dialog .cancel-button StIcon,
+.login-dialog .switch-user-button StIcon,
+.login-dialog .login-dialog-session-list-button StIcon,
+.unlock-dialog .cancel-button StIcon,
+.unlock-dialog .switch-user-button StIcon,
+.unlock-dialog .login-dialog-session-list-button StIcon {
+  icon-size: 16px;
+}
+
+.login-dialog .caps-lock-warning-label,
+.login-dialog .login-dialog-message-warning,
+.unlock-dialog .caps-lock-warning-label,
+.unlock-dialog .login-dialog-message-warning {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-logo-bin {
+  padding: 24px 0px;
+}
+
+.login-dialog-banner {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog-button-box {
+  width: 23em;
+  spacing: 5px;
+}
+
+.login-dialog-message {
+  text-align: center;
+}
+
+.login-dialog-user-selection-box {
+  padding: 100px 0px;
+}
+
+.login-dialog-not-listed-label {
+  padding-left: 2px;
+  font-size: 1em;
+  font-weight: bold;
+  color: rgba(255, 255, 255, 0.7);
+  padding-top: 1em;
+}
+
+.login-dialog-not-listed-label:hover {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-not-listed-label:focus {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.login-dialog-not-listed-button:focus .login-dialog-not-listed-label, .login-dialog-not-listed-button:hover .login-dialog-not-listed-label {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-view {
+  -st-vfade-offset: 1em;
+}
+
+.login-dialog-user-list {
+  spacing: 12px;
+  width: 23em;
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:selected {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:active {
+  background-color: rgba(255, 255, 255, 0.3);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:logged-in {
+  border-right: 2px solid rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-item {
+  border-radius: 3px;
+  padding: 6px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog-user-list-item:ltr {
+  padding-right: 1em;
+}
+
+.login-dialog-user-list-item:rtl {
+  padding-left: 1em;
+}
+
+.login-dialog-user-list-item:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-item:active {
+  background-color: rgba(255, 255, 255, 0.3);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-item .login-dialog-timed-login-indicator {
+  height: 2px;
+  margin: 6px 0 0 0;
+  background-color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-item:focus .login-dialog-timed-login-indicator {
+  background-color: rgba(255, 255, 255, 0.85);
+}
+
+.user-widget-label {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.user-widget.horizontal .user-widget-label {
+  font-size: 15pt;
+  font-weight: 500;
+  font-weight: bold;
+  padding-left: 15px;
+}
+
+.user-widget.horizontal .user-widget-label:ltr {
+  padding-left: 14px;
+  text-align: left;
+}
+
+.user-widget.horizontal .user-widget-label:rtl {
+  padding-right: 14px;
+  text-align: right;
+}
+
+.user-widget.vertical .user-widget-label {
+  font-size: 15pt;
+  font-weight: 500;
+  text-align: center;
+  font-weight: normal;
+  padding-top: 16px;
+}
+
+.login-dialog-prompt-layout {
+  padding-top: 24px;
+  padding-bottom: 12px;
+  spacing: 12px;
+  width: 23em;
+}
+
+.login-dialog-prompt-entry {
+  height: 1.5em;
+}
+
+.login-dialog-prompt-label {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 1em;
+  padding-top: 1em;
+}
+
+/* Screen Shield */
+.unlock-dialog-clock {
+  color: white;
+  font-weight: 300;
+  text-align: center;
+  spacing: 24px;
+  padding-bottom: 2.5em;
+}
+
+.unlock-dialog-clock-time {
+  font-size: 64pt;
+  padding-top: 42px;
+  font-feature-settings: "tnum";
+}
+
+.unlock-dialog-clock-date {
+  font-size: 16pt;
+  font-weight: normal;
+}
+
+.unlock-dialog-clock-hint {
+  font-weight: normal;
+  padding-top: 48px;
+}
+
+.unlock-dialog-notifications-container {
+  margin: 12px 0;
+  spacing: 6px;
+  width: 23em;
+  background-color: transparent;
+}
+
+.unlock-dialog-notifications-container .summary-notification-stack-scrollview {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.unlock-dialog-notifications-container .notification,
+.unlock-dialog-notifications-container .unlock-dialog-notification-source {
+  padding: 12px 6px;
+  border: none;
+  background-color: rgba(32, 32, 32, 0.9);
+  color: rgba(255, 255, 255, 0.85);
+  border-radius: 3px;
+}
+
+.unlock-dialog-notifications-container .notification.critical,
+.unlock-dialog-notifications-container .unlock-dialog-notification-source.critical {
+  background-color: rgba(34, 34, 34, 0.9);
+}
+
+.unlock-dialog-notification-label {
+  padding: 0px 0px 0px 12px;
+}
+
+.unlock-dialog-notification-count-text {
+  weight: bold;
+  padding: 0 6px;
+  color: rgba(32, 32, 32, 0.9);
+  background-color: rgba(255, 255, 255, 0.7);
+  border-radius: 99px;
+  margin-right: 12px;
+}
+
+.screen-shield-background {
+  background: black;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.6);
+}
+
+#lockDialogGroup {
+  background-color: #222222;
+}
+
+#unlockDialogNotifications StButton#vhandle, #unlockDialogNotifications StButton#hhandle {
+  background-color: rgba(32, 32, 32, 0.2);
+}
+
+#unlockDialogNotifications StButton#vhandle:hover, #unlockDialogNotifications StButton#vhandle:focus, #unlockDialogNotifications StButton#hhandle:hover, #unlockDialogNotifications StButton#hhandle:focus {
+  background-color: rgba(32, 32, 32, 0.4);
+}
+
+#unlockDialogNotifications StButton#vhandle:active, #unlockDialogNotifications StButton#hhandle:active {
+  background-color: rgba(26, 115, 232, 0.5);
+}
+
+.bottom #dashtodockDashScrollview,
+.top #dashtodockDashScrollview {
+  -st-hfade-offset: 24px;
+}
+
+.left #dashtodockDashScrollview,
+.right #dashtodockDashScrollview {
+  -st-vfade-offset: 24px;
+}
+
+#dashtodockContainer {
+  background-color: transparent;
+  box-shadow: none;
+}
+
+#dashtodockContainer .number-overlay {
+  color: #FFFFFF;
+  background-color: rgba(0, 0, 0, 0.75);
+  text-align: center;
+}
+
+#dashtodockContainer .notification-badge {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #1A73E8;
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.25);
+  border-radius: 9999px;
+  margin: 2px 3px 5px;
+  padding: 0.2em 0.6em;
+  font-weight: bold;
+  text-align: center;
+}
+
+#dashtodockContainer.top.straight-corner #dash, #dashtodockContainer.top.shrink.straight-corner #dash, #dashtodockContainer.top.extended #dash, #dashtodockContainer.top.extended:overview #dash {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.straight-corner #dash .dash-background, #dashtodockContainer.top.shrink.straight-corner #dash .dash-background, #dashtodockContainer.top.extended #dash .dash-background, #dashtodockContainer.top.extended:overview #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.top.straight-corner #dash .show-apps,
+#dashtodockContainer.top.straight-corner #dash .overview-tile,
+#dashtodockContainer.top.straight-corner #dash .grid-search-result,
+#dashtodockContainer.top.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.top.straight-corner #dash .list-search-result, #dashtodockContainer.top.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.top.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.top.extended #dash .show-apps,
+#dashtodockContainer.top.extended #dash .overview-tile,
+#dashtodockContainer.top.extended #dash .grid-search-result,
+#dashtodockContainer.top.extended #dash .search-provider-icon,
+#dashtodockContainer.top.extended #dash .list-search-result, #dashtodockContainer.top.extended:overview #dash .show-apps,
+#dashtodockContainer.top.extended:overview #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash, #dashtodockContainer.bottom.shrink.straight-corner #dash, #dashtodockContainer.bottom.extended #dash, #dashtodockContainer.bottom.extended:overview #dash {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash .dash-background, #dashtodockContainer.bottom.shrink.straight-corner #dash .dash-background, #dashtodockContainer.bottom.extended #dash .dash-background, #dashtodockContainer.bottom.extended:overview #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash .show-apps,
+#dashtodockContainer.bottom.straight-corner #dash .overview-tile,
+#dashtodockContainer.bottom.straight-corner #dash .grid-search-result,
+#dashtodockContainer.bottom.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.bottom.straight-corner #dash .list-search-result, #dashtodockContainer.bottom.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.bottom.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.bottom.extended #dash .show-apps,
+#dashtodockContainer.bottom.extended #dash .overview-tile,
+#dashtodockContainer.bottom.extended #dash .grid-search-result,
+#dashtodockContainer.bottom.extended #dash .search-provider-icon,
+#dashtodockContainer.bottom.extended #dash .list-search-result, #dashtodockContainer.bottom.extended:overview #dash .show-apps,
+#dashtodockContainer.bottom.extended:overview #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash, #dashtodockContainer.left.shrink.straight-corner #dash, #dashtodockContainer.left.extended #dash, #dashtodockContainer.left.extended:overview #dash {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash .dash-background, #dashtodockContainer.left.shrink.straight-corner #dash .dash-background, #dashtodockContainer.left.extended #dash .dash-background, #dashtodockContainer.left.extended:overview #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash .show-apps,
+#dashtodockContainer.left.straight-corner #dash .overview-tile,
+#dashtodockContainer.left.straight-corner #dash .grid-search-result,
+#dashtodockContainer.left.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.left.straight-corner #dash .list-search-result, #dashtodockContainer.left.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.left.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.left.extended #dash .show-apps,
+#dashtodockContainer.left.extended #dash .overview-tile,
+#dashtodockContainer.left.extended #dash .grid-search-result,
+#dashtodockContainer.left.extended #dash .search-provider-icon,
+#dashtodockContainer.left.extended #dash .list-search-result, #dashtodockContainer.left.extended:overview #dash .show-apps,
+#dashtodockContainer.left.extended:overview #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash, #dashtodockContainer.right.shrink.straight-corner #dash, #dashtodockContainer.right.extended #dash, #dashtodockContainer.right.extended:overview #dash {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash .dash-background, #dashtodockContainer.right.shrink.straight-corner #dash .dash-background, #dashtodockContainer.right.extended #dash .dash-background, #dashtodockContainer.right.extended:overview #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash .show-apps,
+#dashtodockContainer.right.straight-corner #dash .overview-tile,
+#dashtodockContainer.right.straight-corner #dash .grid-search-result,
+#dashtodockContainer.right.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.right.straight-corner #dash .list-search-result, #dashtodockContainer.right.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.right.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.right.extended #dash .show-apps,
+#dashtodockContainer.right.extended #dash .overview-tile,
+#dashtodockContainer.right.extended #dash .grid-search-result,
+#dashtodockContainer.right.extended #dash .search-provider-icon,
+#dashtodockContainer.right.extended #dash .list-search-result, #dashtodockContainer.right.extended:overview #dash .show-apps,
+#dashtodockContainer.right.extended:overview #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.extended #dash .dash-background, #dashtodockContainer.straight-corner #dash .dash-background {
+  border-radius: 0;
+}
+
+#dashtodockContainer.shrink #dash .dash-background {
+  padding: 0 !important;
+  border-radius: 3px;
+}
+
+#dashtodockContainer.shrink #dash .show-apps,
+#dashtodockContainer.shrink #dash .overview-tile,
+#dashtodockContainer.shrink #dash .grid-search-result,
+#dashtodockContainer.shrink #dash .search-provider-icon,
+#dashtodockContainer.shrink #dash .list-search-result {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left #dash .overview-tile, #dashtodockContainer.left #dash .grid-search-result, #dashtodockContainer.left #dash .search-provider-icon, #dashtodockContainer.left #dash .list-search-result, #dashtodockContainer.right #dash .overview-tile, #dashtodockContainer.right #dash .grid-search-result, #dashtodockContainer.right #dash .search-provider-icon, #dashtodockContainer.right #dash .list-search-result {
+  padding: 2px 6px !important;
+}
+
+#dashtodockContainer.left #dash .show-apps, #dashtodockContainer.right #dash .show-apps {
+  padding-bottom: 6px !important;
+}
+
+#dashtodockContainer.left.shrink #dash .show-apps,
+#dashtodockContainer.left.shrink #dash .overview-tile,
+#dashtodockContainer.left.shrink #dash .grid-search-result,
+#dashtodockContainer.left.shrink #dash .search-provider-icon,
+#dashtodockContainer.left.shrink #dash .list-search-result, #dashtodockContainer.right.shrink #dash .show-apps,
+#dashtodockContainer.right.shrink #dash .overview-tile,
+#dashtodockContainer.right.shrink #dash .grid-search-result,
+#dashtodockContainer.right.shrink #dash .search-provider-icon,
+#dashtodockContainer.right.shrink #dash .list-search-result {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.extended #dash .show-apps,
+#dashtodockContainer.left.extended #dash .overview-tile,
+#dashtodockContainer.left.extended #dash .grid-search-result,
+#dashtodockContainer.left.extended #dash .search-provider-icon,
+#dashtodockContainer.left.extended #dash .list-search-result, #dashtodockContainer.left.straight-corner #dash .show-apps,
+#dashtodockContainer.left.straight-corner #dash .overview-tile,
+#dashtodockContainer.left.straight-corner #dash .grid-search-result,
+#dashtodockContainer.left.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.left.straight-corner #dash .list-search-result, #dashtodockContainer.right.extended #dash .show-apps,
+#dashtodockContainer.right.extended #dash .overview-tile,
+#dashtodockContainer.right.extended #dash .grid-search-result,
+#dashtodockContainer.right.extended #dash .search-provider-icon,
+#dashtodockContainer.right.extended #dash .list-search-result, #dashtodockContainer.right.straight-corner #dash .show-apps,
+#dashtodockContainer.right.straight-corner #dash .overview-tile,
+#dashtodockContainer.right.straight-corner #dash .grid-search-result,
+#dashtodockContainer.right.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.right.straight-corner #dash .list-search-result {
+  padding: 2px 12px !important;
+}
+
+#dashtodockContainer.top.shrink #dash .dash-background, #dashtodockContainer.bottom.shrink #dash .dash-background {
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.shrink #dash .show-apps,
+#dashtodockContainer.top.shrink #dash .overview-tile,
+#dashtodockContainer.top.shrink #dash .grid-search-result,
+#dashtodockContainer.top.shrink #dash .search-provider-icon,
+#dashtodockContainer.top.shrink #dash .list-search-result, #dashtodockContainer.bottom.shrink #dash .show-apps,
+#dashtodockContainer.bottom.shrink #dash .overview-tile,
+#dashtodockContainer.bottom.shrink #dash .grid-search-result,
+#dashtodockContainer.bottom.shrink #dash .search-provider-icon,
+#dashtodockContainer.bottom.shrink #dash .list-search-result {
+  margin: 0 !important;
+  padding: 0 0 18px !important;
+}
+
+#dashtodockContainer.top.extended #dash .dash-separator, #dashtodockContainer.top.straight-corner #dash .dash-separator, #dashtodockContainer.bottom.extended #dash .dash-separator, #dashtodockContainer.bottom.straight-corner #dash .dash-separator {
+  margin: 0 8px !important;
+}
+
+#dashtodockContainer.top.extended #dash .show-apps,
+#dashtodockContainer.top.extended #dash .overview-tile,
+#dashtodockContainer.top.extended #dash .grid-search-result,
+#dashtodockContainer.top.extended #dash .search-provider-icon,
+#dashtodockContainer.top.extended #dash .list-search-result, #dashtodockContainer.top.straight-corner #dash .show-apps,
+#dashtodockContainer.top.straight-corner #dash .overview-tile,
+#dashtodockContainer.top.straight-corner #dash .grid-search-result,
+#dashtodockContainer.top.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.top.straight-corner #dash .list-search-result, #dashtodockContainer.bottom.extended #dash .show-apps,
+#dashtodockContainer.bottom.extended #dash .overview-tile,
+#dashtodockContainer.bottom.extended #dash .grid-search-result,
+#dashtodockContainer.bottom.extended #dash .search-provider-icon,
+#dashtodockContainer.bottom.extended #dash .list-search-result, #dashtodockContainer.bottom.straight-corner #dash .show-apps,
+#dashtodockContainer.bottom.straight-corner #dash .overview-tile,
+#dashtodockContainer.bottom.straight-corner #dash .grid-search-result,
+#dashtodockContainer.bottom.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.bottom.straight-corner #dash .list-search-result {
+  padding: 12px 2px !important;
+}
+
+#dashtodockContainer #dash {
+  background: none;
+  box-shadow: none;
+}
+
+#dashtodockContainer #dash .dash-background {
+  background-color: rgba(255, 255, 255, 0.5);
+  background-clip: padding-box;
+}
+
+#dashtodockContainer #dash .show-apps .overview-icon,
+#dashtodockContainer #dash .overview-tile .overview-icon,
+#dashtodockContainer #dash .grid-search-result .overview-icon,
+#dashtodockContainer #dash .search-provider-icon .overview-icon,
+#dashtodockContainer #dash .list-search-result .overview-icon {
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+
+#dashtodockContainer #dash .show-apps:hover .overview-icon, #dashtodockContainer #dash .show-apps:focus .overview-icon, #dashtodockContainer #dash .show-apps:selected .overview-icon,
+#dashtodockContainer #dash .overview-tile:hover .overview-icon,
+#dashtodockContainer #dash .grid-search-result:hover .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:hover .overview-icon,
+#dashtodockContainer #dash .list-search-result:hover .overview-icon,
+#dashtodockContainer #dash .overview-tile:focus .overview-icon,
+#dashtodockContainer #dash .grid-search-result:focus .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:focus .overview-icon,
+#dashtodockContainer #dash .list-search-result:focus .overview-icon,
+#dashtodockContainer #dash .overview-tile:selected .overview-icon,
+#dashtodockContainer #dash .grid-search-result:selected .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:selected .overview-icon,
+#dashtodockContainer #dash .list-search-result:selected .overview-icon {
+  background-color: rgba(255, 255, 255, 0.35) !important;
+  color: rgba(0, 0, 0, 0.88) !important;
+}
+
+#dashtodockContainer #dash .show-apps:active .overview-icon, #dashtodockContainer #dash .show-apps:checked .overview-icon,
+#dashtodockContainer #dash .overview-tile:active .overview-icon,
+#dashtodockContainer #dash .grid-search-result:active .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:active .overview-icon,
+#dashtodockContainer #dash .list-search-result:active .overview-icon,
+#dashtodockContainer #dash .overview-tile:checked .overview-icon,
+#dashtodockContainer #dash .grid-search-result:checked .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:checked .overview-icon,
+#dashtodockContainer #dash .list-search-result:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.5) !important;
+  color: rgba(0, 0, 0, 0.88) !important;
+}
+
+#dashtodockContainer .dash-separator {
+  background-color: rgba(0, 0, 0, 0.15) !important;
+}
+
+#dashtodockContainer .app-grid-running-dot {
+  background-color: rgba(0, 0, 0, 0.55) !important;
+  margin: 0 0 3px !important;
+  offset-y: 0 !important;
+}
+
+#dashtodockContainer StWidget.focused .overview-icon {
+  background-color: rgba(255, 255, 255, 0.35) !important;
+}
+
+#dashtodockContainer StWidget.focused:hover .overview-icon {
+  background-color: rgba(255, 255, 255, 0.5) !important;
+}
+
+#dashtodockContainer StWidget.focused .app-grid-running-dot {
+  background-color: #1A73E8 !important;
+}
+
+#dashtodockContainer.opaque #dash .dash-background {
+  background-color: #f3f3f3;
+}
+
+#dashtodockContainer.transparent #dash .dash-background {
+  background-color: rgba(255, 255, 255, 0.5);
+}
+
+#dashtodockContainer:overview #dash .dash-background {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+#dashtodockContainer:overview #dash .show-apps .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result .overview-icon {
+  color: rgba(255, 255, 255, 0.7) !important;
+}
+
+#dashtodockContainer:overview #dash .show-apps:hover .overview-icon, #dashtodockContainer:overview #dash .show-apps:focus .overview-icon, #dashtodockContainer:overview #dash .show-apps:selected .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:hover .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:hover .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:hover .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:hover .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:focus .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:focus .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:focus .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:focus .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:selected .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:selected .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:selected .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:selected .overview-icon {
+  background-color: rgba(255, 255, 255, 0.35) !important;
+  color: rgba(255, 255, 255, 0.85) !important;
+}
+
+#dashtodockContainer:overview #dash .show-apps:active .overview-icon, #dashtodockContainer:overview #dash .show-apps:checked .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:active .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:active .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:active .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:active .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:checked .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:checked .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:checked .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.35) !important;
+  color: rgba(255, 255, 255, 0.85) !important;
+}
+
+#dashtodockContainer:overview #dash .dash-separator {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#dashtodockContainer:overview #dash .app-grid-running-dot {
+  background-color: rgba(255, 255, 255, 0.5) !important;
+}
+
+#dashtodockContainer:overview #dash StWidget.focused .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#dashtodockContainer:overview #dash StWidget.focused:hover .overview-icon {
+  background-color: rgba(255, 255, 255, 0.3) !important;
+}
+
+#dashtodockContainer:overview #dash StWidget.focused .app-grid-running-dot {
+  background-color: #1A73E8 !important;
+}
+
+#dashtodockContainer.opaque:overview #dash, #dashtodockContainer.transparent:overview #dash {
+  background-color: transparent !important;
+  box-shadow: none !important;
+}
+
+#dashtodockContainer.opaque:overview #dash .dash-background, #dashtodockContainer.transparent:overview #dash .dash-background {
+  background-color: transparent !important;
+}
+
+#dashtodockContainer.extended:overview #dash, #dashtodockContainer.opaque.extended:overview #dash, #dashtodockContainer.transparent.extended:overview #dash {
+  background: none;
+}
+
+#dashtodockContainer.extended:overview .dash-background, #dashtodockContainer.opaque.extended:overview .dash-background, #dashtodockContainer.transparent.extended:overview .dash-background {
+  background-color: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#dashtodockContainer.running-dots .dash-item-container > StButton, #dashtodockContainer.dashtodock .dash-item-container > StButton {
+  transition-duration: 250ms;
+  background-size: contain;
+}
+
+#dashtodockContainer.extended .show-apps .overview-icon,
+#dashtodockContainer.extended .overview-tile .overview-icon,
+#dashtodockContainer.extended .grid-search-result .overview-icon,
+#dashtodockContainer.extended .search-provider-icon .overview-icon,
+#dashtodockContainer.extended .list-search-result .overview-icon, #dashtodockContainer.extended:overview .show-apps .overview-icon,
+#dashtodockContainer.extended:overview .overview-tile .overview-icon {
+  border-radius: 3px;
+}
+
+#dashtodockContainer .metro .overview-icon {
+  border-radius: 0;
+}
+
+.dashtodock-app-well-preview-menu-item {
+  padding: 1em 1em 0.5em 1em;
+}
+
+#dashtodockPreviewSeparator.popup-separator-menu-item-horizontal {
+  width: 1px;
+  height: auto;
+  border-right-width: 1px;
+  margin: 32px 0;
+}
+
+.dashtopanelMainPanel .show-apps,
+.dashtopanelMainPanel .overview-tile,
+.dashtopanelMainPanel .grid-search-result,
+.dashtopanelMainPanel .search-provider-icon,
+.dashtopanelMainPanel .list-search-result {
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+}
+
+.dashtopanelMainPanel .show-apps .overview-icon,
+.dashtopanelMainPanel .overview-tile .overview-icon,
+.dashtopanelMainPanel .grid-search-result .overview-icon,
+.dashtopanelMainPanel .search-provider-icon .overview-icon,
+.dashtopanelMainPanel .list-search-result .overview-icon {
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+}
+
+.dashtopanelMainPanel .show-apps .overview-icon {
+  border-radius: 3px !important;
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+
+.dashtopanelMainPanel .show-apps:hover .overview-icon, .dashtopanelMainPanel .show-apps:focus .overview-icon, .dashtopanelMainPanel .show-apps:selected .overview-icon {
+  background-color: rgba(255, 255, 255, 0.35) !important;
+  color: rgba(0, 0, 0, 0.88) !important;
+  box-shadow: none !important;
+}
+
+.dashtopanelMainPanel .show-apps:active .overview-icon, .dashtopanelMainPanel .show-apps:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.5) !important;
+  color: rgba(0, 0, 0, 0.88) !important;
+  box-shadow: none !important;
+}
+
+.dashtopanelMainPanel .panel-button {
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+
+.openweather-button, .openweather-button-action, .openweather-menu-button-container, .openweather-button-box {
+  border: 1px solid transparent !important;
+}
+
+.openweather-provider {
+  padding: 0 16px;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.54);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.openweather-provider:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+  box-shadow: none;
+}
+
+.openweather-provider:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: none;
+}
+
+.openweather-provider:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+.openweather-current-icon, .openweather-current-summary, .openweather-current-summarybox {
+  background: none;
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.openweather-current-databox-values {
+  background: none;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.openweather-current-databox-captions {
+  background: none;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.openweather-forecast-icon, .openweather-forecast-summary {
+  background: none;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.openweather-forecast-day, .openweather-forecast-temperature {
+  background: none;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.openweather-sunrise-icon, .openweather-sunset-icon, .openweather-build-icon {
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.gsconnect-device-menu .popup-menu-item {
+  height: 20px !important;
+  padding: 3px 0;
+}
+
+.gsconnect-device-menu .popup-menu-item > :last-child:ltr {
+  padding-right: 6px !important;
+  margin-right: 12px !important;
+}
+
+.gsconnect-device-menu .popup-menu-item > :last-child:rtl {
+  padding-left: 6px !important;
+  padding-left: 12px !important;
+}
+
+#panel.light-panel .panel-button,
+#panel.dark-panel .panel-button,
+#panel.transparent-panel .panel-button {
+  color: rgba(255, 255, 255, 0.7) !important;
+}
+
+#panel.light-panel .panel-button.clock-display .clock,
+#panel.dark-panel .panel-button.clock-display .clock,
+#panel.transparent-panel .panel-button.clock-display .clock {
+  color: rgba(255, 255, 255, 0.7) !important;
+}
+
+#panel.light-panel .panel-button:hover,
+#panel.dark-panel .panel-button:hover,
+#panel.transparent-panel .panel-button:hover {
+  color: rgba(255, 255, 255, 0.7) !important;
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#panel.light-panel .panel-button:active, #panel.light-panel .panel-button:checked, #panel.light-panel .panel-button:focus,
+#panel.dark-panel .panel-button:active,
+#panel.dark-panel .panel-button:checked,
+#panel.dark-panel .panel-button:focus,
+#panel.transparent-panel .panel-button:active,
+#panel.transparent-panel .panel-button:checked,
+#panel.transparent-panel .panel-button:focus {
+  color: rgba(255, 255, 255, 0.85) !important;
+  background-color: rgba(255, 255, 255, 0.3) !important;
+}
+
+#panel.light-panel .panel-button:hover.clock-display .clock, #panel.light-panel .panel-button:active.clock-display .clock, #panel.light-panel .panel-button:overview.clock-display .clock, #panel.light-panel .panel-button:focus.clock-display .clock, #panel.light-panel .panel-button:checked.clock-display .clock,
+#panel.dark-panel .panel-button:hover.clock-display .clock,
+#panel.dark-panel .panel-button:active.clock-display .clock,
+#panel.dark-panel .panel-button:overview.clock-display .clock,
+#panel.dark-panel .panel-button:focus.clock-display .clock,
+#panel.dark-panel .panel-button:checked.clock-display .clock,
+#panel.transparent-panel .panel-button:hover.clock-display .clock,
+#panel.transparent-panel .panel-button:active.clock-display .clock,
+#panel.transparent-panel .panel-button:overview.clock-display .clock,
+#panel.transparent-panel .panel-button:focus.clock-display .clock,
+#panel.transparent-panel .panel-button:checked.clock-display .clock {
+  color: rgba(255, 255, 255, 0.85) !important;
+}
+
+.overview-components-transparent .search-entry,
+.overview-components-light .search-entry,
+.overview-components-dark .search-entry {
+  caret-color: rgba(255, 255, 255, 0.75) !important;
+}
+
+.overview-components-transparent .search-entry .search-entry-icon,
+.overview-components-light .search-entry .search-entry-icon,
+.overview-components-dark .search-entry .search-entry-icon {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.overview-components-transparent .search-entry StLabel.hint-text,
+.overview-components-light .search-entry StLabel.hint-text,
+.overview-components-dark .search-entry StLabel.hint-text {
+  color: rgba(255, 255, 255, 0.35) !important;
+}
+
+.arcmenu-menu {
+  border-image: none !important;
+  border-radius: 3px !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+}
+
+.arcmenu-menu .popup-menu-content {
+  padding: 6px !important;
+  margin: 6px !important;
+  border: none !important;
+  background-color: rgba(255, 255, 255, 0.97);
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.1) !important;
+  border-radius: 3px !important;
+}

--- a/src/gnome-shell/shell-48-0/gnome-shell-Light.scss
+++ b/src/gnome-shell/shell-48-0/gnome-shell-Light.scss
@@ -1,0 +1,10 @@
+$variant: 'light';
+$laptop: 'false';
+$panel: 'light';
+
+@import '../sass/variables';
+@import '../sass/colors';
+@import '../sass/drawing';
+@import '../sass/common-40-0';
+@import '../sass/widgets-48-0';
+@import '../sass/extensions-46-0';

--- a/src/gnome-shell/shell-48-0/gnome-shell-compact.css
+++ b/src/gnome-shell/shell-48-0/gnome-shell-compact.css
@@ -1,0 +1,4945 @@
+/* This stylesheet is generated, DO NOT EDIT */
+stage {
+  font-size: 9.75pt;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.87);
+}
+
+/* Common Stylings */
+#dash .dash-item-container .show-apps,
+#dash .dash-item-container .overview-tile,
+#dash .dash-item-container .grid-search-result,
+#dash .dash-item-container .search-provider-icon,
+#dash .dash-item-container .list-search-result {
+  background: none;
+  box-shadow: none;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  margin: 0;
+}
+
+#dash .dash-item-container .show-apps .overview-icon,
+#dash .dash-item-container .overview-tile .overview-icon,
+#dash .dash-item-container .grid-search-result .overview-icon,
+#dash .dash-item-container .search-provider-icon .overview-icon,
+#dash .dash-item-container .list-search-result .overview-icon {
+  border-radius: 6px;
+  padding: 4px;
+  spacing: 4px;
+  text-align: center;
+  transition-duration: 100ms;
+}
+
+.search-statustext {
+  font-size: 45px;
+  font-weight: 400;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.popup-menu-content {
+  background: rgba(255, 255, 255, 0.97);
+  color: rgba(0, 0, 0, 0.87);
+  border-radius: 3px;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.1);
+}
+
+.modal-dialog {
+  background: rgba(255, 255, 255, 0.97);
+  color: rgba(0, 0, 0, 0.87);
+  border-radius: 6px;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2);
+}
+
+/* General Typography */
+.message-notification-group .message-group-header .message-group-title, .message-list .message-list-placeholder {
+  font-weight: 800;
+  font-size: 1.364em;
+}
+
+.quick-toggle-menu .header .title {
+  font-weight: 700;
+  font-size: 1.364em;
+}
+
+.bt-menu-placeholder.popup-menu-item {
+  font-weight: 700;
+  font-size: 1.182em;
+}
+
+.background-app-item .title, .message-list-controls, .calendar .calendar-month-header .calendar-month-label {
+  font-weight: 700;
+  font-size: 1em;
+}
+
+.quick-toggle-menu .header .subtitle {
+  font-weight: 700;
+  font-size: 0.818em;
+}
+
+.background-app-item .subtitle, .message .message-header .message-header-content .event-time {
+  font-weight: 400;
+  font-size: 0.818em;
+}
+
+/* WIDGETS */
+.shell-link {
+  border-radius: 3px;
+  color: #1A73E8;
+  background-color: transparent;
+}
+
+.shell-link:hover {
+  color: #1A73E8;
+  background-color: rgba(26, 115, 232, 0.15);
+}
+
+.shell-link:active {
+  color: #1A73E8;
+  background-color: rgba(26, 115, 232, 0.3);
+}
+
+.lowres-icon {
+  icon-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+}
+
+.icon-dropshadow {
+  icon-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+}
+
+/* Entries */
+StEntry {
+  min-height: 24px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  border-width: 0;
+  caret-color: rgba(0, 0, 0, 0.54);
+  selection-background-color: #1A73E8;
+  selected-color: #FFFFFF !important;
+  font-size: 11.25pt;
+  font-weight: 400;
+  caret-color: rgba(0, 0, 0, 0.54);
+  color: rgba(0, 0, 0, 0.54);
+  background-color: #ffffff;
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+StEntry:hover {
+  border: 2px solid rgba(0, 0, 0, 0.2) !important;
+}
+
+StEntry:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #1A73E8 !important;
+}
+
+StEntry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+StEntry StIcon.capslock-warning {
+  icon-size: 16px;
+  warning-color: #FF6D00;
+  padding: 0 0;
+}
+
+StEntry StIcon.peek-password {
+  icon-size: 16px;
+  padding: 0 4px;
+}
+
+StEntry StLabel.hint-text {
+  margin-left: 2px;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+/* Buttons */
+.screenshot-ui-show-pointer-button, .screenshot-ui-type-button {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:focus, .screenshot-ui-type-button:focus {
+  color: rgba(255, 255, 255, 0.85);
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:hover, .screenshot-ui-type-button:hover {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.15);
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:active, .screenshot-ui-type-button:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.3);
+  box-shadow: 0 0 transparent;
+}
+
+.screenshot-ui-show-pointer-button:checked, .screenshot-ui-type-button:checked {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #1A73E8;
+  border-color: #1A73E8;
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:checked:hover, .screenshot-ui-type-button:checked:hover, .screenshot-ui-show-pointer-button:checked:focus, .screenshot-ui-type-button:checked:focus {
+  background-color: #1A73E8;
+}
+
+.screenshot-ui-show-pointer-button:insensitive, .screenshot-ui-type-button:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.icon-button.flat, .message .message-header .flat.message-expand-button,
+.message .message-header .flat.message-close-button, .message-notification-group .flat.message-collapse-button, .button.flat {
+  color: rgba(0, 0, 0, 0.54);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.icon-button.flat:focus, .message .message-header .flat.message-expand-button:focus,
+.message .message-header .flat.message-close-button:focus, .message-notification-group .flat.message-collapse-button:focus, .button.flat:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: none;
+}
+
+.icon-button.flat:hover, .message .message-header .flat.message-expand-button:hover,
+.message .message-header .flat.message-close-button:hover, .message-notification-group .flat.message-collapse-button:hover, .button.flat:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+  box-shadow: none;
+}
+
+.icon-button.flat:selected, .message .message-header .flat.message-expand-button:selected,
+.message .message-header .flat.message-close-button:selected, .message-notification-group .flat.message-collapse-button:selected, .button.flat:selected, .icon-button.flat:active, .message .message-header .flat.message-expand-button:active,
+.message .message-header .flat.message-close-button:active, .message-notification-group .flat.message-collapse-button:active, .button.flat:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+.icon-button.flat:checked, .message .message-header .flat.message-expand-button:checked,
+.message .message-header .flat.message-close-button:checked, .message-notification-group .flat.message-collapse-button:checked, .button.flat:checked {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+.icon-button.flat:insensitive, .message .message-header .flat.message-expand-button:insensitive,
+.message .message-header .flat.message-close-button:insensitive, .message-notification-group .flat.message-collapse-button:insensitive, .button.flat:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:checked, .icon-button.default, .message .message-header .default.message-expand-button,
+.message .message-header .default.message-close-button, .message-notification-group .default.message-collapse-button, .button.default {
+  color: #FFFFFF;
+  background-color: #1A73E8;
+  border-color: #1151a5;
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:focus:checked, .icon-button.default:focus, .message .message-header .default.message-expand-button:focus,
+.message .message-header .default.message-close-button:focus, .message-notification-group .default.message-collapse-button:focus, .button.default:focus {
+  color: #1A73E8;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.keyboard-brightness-level .button:focus:hover:checked, .icon-button.default:focus:hover, .message .message-header .default.message-expand-button:focus:hover,
+.message .message-header .default.message-close-button:focus:hover, .message-notification-group .default.message-collapse-button:focus:hover, .button.default:focus:hover, .keyboard-brightness-level .button:focus:active:checked, .icon-button.default:focus:active, .message .message-header .default.message-expand-button:focus:active,
+.message .message-header .default.message-close-button:focus:active, .message-notification-group .default.message-collapse-button:focus:active, .button.default:focus:active {
+  color: #1A73E8;
+}
+
+.keyboard-brightness-level .button:hover:checked, .icon-button.default:hover, .message .message-header .default.message-expand-button:hover,
+.message .message-header .default.message-close-button:hover, .message-notification-group .default.message-collapse-button:hover, .button.default:hover {
+  color: #FFFFFF;
+  background-color: #1A73E8;
+  border-color: #0e458e;
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:insensitive:checked, .icon-button.default:insensitive, .message .message-header .default.message-expand-button:insensitive,
+.message .message-header .default.message-close-button:insensitive, .message-notification-group .default.message-collapse-button:insensitive, .button.default:insensitive {
+  color: #FFFFFF;
+  background-color: #1A73E8;
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:active:checked, .icon-button.default:active, .message .message-header .default.message-expand-button:active,
+.message .message-header .default.message-close-button:active, .message-notification-group .default.message-collapse-button:active, .button.default:active {
+  color: #FFFFFF;
+  background-color: #1567d3;
+  border-color: #0e458e;
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:active:hover:checked, .icon-button.default:active:hover, .message .message-header .default.message-expand-button:active:hover,
+.message .message-header .default.message-close-button:active:hover, .message-notification-group .default.message-collapse-button:active:hover, .button.default:active:hover, .keyboard-brightness-level .button:active:focus:checked, .icon-button.default:active:focus, .message .message-header .default.message-expand-button:active:focus,
+.message .message-header .default.message-close-button:active:focus, .message-notification-group .default.message-collapse-button:active:focus, .button.default:active:focus {
+  background-color: #1567d3;
+}
+
+.icon-button, .background-app-item .icon-button, .background-app-item .message-notification-group .message-collapse-button, .message-notification-group .background-app-item .message-collapse-button, .background-app-item .message .message-header .message-expand-button, .message .message-header .background-app-item .message-expand-button,
+.background-app-item .message .message-header .message-close-button,
+.message .message-header .background-app-item .message-close-button, .message .message-header .message-expand-button,
+.message .message-header .message-close-button, .message-notification-group .message-collapse-button, .button {
+  padding: 4px 8px;
+  border-width: 0;
+  border-radius: 3px;
+  font-size: 9.75pt;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.54);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.icon-button:focus, .message .message-header .message-expand-button:focus,
+.message .message-header .message-close-button:focus, .message-notification-group .message-collapse-button:focus, .button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: none;
+}
+
+.icon-button:hover, .message .message-header .message-expand-button:hover,
+.message .message-header .message-close-button:hover, .message-notification-group .message-collapse-button:hover, .button:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+  box-shadow: none;
+}
+
+.icon-button:selected, .message .message-header .message-expand-button:selected,
+.message .message-header .message-close-button:selected, .message-notification-group .message-collapse-button:selected, .button:selected, .icon-button:active, .message .message-header .message-expand-button:active,
+.message .message-header .message-close-button:active, .message-notification-group .message-collapse-button:active, .button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+.icon-button:checked, .message .message-header .message-expand-button:checked,
+.message .message-header .message-close-button:checked, .message-notification-group .message-collapse-button:checked, .button:checked {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #1A73E8;
+  border-color: #1A73E8;
+  box-shadow: none;
+}
+
+.icon-button:checked:hover, .message .message-header .message-expand-button:checked:hover,
+.message .message-header .message-close-button:checked:hover, .message-notification-group .message-collapse-button:checked:hover, .button:checked:hover, .icon-button:checked:focus, .message .message-header .message-expand-button:checked:focus,
+.message .message-header .message-close-button:checked:focus, .message-notification-group .message-collapse-button:checked:focus, .button:checked:focus {
+  background-color: #1A73E8;
+}
+
+.icon-button:insensitive, .message .message-header .message-expand-button:insensitive,
+.message .message-header .message-close-button:insensitive, .message-notification-group .message-collapse-button:insensitive, .button:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button, .notification-button {
+  border-radius: 3px;
+  border: 1px solid;
+  color: rgba(0, 0, 0, 0.62);
+  background-color: #ffffff;
+  border-color: #d9d9d9;
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button:focus, .notification-button:focus {
+  color: #1A73E8;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.modal-dialog .modal-dialog-button:focus:hover, .notification-button:focus:hover, .modal-dialog .modal-dialog-button:focus:active, .notification-button:focus:active {
+  color: #1A73E8;
+}
+
+.modal-dialog .modal-dialog-button:hover, .notification-button:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #ffffff;
+  border-color: #cccccc;
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button:selected, .notification-button:selected, .modal-dialog .modal-dialog-button:active, .notification-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #f2f2f2;
+  border-color: #cccccc;
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button:selected:hover, .notification-button:selected:hover, .modal-dialog .modal-dialog-button:selected:focus, .notification-button:selected:focus, .modal-dialog .modal-dialog-button:active:hover, .notification-button:active:hover, .modal-dialog .modal-dialog-button:active:focus, .notification-button:active:focus {
+  background-color: #f2f2f2;
+}
+
+.modal-dialog .modal-dialog-button:checked, .notification-button:checked {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #1A73E8;
+  border-color: #1A73E8;
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button:checked:hover, .notification-button:checked:hover, .modal-dialog .modal-dialog-button:checked:focus, .notification-button:checked:focus {
+  background-color: #1A73E8;
+}
+
+.modal-dialog .modal-dialog-button:insensitive, .notification-button:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: rgba(0, 0, 0, 0.06);
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.button {
+  min-height: 1.5em;
+}
+
+.icon-button, .background-app-item .icon-button, .background-app-item .message-notification-group .message-collapse-button, .message-notification-group .background-app-item .message-collapse-button, .background-app-item .message .message-header .message-expand-button, .message .message-header .background-app-item .message-expand-button,
+.background-app-item .message .message-header .message-close-button,
+.message .message-header .background-app-item .message-close-button, .message .message-header .message-expand-button,
+.message .message-header .message-close-button, .message-notification-group .message-collapse-button {
+  border-radius: 9999px;
+  padding: 0.818em;
+  min-height: 1.091em;
+}
+
+.icon-button StIcon, .background-app-item .icon-button StIcon, .background-app-item .message-notification-group .message-collapse-button StIcon, .message-notification-group .background-app-item .message-collapse-button StIcon, .background-app-item .message .message-header .message-expand-button StIcon, .message .message-header .background-app-item .message-expand-button StIcon,
+.background-app-item .message .message-header .message-close-button StIcon,
+.message .message-header .background-app-item .message-close-button StIcon, .message .message-header .message-expand-button StIcon,
+.message .message-header .message-close-button StIcon, .message-notification-group .message-collapse-button StIcon {
+  icon-size: 1.091em;
+  -st-icon-style: symbolic;
+}
+
+/* Check Boxes */
+.check-box StBoxLayout {
+  spacing: .8em;
+}
+
+.check-box StBin {
+  width: 24px;
+  height: 24px;
+  padding: 4px;
+  border-radius: 100px;
+  background-image: url("assets/checkbox-off.svg");
+}
+
+.check-box:focus StBin {
+  background-image: url("assets/checkbox-off.svg");
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.check-box:hover StBin {
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.check-box:active StBin {
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.check-box:checked StBin {
+  background-image: url("assets/checkbox.svg");
+}
+
+.check-box:focus:checked StBin {
+  background-image: url("assets/checkbox.svg");
+}
+
+.check-box:hover:checked StBin {
+  background-color: rgba(40, 124, 233, 0.15);
+}
+
+.check-box:active:checked StBin {
+  background-color: rgba(40, 124, 233, 0.3);
+}
+
+.check-box StIcon {
+  icon-size: 0;
+  padding: 0;
+  border: none;
+  background-color: transparent;
+  color: transparent;
+}
+
+.check-box:checked StIcon {
+  background-color: transparent;
+  color: transparent;
+}
+
+.check-box:checked:hover StIcon {
+  background-color: transparent;
+  color: transparent;
+}
+
+.check-box:checked:active StIcon {
+  background-color: transparent;
+  color: transparent;
+}
+
+/* Switches */
+.toggle-switch {
+  width: 36px;
+  height: 18px;
+  background: transparent;
+  color: rgba(0, 0, 0, 0.87);
+  border: 1px solid rgba(0, 0, 0, 0.38);
+}
+
+.toggle-switch:hover {
+  background: transparent;
+  color: rgba(0, 0, 0, 0.87);
+  border: 1px solid rgba(0, 0, 0, 0.54);
+}
+
+.toggle-switch StIcon {
+  icon-size: 10px;
+}
+
+.toggle-switch .handle {
+  margin: 4px;
+  width: 10px;
+  height: 10px;
+  border-radius: 9999px;
+  background: rgba(0, 0, 0, 0.54);
+  box-shadow: none;
+  transition-duration: 100ms;
+}
+
+.toggle-switch:checked {
+  background: #1A73E8;
+  color: white;
+  border-color: #1A73E8;
+}
+
+.toggle-switch:checked:hover {
+  background-color: #3181ea;
+  color: white;
+  border-color: #3181ea;
+}
+
+.toggle-switch:checked .handle {
+  background: white;
+}
+
+/* Slider */
+.slider {
+  height: 12px;
+  color: #287ce9;
+  -barlevel-height: 2px;
+  -barlevel-background-color: rgba(0, 0, 0, 0.2);
+  -barlevel-active-background-color: #287ce9;
+  -barlevel-overdrive-color: #FF5252;
+  -barlevel-overdrive-separator-width: 2px;
+  -slider-handle-radius: 6px;
+}
+
+.slider:hover {
+  color: #3f8aec;
+}
+
+.slider:active {
+  color: #176ee1;
+}
+
+/* Scrollbars */
+StScrollView.vfade {
+  -st-vfade-offset: 32px;
+}
+
+StScrollView.hfade {
+  -st-hfade-offset: 32px;
+}
+
+StScrollBar {
+  padding: 0;
+}
+
+StScrollView StScrollBar {
+  min-width: 8px;
+  min-height: 8px;
+}
+
+StScrollBar StBin#trough {
+  border-radius: 9999px;
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+StScrollBar StButton#vhandle, StScrollBar StButton#hhandle {
+  border-radius: 9999px;
+  background-color: rgba(0, 0, 0, 0.38);
+  border: 4px solid transparent;
+}
+
+StScrollBar StButton#vhandle:hover, StScrollBar StButton#hhandle:hover {
+  background-color: rgba(0, 0, 0, 0.54);
+}
+
+StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
+  background-color: rgba(0, 0, 0, 0.87);
+}
+
+/* Popovers/Menus */
+.popup-menu-boxpointer, .candidate-popup-boxpointer {
+  -arrow-border-radius: 3px;
+  -arrow-background-color: transparent;
+  -arrow-border-width: 0;
+  -arrow-border-color: transparent;
+  -arrow-base: 27px;
+  -arrow-rise: 0;
+  -arrow-box-shadow: none;
+}
+
+.popup-menu {
+  min-width: 15em;
+  color: rgba(0, 0, 0, 0.87);
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+.popup-menu.panel-menu {
+  -boxpointer-gap: 2px;
+  margin-bottom: 1.75em;
+}
+
+.popup-menu-content {
+  padding: 4px;
+  margin: 2px 4px 10px;
+  border: none;
+}
+
+.popup-menu-item {
+  spacing: 4px;
+  padding: 4px 8px;
+  margin: 0;
+  color: rgba(0, 0, 0, 0.87);
+  transition-duration: 100ms;
+  border-radius: 3px;
+  background-image: none;
+  background-gradient-direction: none !important;
+}
+
+.popup-menu-item:ltr {
+  padding-right: 8px;
+  padding-left: 8px;
+}
+
+.popup-menu-item:rtl {
+  padding-right: 8px;
+  padding-left: 8px;
+}
+
+.popup-menu-item:checked {
+  background-color: rgba(0, 0, 0, 0.08) !important;
+  font-weight: normal;
+  border-radius: 3px 3px 0 0 !important;
+  border: none;
+  box-shadow: none;
+  color: rgba(0, 0, 0, 0.87) !important;
+  background-gradient-direction: none !important;
+}
+
+.popup-menu-item:checked.selected, .popup-menu-item:checked:hover, .popup-menu-item:checked:focus {
+  background-color: rgba(0, 0, 0, 0.1) !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+}
+
+.popup-menu-item:checked:active, .popup-menu-item:checked.selected:active {
+  background-color: rgba(0, 0, 0, 0.08) !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+}
+
+.popup-menu-item:checked:insensitive {
+  color: rgba(0, 0, 0, 0.38) !important;
+}
+
+.popup-menu-item.selected, .popup-menu-item:hover, .popup-menu-item:focus {
+  background-color: rgba(0, 0, 0, 0.06) !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+  transition-duration: 0ms;
+  background-gradient-direction: none !important;
+}
+
+.popup-menu-item:active {
+  background-color: rgba(0, 0, 0, 0.2) !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+  transition-duration: 150ms;
+  background-gradient-direction: none !important;
+}
+
+.popup-menu-item.selected:active {
+  color: rgba(0, 0, 0, 0.87) !important;
+}
+
+.popup-menu-item:insensitive {
+  color: rgba(0, 0, 0, 0.38) !important;
+}
+
+.popup-inactive-menu-item {
+  color: rgba(0, 0, 0, 0.87) !important;
+}
+
+.popup-inactive-menu-item:insensitive {
+  color: rgba(0, 0, 0, 0.38) !important;
+}
+
+.popup-menu-arrow,
+.popup-menu-icon {
+  icon-size: 16px;
+}
+
+.popup-sub-menu {
+  margin: 0;
+  background-color: rgba(0, 0, 0, 0.08) !important;
+  border-radius: 0 0 3px 3px !important;
+  border: none;
+  box-shadow: none;
+  background-image: none !important;
+}
+
+.popup-sub-menu .popup-menu-item {
+  margin: 0;
+  border-radius: 0;
+  background-image: none !important;
+  background-color: transparent !important;
+}
+
+.popup-sub-menu .popup-menu-item.selected, .popup-sub-menu .popup-menu-item:hover, .popup-sub-menu .popup-menu-item:focus {
+  background-color: rgba(0, 0, 0, 0.06) !important;
+}
+
+.popup-sub-menu .popup-menu-item:active {
+  background-color: rgba(0, 0, 0, 0.2) !important;
+}
+
+.popup-sub-menu .popup-menu-item:last-child {
+  border-radius: 0 0 3px 3px !important;
+  border-bottom-width: 0;
+}
+
+.popup-sub-menu .popup-menu-section .popup-menu-item:last-child:hover, .popup-sub-menu .popup-menu-section .popup-menu-item:last-child:focus {
+  border-radius: 0;
+}
+
+.popup-sub-menu .popup-menu-section:last-child .popup-menu-item:last-child {
+  border-radius: 0 0 3px 3px !important;
+}
+
+.popup-menu-ornament {
+  width: 1.2em;
+}
+
+.popup-menu-ornament:ltr {
+  text-align: right;
+}
+
+.popup-menu-ornament:rtl {
+  text-align: left;
+}
+
+.popup-separator-menu-item {
+  background: none;
+  border: none;
+  padding: 0 0;
+  margin: 0 0;
+  height: 2px;
+}
+
+.popup-separator-menu-item .popup-separator-menu-item-separator {
+  height: 1px;
+  margin: 0 0;
+  padding: 0 0;
+  background: none;
+}
+
+.popup-sub-menu .popup-separator-menu-item .popup-separator-menu-item-separator {
+  margin: 0 0;
+  padding: 0 0;
+  background: none;
+}
+
+.background-menu {
+  -boxpointer-gap: 2px;
+  -arrow-rise: 0px;
+}
+
+.aggregate-menu {
+  min-width: 19em;
+}
+
+.aggregate-menu .popup-menu-icon {
+  padding: 0;
+  margin: 0;
+  -st-icon-style: symbolic;
+}
+
+.aggregate-menu .popup-menu-icon:ltr {
+  margin-right: 2px;
+}
+
+.aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
+  padding-left: 8px !important;
+  margin-left: 0 !important;
+}
+
+.aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
+  padding-right: 8px !important;
+  margin-right: 0 !important;
+}
+
+/* Date/Time Menu */
+#calendarArea {
+  padding: 4px 0;
+}
+
+.datemenu-popover {
+  border-radius: 7px !important;
+}
+
+.calendar {
+  padding: 0;
+  margin: 0 6px;
+  border: none;
+  box-shadow: none;
+  background: none;
+  text-shadow: none;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.calendar .calendar-month-header .calendar-change-month-back StIcon,
+.calendar .calendar-month-header .calendar-change-month-forward StIcon {
+  icon-size: 1.091em;
+}
+
+.calendar .calendar-month-header .calendar-month-label {
+  background-color: transparent !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+  padding: 8px 0;
+  width: 10em;
+  text-align: center;
+}
+
+.calendar .calendar-day-heading {
+  width: 28px;
+  height: 21px;
+  margin-top: 2px;
+  padding: 7px 0 0;
+  border-radius: 9999px;
+  background-color: transparent !important;
+  color: rgba(0, 0, 0, 0.38) !important;
+  font-size: 9pt;
+  font-weight: 400;
+  font-weight: bold;
+  text-align: center;
+}
+
+.datemenu-calendar-column {
+  spacing: 4px;
+  border: none;
+  padding: 0;
+  margin: 0;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.datemenu-calendar-column:hover, .datemenu-calendar-column:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.datemenu-calendar-column:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.datemenu-calendar-column:ltr {
+  margin-right: 2px;
+  margin-left: 6px;
+  border-left-width: 0;
+}
+
+.datemenu-calendar-column:rtl {
+  margin-left: 2px;
+  margin-right: 6px;
+  border-right-width: 0;
+}
+
+.datemenu-calendar-column .datemenu-displays-section {
+  padding-bottom: 0;
+}
+
+.datemenu-calendar-column .datemenu-displays-box {
+  spacing: 4px;
+}
+
+.datemenu-today-button {
+  min-height: 48px;
+  padding: 4px;
+  border-radius: 3px;
+  border: none;
+  box-shadow: none;
+  text-shadow: none;
+  background: none;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.datemenu-today-button .day-label {
+  font-size: 15pt;
+  font-weight: 500;
+  font-weight: bold;
+}
+
+.datemenu-today-button .date-label {
+  font-size: 18pt;
+  font-weight: 400;
+}
+
+.datemenu-today-button:hover, .datemenu-today-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.datemenu-today-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.pager-button {
+  width: 28px;
+  height: 28px;
+  margin: 2px !important;
+  padding: 0 !important;
+  border-radius: 9999px;
+  background-color: transparent;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.pager-button:hover, .pager-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.pager-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.calendar-change-month-back {
+  padding: 2px !important;
+  background-image: url("assets/calendar-arrow-left.svg");
+}
+
+.calendar-change-month-back:rtl {
+  background-image: url("assets/calendar-arrow-right.svg");
+}
+
+.calendar-change-month-forward {
+  padding: 2px !important;
+  background-image: url("assets/calendar-arrow-right.svg");
+}
+
+.calendar-change-month-forward:rtl {
+  background-image: url("assets/calendar-arrow-left.svg");
+}
+
+.calendar-day {
+  font-size: 9pt;
+  font-weight: 400;
+  text-align: center;
+  width: 28px !important;
+  height: 28px !important;
+  padding: 2px !important;
+  margin: 2px !important;
+  border-radius: 9999px;
+  color: rgba(0, 0, 0, 0.54) !important;
+  background-color: transparent !important;
+  border: none;
+  font-feature-settings: "tnum";
+  text-shadow: none;
+}
+
+.calendar-day:hover, .calendar-day:focus {
+  background-color: rgba(0, 0, 0, 0.06) !important;
+  box-shadow: none !important;
+}
+
+.calendar-day:active {
+  color: rgba(0, 0, 0, 0.54) !important;
+  background-color: rgba(0, 0, 0, 0.2) !important;
+  border-color: transparent;
+}
+
+.calendar-day:selected {
+  color: rgba(0, 0, 0, 0.87) !important;
+  background-color: rgba(0, 0, 0, 0.2) !important;
+  border-color: transparent;
+  box-shadow: none !important;
+}
+
+.calendar-day {
+  border-width: 0;
+}
+
+.calendar-day-top {
+  border-top-width: 0;
+}
+
+.calendar-day-left {
+  border-left-width: 0;
+}
+
+.calendar-nonwork-day {
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.calendar-today {
+  font-weight: bold !important;
+  color: white !important;
+  background-color: #1A73E8 !important;
+  border: none;
+}
+
+.calendar-today:hover, .calendar-today:focus {
+  background-color: #287ce9 !important;
+  color: white !important;
+  box-shadow: none !important;
+}
+
+.calendar-today:active, .calendar-today:selected {
+  background-color: #1A73E8 !important;
+  color: white !important;
+  box-shadow: none !important;
+}
+
+.calendar-today:active:hover, .calendar-today:active:focus, .calendar-today:selected:hover, .calendar-today:selected:focus {
+  background-color: #287ce9 !important;
+  color: white !important;
+}
+
+.calendar-day-with-events {
+  color: rgba(0, 0, 0, 0.38);
+  background-image: url("assets/calendar-today.svg");
+}
+
+.calendar-day-with-events.calendar-work-day {
+  color: rgba(0, 0, 0, 0.38);
+  font-weight: bold;
+}
+
+.calendar-weekend {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.calendar-other-month {
+  color: rgba(0, 0, 0, 0.26) !important;
+  opacity: 1;
+  font-weight: normal;
+}
+
+.calendar-other-month.calendar-weekend {
+  color: rgba(0, 0, 0, 0.26) !important;
+}
+
+.calendar-week-number {
+  height: 1.8em !important;
+  width: 2.6em !important;
+  padding: 0px 0 !important;
+  margin: 4px 0 !important;
+  border-radius: 9999px;
+  background-color: rgba(0, 0, 0, 0.04);
+  color: rgba(0, 0, 0, 0.38);
+  font-size: inherit;
+  font-weight: bold;
+  text-align: center;
+  text-shadow: none;
+}
+
+.world-clocks-button,
+.weather-button,
+.events-button {
+  padding: 4px 8px;
+  border-radius: 3px;
+  box-shadow: none;
+  text-shadow: none;
+  color: rgba(0, 0, 0, 0.54);
+  background-color: rgba(255, 255, 255, 0.35) !important;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.world-clocks-button:hover, .world-clocks-button:focus,
+.weather-button:hover,
+.weather-button:focus,
+.events-button:hover,
+.events-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06) !important;
+  border-color: rgba(0, 0, 0, 0.15);
+  box-shadow: none;
+}
+
+.world-clocks-button:active,
+.weather-button:active,
+.events-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.08) !important;
+  box-shadow: none;
+}
+
+.world-clocks-header,
+.weather-header,
+.message-list-section-title,
+.events-section-title,
+.events-title {
+  color: rgba(0, 0, 0, 0.38);
+  font-weight: bold;
+  margin-bottom: 4px;
+  text-shadow: none;
+}
+
+.weather-grid,
+.world-clocks-grid {
+  spacing-rows: 8px;
+  spacing-columns: 16px;
+}
+
+.world-clocks-header,
+.weather-header,
+.events-section-title {
+  color: rgba(0, 0, 0, 0.38);
+  font-weight: bold;
+}
+
+.events-button .events-box {
+  spacing: 4px;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.events-button .events-list {
+  spacing: 8px;
+  text-shadow: none;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.events-button .event-time {
+  color: rgba(0, 0, 0, 0.26);
+  font-feature-settings: "tnum";
+}
+
+.world-clocks-button .world-clocks-city {
+  color: rgba(0, 0, 0, 0.38);
+  font-weight: normal;
+  font-size: 1em;
+}
+
+.world-clocks-button .world-clocks-time {
+  color: rgba(0, 0, 0, 0.38);
+  font-feature-settings: "tnum";
+  font-weight: bold;
+  font-size: 1em;
+}
+
+.world-clocks-button .world-clocks-time:ltr {
+  text-align: right;
+}
+
+.world-clocks-button .world-clocks-time:rtl {
+  text-align: left;
+}
+
+.world-clocks-button .world-clocks-timezone {
+  color: rgba(0, 0, 0, 0.38);
+  font-feature-settings: "tnum";
+  font-size: 1em;
+}
+
+.weather-button .weather-box {
+  spacing: 4px;
+}
+
+.weather-button .weather-header-box {
+  spacing: 4px;
+}
+
+.weather-button .weather-header.location {
+  font-weight: normal;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.weather-button .weather-forecast-icon {
+  icon-size: 24px;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.weather-button .weather-forecast-time {
+  color: rgba(0, 0, 0, 0.38);
+  font-size: 0.8em;
+  font-feature-settings: "tnum";
+  font-weight: normal;
+  padding-top: 0.2em;
+  padding-bottom: 0.4em;
+}
+
+.weather-button .weather-forecast-temp {
+  font-weight: bold;
+  color: rgba(0, 0, 0, 0.52);
+  text-shadow: none;
+}
+
+/* Message List */
+.message-list {
+  width: 29em;
+  padding: 0;
+  color: rgba(0, 0, 0, 0.54);
+  text-shadow: none;
+  box-shadow: none;
+  border: 0 solid rgba(0, 0, 0, 0.12);
+}
+
+.message-list:ltr {
+  margin-left: 4px;
+  margin-right: 0;
+  padding-right: 8px;
+  border-right-width: 1px;
+}
+
+.message-list:rtl {
+  margin-right: 4px;
+  margin-left: 0;
+  padding-left: 8px;
+  border-left-width: 1px;
+}
+
+.message-list .message-list-placeholder {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.message-list .message-list-placeholder > StIcon {
+  icon-size: 96px;
+  margin-bottom: 6px;
+  -st-icon-style: symbolic;
+}
+
+.message-view {
+  -st-vfade-offset: 68px;
+}
+
+.message-view:ltr {
+  margin-right: 0;
+}
+
+.message-view:rtl {
+  margin-left: 0;
+}
+
+.message-view .message {
+  margin-bottom: 8px !important;
+}
+
+.message-list-controls {
+  padding: 8px;
+  padding-bottom: 4px;
+  spacing: 4px;
+}
+
+.message-list-controls .dnd-button {
+  border-width: 2px;
+  border-color: transparent;
+  border-radius: 32px;
+  border-style: solid;
+}
+
+.message-list-controls .dnd-button:focus {
+  border-color: rgba(26, 115, 232, 0.6);
+}
+
+.message-notification-group {
+  spacing: 8px;
+}
+
+.message-notification-group .message-group-header {
+  padding: 4px;
+}
+
+.message-notification-group .message-group-header .message-group-title {
+  margin: 0 2px;
+}
+
+.message-notification-group .message-collapse-button {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.07);
+  padding: 4px;
+}
+
+.message-notification-group .message-collapse-button:hover {
+  background-color: rgba(0, 0, 0, 0.17);
+}
+
+.message-notification-group .message-collapse-button:active {
+  background-color: rgba(0, 0, 0, 0.07);
+}
+
+.message {
+  background-color: rgba(255, 255, 255, 0.35);
+  border-radius: 3px;
+  color: rgba(0, 0, 0, 0.54);
+  text-shadow: none;
+  padding: 0;
+  margin: 2px;
+  box-shadow: 0 3px 8px -2px rgba(0, 0, 0, 0.15);
+  background-color: rgba(255, 255, 255, 0.95);
+  border: 1px solid transparent;
+  border-left: none;
+  border-bottom: none;
+}
+
+.message:hover, .message:focus, .message:active {
+  background-color: #ffffff;
+}
+
+.popup-menu .message {
+  margin: 0 0 2px;
+  box-shadow: none;
+  background-color: rgba(255, 255, 255, 0.35);
+  border-radius: 3px;
+  color: rgba(0, 0, 0, 0.54);
+  border: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.popup-menu .message:hover, .popup-menu .message:focus {
+  background-color: rgba(0, 0, 0, 0.06);
+  border-color: rgba(0, 0, 0, 0.15);
+}
+
+.popup-menu .message:active {
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.message:second-in-stack {
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.message:lower-in-stack {
+  box-shadow: none;
+}
+
+.message .message-header {
+  padding: 0 0.409em;
+  spacing: 4px;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.message .message-header:ltr {
+  padding-right: 0;
+}
+
+.message .message-header:rtl {
+  padding-left: 0;
+}
+
+.message .message-header .message-source-icon {
+  icon-size: 1.091em;
+  -st-icon-style: symbolic;
+}
+
+.message .message-header .message-header-content {
+  spacing: 4px;
+  min-height: 1.637em;
+  padding-bottom: 4px;
+}
+
+.message .message-header .message-header-content .message-source-title {
+  font-weight: bold;
+}
+
+.message .message-header .message-header-content .event-time {
+  color: rgba(0, 0, 0, 0.38);
+  padding-bottom: 0.068em;
+}
+
+.message .message-header .message-header-content .event-time:ltr {
+  text-align: right;
+}
+
+.message .message-header .message-header-content .event-time:rtl {
+  text-align: left;
+}
+
+.message .message-header .message-expand-button,
+.message .message-header .message-close-button {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0);
+  padding: 4px;
+}
+
+.message .message-header .message-expand-button:hover,
+.message .message-header .message-close-button:hover {
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.message .message-header .message-expand-button:active, .message .message-header .message-expand-button:active:hover,
+.message .message-header .message-close-button:active,
+.message .message-header .message-close-button:active:hover {
+  background-color: rgba(0, 0, 0, 0.11);
+}
+
+.message .message-header .message-expand-button:insensitive,
+.message .message-header .message-close-button:insensitive {
+  background-color: rgba(0, 0, 0, 0);
+}
+
+.message .message-header .message-expand-button {
+  padding: 6px;
+}
+
+.message .message-header .message-expand-button:ltr {
+  margin-right: 4px;
+}
+
+.message .message-header .message-expand-button:rtl {
+  margin-left: 4px;
+}
+
+.message .message-box {
+  padding: 4px;
+  margin: 4px;
+  margin-top: 0;
+  spacing: 4px;
+}
+
+.message .message-box .message-icon {
+  icon-size: 48px;
+  -st-icon-style: symbolic;
+}
+
+.message .message-box .message-icon:ltr {
+  margin-right: 4px;
+}
+
+.message .message-box .message-icon:rtl {
+  margin-left: 4px;
+}
+
+.message .message-box .message-icon.message-themed-icon {
+  border-radius: 9999px;
+  background-color: rgba(0, 0, 0, 0.07);
+  icon-size: 16px;
+  min-width: 48px;
+  min-height: 48px;
+}
+
+.message .message-box:first-child {
+  margin-top: 8px;
+}
+
+.message .message-box .message-content {
+  spacing: 2px;
+}
+
+.message .message-box .message-content .message-title {
+  font-weight: bold;
+}
+
+.url-highlighter {
+  link-color: #1A73E8;
+}
+
+/* Media Controls */
+.message-media-control {
+  margin: 4px 0;
+  padding: 0 8px;
+  border-radius: 9999px;
+  color: rgba(0, 0, 0, 0.54);
+  border: none;
+}
+
+.message-media-control:hover, .message-media-control:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.message-media-control:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.message-media-control:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.message-media-control StIcon {
+  icon-size: 16px;
+}
+
+.media-message .message-icon {
+  border-radius: 3px !important;
+}
+
+.media-message .message-icon.message-themed-icon {
+  icon-size: 32px !important;
+}
+
+.candidate-popup-content {
+  background-color: rgba(255, 255, 255, 0.97);
+  border-radius: 3px;
+  box-shadow: 0 3px 8px -2px rgba(0, 0, 0, 0.25) !important;
+  margin: 2px 8px 11px;
+  padding: 4px;
+  spacing: 4px;
+  border: 1px solid transparent;
+}
+
+.candidate-index {
+  padding: 0 0.5em 0 0;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.candidate-box {
+  padding: 0.3em 0.5em 0.3em 0.5em;
+  margin-right: 2px;
+  border-radius: 3px;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.candidate-box:hover {
+  background-color: rgba(0, 0, 0, 0.06);
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.candidate-box:active {
+  background-color: rgba(0, 0, 0, 0.2);
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.candidate-box:selected {
+  background-color: rgba(0, 0, 0, 0.06);
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.candidate-box:last-child {
+  margin-right: 0;
+}
+
+.candidate-page-button-box {
+  height: 2em;
+}
+
+.vertical .candidate-page-button-box {
+  padding-top: 0.5em;
+}
+
+.horizontal .candidate-page-button-box {
+  padding-left: 0.5em;
+}
+
+.candidate-page-button {
+  padding: 4px;
+}
+
+.candidate-page-button-previous {
+  border-radius: 3px 0px 0px 3px;
+  border-right-width: 0;
+}
+
+.candidate-page-button-next {
+  border-radius: 0px 3px 3px 0px;
+}
+
+.candidate-page-button-icon {
+  icon-size: 1em;
+}
+
+/* Notifications & Message Tray */
+.notification-banner {
+  min-height: 64px;
+  width: 34em;
+  margin: 4px;
+  border-radius: 6px;
+}
+
+.notification-buttons-bin {
+  spacing: 0;
+  padding: 0 4px 4px;
+  margin: 0;
+  border: none;
+}
+
+.notification-button {
+  min-height: 20px;
+  padding: 4px 8px;
+  font-weight: bold;
+}
+
+.hotplug-notification-item {
+  padding: 2px 10px;
+  border-top: 1px solid rgba(0, 0, 0, 0.12);
+  text-shadow: none;
+  font-size: 9.75pt;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.54);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.hotplug-notification-item:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+  box-shadow: none;
+}
+
+.hotplug-notification-item:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+.hotplug-notification-item:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.hotplug-notification-item:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: none;
+}
+
+.hotplug-notification-item:first-child {
+  border-radius: 0 0 0 3px;
+}
+
+.hotplug-notification-item:last-child {
+  border-radius: 0 0 3px 0;
+}
+
+.hotplug-notification-item:first-child:last-child {
+  border-radius: 0 0 3px 3px;
+}
+
+.hotplug-notification-item-icon {
+  icon-size: 24px;
+  padding: 0 4px;
+}
+
+/* Modal Dialogs */
+.headline {
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+.modal-dialog {
+  padding: 0;
+}
+
+.modal-dialog .modal-dialog-content-box {
+  margin: 32px 40px 42px;
+  spacing: 32px;
+  max-width: 28em;
+}
+
+.modal-dialog .modal-dialog-button-box {
+  padding: 8px;
+  background: rgba(0, 0, 0, 0.06);
+  border-radius: 0 0 6px 6px;
+  border-top: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.modal-dialog .modal-dialog-button {
+  font-weight: bold;
+  background-gradient-direction: none !important;
+  margin: 0 !important;
+}
+
+/* End Session Dialog */
+.end-session-dialog {
+  width: 30em;
+}
+
+.end-session-dialog .end-session-dialog-battery-warning,
+.end-session-dialog .dialog-list-title {
+  color: #FF6D00;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child {
+  background-color: #FF5252 !important;
+  color: white !important;
+  border-color: rgba(224, 72, 72, 0.9805) !important;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child:hover {
+  background-color: #ff8080 !important;
+  border-color: rgba(203, 65, 65, 0.9675) !important;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child:active {
+  background-color: #ff5c5c !important;
+  border-color: rgba(203, 65, 65, 0.9675) !important;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child:insensitive {
+  color: rgba(255, 255, 255, 0.5) !important;
+  background-color: rgba(255, 82, 82, 0.35) !important;
+  border-color: rgba(235, 76, 76, 0.987) !important;
+}
+
+/* Message Dialog */
+.message-dialog-content {
+  spacing: 18px;
+}
+
+.message-dialog-content .message-dialog-title {
+  text-align: center;
+  font-size: 18pt;
+  font-weight: 800;
+}
+
+.message-dialog-content .message-dialog-title.lightweight {
+  font-size: 13pt;
+  font-weight: 800;
+}
+
+.message-dialog-content .message-dialog-description {
+  text-align: center;
+}
+
+/* Dialog List */
+.dialog-list {
+  spacing: 18px;
+}
+
+.dialog-list .dialog-list-title {
+  text-align: center;
+  font-weight: bold;
+}
+
+.dialog-list .dialog-list-scrollview {
+  max-height: 200px;
+}
+
+.dialog-list .dialog-list-box {
+  spacing: 1em;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item {
+  spacing: 1em;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item .dialog-list-item-title {
+  font-weight: bold;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item .dialog-list-item-description {
+  color: rgba(0, 0, 0, 0.54);
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+/* Run Dialog */
+.run-dialog .modal-dialog-content-box {
+  margin-top: 24px;
+  margin-bottom: 14px;
+}
+
+.run-dialog .run-dialog-entry {
+  width: 20em;
+}
+
+.run-dialog .run-dialog-description {
+  font-size: 11.25pt;
+  font-weight: 400;
+  text-align: center;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+/* Password or Authentication Dialog */
+.prompt-dialog {
+  width: 28em;
+}
+
+.prompt-dialog .modal-dialog-content-box {
+  margin-bottom: 24px;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child {
+  background-color: #287ce9 !important;
+  color: white !important;
+  border-color: rgba(35, 109, 205, 0.9805) !important;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:hover {
+  background-color: #5295ee !important;
+  border-color: rgba(32, 98, 186, 0.9675) !important;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:active {
+  background-color: #3181ea !important;
+  border-color: rgba(32, 98, 186, 0.9675) !important;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:insensitive {
+  color: rgba(255, 255, 255, 0.5) !important;
+  background-color: rgba(40, 124, 233, 0.35) !important;
+  border-color: rgba(37, 114, 215, 0.987) !important;
+}
+
+.prompt-dialog-password-grid {
+  spacing-rows: 8px;
+  spacing-columns: 4px;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry {
+  width: auto;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry:ltr {
+  margin-left: 20px;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry:rtl {
+  margin-right: 20px;
+}
+
+.prompt-dialog-password-layout {
+  spacing: 8px;
+}
+
+.prompt-dialog-password-entry {
+  width: 20em;
+}
+
+.prompt-dialog-error-label,
+.prompt-dialog-info-label,
+.prompt-dialog-null-label {
+  text-align: center;
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+.prompt-dialog-error-label {
+  color: #FF6D00;
+}
+
+/* Polkit Dialog */
+.polkit-dialog-user-layout {
+  text-align: center;
+  spacing: 8px;
+  margin-bottom: 6px;
+}
+
+.polkit-dialog-user-layout .polkit-dialog-user-root-label {
+  color: #FF6D00;
+}
+
+/* Audio selection dialog */
+.audio-device-selection-dialog .modal-dialog-content-box {
+  margin-bottom: 28px;
+}
+
+.audio-device-selection-dialog .audio-selection-box {
+  spacing: 20px;
+}
+
+.audio-selection-device {
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 3px;
+}
+
+.audio-selection-device:active, .audio-selection-device:hover, .audio-selection-device:focus {
+  background-color: #1A73E8;
+}
+
+.audio-selection-device-box {
+  padding: 20px;
+  spacing: 20px;
+}
+
+.audio-selection-device-icon {
+  icon-size: 64px;
+}
+
+/* Welcome dialog */
+.welcome-dialog-image {
+  background-image: url("resource:///org/gnome/shell/theme/gnome-shell-start.svg");
+  background-size: contain;
+  /* Reasonable maximum dimensions */
+  height: 300px;
+  width: 300px;
+}
+
+/* Network Dialogs */
+.nm-dialog {
+  max-height: 34em;
+  min-height: 31em;
+  min-width: 32em;
+}
+
+.nm-dialog-content {
+  spacing: 20px;
+  padding: 24px;
+}
+
+.nm-dialog-airplane-box {
+  spacing: 12px;
+}
+
+.nm-dialog-airplane-headline {
+  font-weight: bold;
+  text-align: center;
+}
+
+.nm-dialog-airplane-text {
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.nm-dialog-header {
+  font-weight: bold;
+}
+
+.nm-dialog-header-icon {
+  icon-size: 32px;
+}
+
+.nm-dialog-header-hbox {
+  spacing: 10px;
+}
+
+.nm-dialog-scroll-view {
+  border: none;
+  background-color: rgba(0, 0, 0, 0.06);
+  border-radius: 3px;
+  padding: 8px;
+  padding-right: 0;
+}
+
+.nm-dialog-item {
+  font-size: 1em;
+  border-bottom: none;
+  border-radius: -1px;
+  padding: 8px;
+  spacing: 0px;
+}
+
+.nm-dialog-item:hover, .nm-dialog-item:focus {
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.nm-dialog-item:active {
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.nm-dialog-item:selected {
+  background-color: #1A73E8;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.nm-dialog-icon {
+  icon-size: 16px;
+}
+
+.nm-dialog-icons {
+  spacing: 8px;
+}
+
+.no-networks-label {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.no-networks-box {
+  spacing: 4px;
+}
+
+/* OSD */
+.screenshot-ui-panel, .workspace-switcher-container, .switcher-list, .resize-popup, .osd-window {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #222222;
+  border: none;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.35);
+  border-radius: 3px;
+  padding: 8px;
+}
+
+.osd-window {
+  text-align: center;
+  font-weight: bold;
+  spacing: 8px;
+  padding: 8px 12px;
+  margin-bottom: 4em;
+}
+
+.osd-window > * {
+  spacing: 8px;
+}
+
+.osd-window StIcon {
+  icon-size: 32px;
+}
+
+.osd-window StLabel:ltr {
+  margin-right: 6px;
+}
+
+.osd-window StLabel:rtl {
+  margin-left: 6px;
+}
+
+.osd-window .osd-monitor-label {
+  font-size: 3em;
+}
+
+.osd-window .level {
+  height: 4px;
+  -barlevel-height: 4px;
+  -barlevel-background-color: rgba(26, 115, 232, 0.3);
+  -barlevel-active-background-color: #1A73E8;
+  -barlevel-overdrive-color: #FF5252;
+  -barlevel-overdrive-separator-width: 3px;
+  -barlevel-border-width: 0;
+}
+
+/* Pad OSD */
+.pad-osd-window {
+  padding: 32px;
+  background-color: rgba(0, 0, 0, 0.8);
+  border: none;
+}
+
+.pad-osd-window .pad-osd-title-box {
+  spacing: 12px;
+}
+
+.pad-osd-window .pad-osd-title-menu-box {
+  spacing: 6px;
+}
+
+.combo-box-label {
+  width: 15em;
+}
+
+/* App Switcher */
+.switcher-popup {
+  padding: 8px;
+  spacing: 16px;
+}
+
+.switcher-list .item-box {
+  padding: 8px;
+  border-radius: 3px;
+  border: none;
+}
+
+.switcher-list .item-box:outlined {
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.switcher-list .item-box:selected {
+  background-color: #1A73E8;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.switcher-list .thumbnail-box {
+  padding: 2px;
+  spacing: 4px;
+}
+
+.switcher-list .thumbnail {
+  width: 256px;
+}
+
+.switcher-list .separator {
+  width: 1px;
+  background: rgba(0, 0, 0, 0.12);
+}
+
+.switcher-list .switcher-list-item-container {
+  spacing: 8px;
+}
+
+.switcher-arrow {
+  border-color: rgba(0, 0, 0, 0);
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.switcher-arrow:highlighted {
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.input-source-switcher-symbol {
+  font-size: 34pt;
+  width: 96px;
+  height: 96px;
+}
+
+.cycler-highlight {
+  border: 5px solid #1A73E8;
+}
+
+/* Workspace Switcher */
+.workspace-switcher-group {
+  padding: 8px;
+}
+
+.workspace-switcher {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  spacing: 8px;
+}
+
+.ws-switcher-box {
+  height: 50px;
+  background-size: 32px;
+  border: none;
+  background: rgba(0, 0, 0, 0.06);
+  border-radius: 3px;
+}
+
+.ws-switcher-active-up,
+.ws-switcher-active-down,
+.ws-switcher-active-left,
+.ws-switcher-active-right {
+  height: 52px;
+  background-color: #1A73E8;
+  border: none;
+  border-radius: 5px;
+  color: #FFFFFF;
+}
+
+/* Top Bar */
+#panel .panel-button#panelActivities {
+  -natural-hpadding: 10px;
+}
+
+#panel .panel-button#panelActivities StBoxLayout {
+  spacing: 4px;
+}
+
+#panel .panel-button#panelActivities .workspace-dot {
+  border-radius: 9999px;
+  min-width: 8px;
+  min-height: 8px;
+  background-color: #FFFFFF;
+}
+
+#panel {
+  font-weight: normal;
+  font-feature-settings: "tnum";
+  transition-duration: 250ms;
+  border: none;
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.5);
+  margin: 0;
+  border-radius: 0;
+  height: 30px;
+}
+
+#panel #panelLeft, #panel #panelCenter {
+  spacing: 0;
+}
+
+#panel .panel-corner {
+  -panel-corner-radius: 0;
+  -panel-corner-background-color: rgba(0, 0, 0, 0.5);
+  -panel-corner-border-width: 0;
+  -panel-corner-border-color: transparent;
+  -panel-corner-opacity: 0;
+  transition-duration: 250ms;
+}
+
+#panel .panel-button {
+  -natural-hpadding: 4px;
+  -minimum-hpadding: 4px;
+  font-weight: normal;
+  color: rgba(255, 255, 255, 0.75);
+  transition-duration: 150ms;
+  text-shadow: none;
+  border-radius: 0;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#panel .panel-button StLabel {
+  padding: 0;
+}
+
+#panel .panel-button:hover {
+  color: rgba(255, 255, 255, 0.75);
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+#panel .panel-button:active, #panel .panel-button:checked, #panel .panel-button:focus {
+  color: #FFFFFF;
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#panel .panel-button:hover, #panel .panel-button:active, #panel .panel-button:overview, #panel .panel-button:focus, #panel .panel-button:checked {
+  text-shadow: none;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#panel .panel-button.clock-display {
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#panel .panel-button.clock-display:hover {
+  color: rgba(255, 255, 255, 0.75);
+  background-color: rgba(255, 255, 255, 0.1) !important;
+}
+
+#panel .panel-button.clock-display:active, #panel .panel-button.clock-display:checked, #panel .panel-button.clock-display:focus {
+  color: #FFFFFF;
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#panel .panel-button.clock-display:active .clock, #panel .panel-button.clock-display:checked .clock, #panel .panel-button.clock-display:focus .clock {
+  box-shadow: none;
+  background: none;
+  color: #FFFFFF;
+}
+
+#panel .panel-button.clock-display:hover, #panel .panel-button.clock-display:active, #panel .panel-button.clock-display:checked, #panel .panel-button.clock-display:focus {
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#panel .panel-button.clock-display .clock {
+  color: rgba(255, 255, 255, 0.75);
+  transition-duration: 150ms;
+  border: none;
+  border-radius: 0;
+}
+
+#panel .panel-button.clock-display .messages-indicator {
+  icon-size: 1.091em;
+}
+
+#panel .panel-button .system-status-icon {
+  icon-size: 16px;
+  padding: 4px;
+  margin: 0 2px;
+}
+
+#panel .panel-button .panel-status-menu-box .system-status-icon {
+  margin: 0;
+}
+
+#panel .panel-button .panel-status-menu-box StLabel {
+  padding: 0 0 0 2px;
+}
+
+#panel .panel-button .panel-status-menu-box,
+#panel .panel-button .panel-status-indicators-box {
+  spacing: 2px;
+}
+
+#panel .panel-button .appindicator-trayicons-box,
+#panel .panel-button .panel-status-indicators-box.appindicator-box {
+  margin: 0 4px;
+}
+
+#panel .panel-button .clipboard-indicator-icon {
+  margin: 0 4px;
+}
+
+#panel .panel-button .app-menu-icon {
+  -st-icon-style: symbolic;
+}
+
+#panel.unlock-screen, #panel.login-screen, #panel.lock-screen, #panel:overview {
+  background-color: transparent;
+}
+
+#panel.unlock-screen .panel-button, #panel.login-screen .panel-button, #panel.lock-screen .panel-button, #panel:overview .panel-button {
+  border-radius: 3px;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+}
+
+#panel.unlock-screen .panel-button:hover, #panel.login-screen .panel-button:hover, #panel.lock-screen .panel-button:hover, #panel:overview .panel-button:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#panel.unlock-screen .panel-button:active, #panel.unlock-screen .panel-button:checked, #panel.unlock-screen .panel-button:focus, #panel.login-screen .panel-button:active, #panel.login-screen .panel-button:checked, #panel.login-screen .panel-button:focus, #panel.lock-screen .panel-button:active, #panel.lock-screen .panel-button:checked, #panel.lock-screen .panel-button:focus, #panel:overview .panel-button:active, #panel:overview .panel-button:checked, #panel:overview .panel-button:focus {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+#panel.unlock-screen .panel-button.clock-display:hover, #panel.login-screen .panel-button.clock-display:hover, #panel.lock-screen .panel-button.clock-display:hover, #panel:overview .panel-button.clock-display:hover {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#panel.unlock-screen .panel-button.clock-display:active, #panel.unlock-screen .panel-button.clock-display:checked, #panel.unlock-screen .panel-button.clock-display:focus, #panel.login-screen .panel-button.clock-display:active, #panel.login-screen .panel-button.clock-display:checked, #panel.login-screen .panel-button.clock-display:focus, #panel.lock-screen .panel-button.clock-display:active, #panel.lock-screen .panel-button.clock-display:checked, #panel.lock-screen .panel-button.clock-display:focus, #panel:overview .panel-button.clock-display:active, #panel:overview .panel-button.clock-display:checked, #panel:overview .panel-button.clock-display:focus {
+  background-color: rgba(255, 255, 255, 0.3) !important;
+}
+
+#panel.unlock-screen .panel-button.clock-display .clock, #panel.login-screen .panel-button.clock-display .clock, #panel.lock-screen .panel-button.clock-display .clock, #panel:overview .panel-button.clock-display .clock {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+#panel.unlock-screen .panel-button#panelActivities, #panel.login-screen .panel-button#panelActivities, #panel.lock-screen .panel-button#panelActivities, #panel:overview .panel-button#panelActivities {
+  box-shadow: none;
+  border: none;
+  background-color: transparent;
+}
+
+#panel.unlock-screen .panel-button#panelActivities:hover, #panel.login-screen .panel-button#panelActivities:hover, #panel.lock-screen .panel-button#panelActivities:hover, #panel:overview .panel-button#panelActivities:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#panel.unlock-screen .panel-button#panelActivities .workspace-dot, #panel.login-screen .panel-button#panelActivities .workspace-dot, #panel.lock-screen .panel-button#panelActivities .workspace-dot, #panel:overview .panel-button#panelActivities .workspace-dot {
+  background-color: rgba(255, 255, 255, 0.85);
+}
+
+#panel.unlock-screen .panel-corner, #panel.login-screen .panel-corner, #panel.lock-screen .panel-corner, #panel:overview .panel-corner {
+  -panel-corner-opacity: 0;
+  -panel-corner-radius: 0;
+  -panel-corner-background-color: transparent;
+  -panel-corner-border-color: transparent;
+}
+
+#panel Gjs_ui_panel_AggregateMenu.panel-button .system-status-icon {
+  margin: 0 !important;
+  padding: 4px !important;
+}
+
+#panel Gjs_kimpanel_kde_org_indicator_KimIndicator.panel-button .panel-status-menu-box {
+  margin: 0 4px;
+}
+
+#panel .screencast-indicator,
+#panel .remote-access-indicator {
+  color: #FF6D00;
+}
+
+#appMenu {
+  spacing: 4px;
+}
+
+#appMenu .label-shadow {
+  color: transparent;
+}
+
+#appMenu .panel-status-menu-box {
+  padding: 0 4px;
+  spacing: 4px;
+}
+
+/* Activities Ripple */
+.ripple-box {
+  background-color: rgba(26, 115, 232, 0.35);
+  width: 52px;
+  height: 52px;
+  border-radius: 0 0 52px 0;
+}
+
+.ripple-box:rtl {
+  border-radius: 0 0 0 52px;
+}
+
+/* OVERVIEW */
+.controls-manager, .secondary-monitor-workspaces {
+  spacing: 8px;
+}
+
+#overviewGroup {
+  background-color: #222222;
+}
+
+.overview-controls {
+  padding-bottom: 32px;
+}
+
+/* Window Picker */
+.window-picker {
+  spacing: 4px;
+}
+
+.window-caption {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(32, 32, 32, 0.9);
+  border-radius: 6px;
+  padding: 4px 8px;
+}
+
+.window-close, .screenshot-ui-close-button {
+  background-color: #1A73E8;
+  color: white;
+  border-radius: 9999px;
+  padding: 3px;
+  height: 30px;
+  width: 30px;
+  box-shadow: -1px 1px 5px 0px rgba(0, 0, 0, 0.5);
+  transition-duration: 300ms;
+}
+
+.window-close StIcon, .screenshot-ui-close-button StIcon {
+  icon-size: 24px;
+}
+
+.window-close:hover, .screenshot-ui-close-button:hover {
+  background-color: #609eef;
+}
+
+.window-close:active, .screenshot-ui-close-button:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #1567d3;
+}
+
+.workspace-background {
+  border-radius: 30px;
+  background-color: #222222;
+  box-shadow: 0 4px 16px 4px rgba(0, 0, 0, 0.3);
+  border: none;
+}
+
+.search-entry {
+  min-height: 24px;
+  padding: 2px 4px;
+  width: 320px;
+  border: none !important;
+  border-radius: 3px;
+  selection-background-color: #1A73E8;
+  selected-color: #FFFFFF !important;
+  caret-color: rgba(0, 0, 0, 0.54);
+  color: rgba(0, 0, 0, 0.54);
+  background-color: #ffffff;
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+.search-entry:hover {
+  border: 2px solid rgba(0, 0, 0, 0.2) !important;
+}
+
+.search-entry:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #1A73E8 !important;
+}
+
+.search-entry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.search-entry .search-entry-icon {
+  icon-size: 16px;
+  padding: 0 4px;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.search-entry StLabel.hint-text {
+  margin-left: 2px;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+#overview .search-entry {
+  min-height: 24px;
+  padding: 4px 6px;
+  margin-top: 8px;
+  margin-bottom: 4px;
+  border-radius: 5px;
+  caret-color: rgba(0, 0, 0, 0.75);
+  color: rgba(0, 0, 0, 0.75);
+  background-color: rgba(255, 255, 255, 0.75) !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#overview .search-entry:hover {
+  color: rgba(0, 0, 0, 0.75);
+  background-color: rgba(255, 255, 255, 0.85) !important;
+}
+
+#overview .search-entry:focus {
+  color: rgba(0, 0, 0, 0.85);
+  background-color: rgba(255, 255, 255, 0.95) !important;
+  border: none !important;
+  selection-background-color: #1A73E8;
+  selected-color: #FFFFFF !important;
+}
+
+#overview .search-entry .search-entry-icon {
+  color: rgba(0, 0, 0, 0.65);
+}
+
+#overview .search-entry:hover .search-entry-icon, #overview .search-entry:focus .search-entry-icon {
+  color: rgba(0, 0, 0, 0.75);
+}
+
+#overview .search-entry StLabel.hint-text {
+  color: rgba(0, 0, 0, 0.35);
+}
+
+/* Search */
+#searchResults {
+  margin: 0 4px;
+}
+
+#searchResultsContent {
+  max-width: 1044px;
+}
+
+.search-section {
+  spacing: 8px;
+}
+
+.search-section .search-section-separator {
+  height: 4px;
+  background-color: transparent;
+}
+
+.search-section-content {
+  background-color: rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.1);
+  text-shadow: none;
+  color: rgba(255, 255, 255, 0.85);
+  padding: 12px;
+  spacing: 4px;
+}
+
+.list-search-result, .search-provider-icon {
+  border-radius: 6px;
+}
+
+.search-statustext {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.grid-search-results {
+  spacing: 24px;
+  margin: 0 6px;
+}
+
+.search-provider-icon:ltr {
+  margin-right: 2px;
+}
+
+.search-provider-icon:rtl {
+  margin-left: 2px;
+}
+
+.search-provider-icon .list-search-provider-content {
+  spacing: 8px;
+}
+
+.search-provider-icon .list-search-provider-content .list-search-provider-details {
+  width: 120px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.list-search-results {
+  spacing: 4px;
+}
+
+.list-search-result .list-search-result-content {
+  spacing: 4px;
+}
+
+.list-search-result .list-search-result-title {
+  spacing: 8px;
+}
+
+.list-search-result .list-search-result-description {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+/* Dash */
+#dash {
+  padding-left: 4px;
+  padding-right: 4px;
+}
+
+#dash .dash-background {
+  background-color: rgba(255, 255, 255, 0.2);
+  border-radius: 11px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 7px;
+  padding-right: 7px;
+}
+
+#dash .dash-item-container .placeholder {
+  background-image: none;
+  background-size: contain;
+  height: 32px;
+}
+
+#dash .dash-item-container .empty-dash-drop-target {
+  width: 32px;
+  height: 32px;
+}
+
+#dash .dash-item-container .show-apps,
+#dash .dash-item-container .overview-tile,
+#dash .dash-item-container .grid-search-result,
+#dash .dash-item-container .search-provider-icon,
+#dash .dash-item-container .list-search-result {
+  margin: 0 1px;
+  padding-bottom: 6px;
+}
+
+#dash .dash-item-container .show-apps .overview-icon,
+#dash .dash-item-container .overview-tile .overview-icon,
+#dash .dash-item-container .grid-search-result .overview-icon,
+#dash .dash-item-container .search-provider-icon .overview-icon,
+#dash .dash-item-container .list-search-result .overview-icon {
+  background-color: transparent;
+}
+
+#dash .dash-item-container .show-apps:focus .overview-icon,
+#dash .dash-item-container .overview-tile:focus .overview-icon,
+#dash .dash-item-container .grid-search-result:focus .overview-icon,
+#dash .dash-item-container .search-provider-icon:focus .overview-icon,
+#dash .dash-item-container .list-search-result:focus .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#dash .dash-item-container .show-apps:hover .overview-icon,
+#dash .dash-item-container .overview-tile:hover .overview-icon,
+#dash .dash-item-container .grid-search-result:hover .overview-icon,
+#dash .dash-item-container .search-provider-icon:hover .overview-icon,
+#dash .dash-item-container .list-search-result:hover .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#dash .dash-item-container .show-apps:active .overview-icon,
+#dash .dash-item-container .overview-tile:active .overview-icon,
+#dash .dash-item-container .grid-search-result:active .overview-icon,
+#dash .dash-item-container .search-provider-icon:active .overview-icon,
+#dash .dash-item-container .list-search-result:active .overview-icon {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+#dash .dash-item-container .show-apps:checked .overview-icon,
+#dash .dash-item-container .overview-tile:checked .overview-icon,
+#dash .dash-item-container .grid-search-result:checked .overview-icon,
+#dash .dash-item-container .search-provider-icon:checked .overview-icon,
+#dash .dash-item-container .list-search-result:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+#dash .dash-item-container .show-apps:insensitive .overview-icon,
+#dash .dash-item-container .overview-tile:insensitive .overview-icon,
+#dash .dash-item-container .grid-search-result:insensitive .overview-icon,
+#dash .dash-item-container .search-provider-icon:insensitive .overview-icon,
+#dash .dash-item-container .list-search-result:insensitive .overview-icon {
+  background-color: transparent;
+}
+
+#dash .dash-item-container .app-grid-running-dot {
+  offset-y: -8px;
+}
+
+#dash .dash-separator {
+  width: 1px;
+  margin-left: 2px;
+  margin-right: 2px;
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#dash .dash-separator,
+#dash .dash-background {
+  margin-bottom: 6px;
+}
+
+.dash-label {
+  border-radius: 3px;
+  padding: 4px 8px;
+  margin: 4px;
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(0, 0, 0, 0.75);
+  border: none;
+  box-shadow: none;
+  text-align: center;
+  -y-offset: 2px;
+}
+
+/* App Grid */
+.icon-grid {
+  row-spacing: 12px;
+  column-spacing: 12px;
+  max-row-spacing: 36px;
+  max-column-spacing: 36px;
+  page-padding-top: 24px;
+  page-padding-bottom: 24px;
+  page-padding-left: 18px;
+  page-padding-right: 18px;
+}
+
+/* App Icons */
+.overview-tile, .grid-search-result, .search-provider-icon, .list-search-result {
+  border-radius: 9px;
+  padding: 12px;
+  spacing: 6px;
+  transition-duration: 150ms;
+  text-align: center;
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.85);
+  border: 1px solid transparent;
+  box-shadow: inset 0 1px transparent;
+}
+
+.overview-tile:hover, .grid-search-result:hover, .search-provider-icon:hover, .list-search-result:hover, .overview-tile:focus, .grid-search-result:focus, .search-provider-icon:focus, .list-search-result:focus, .overview-tile:highlighted, .grid-search-result:highlighted, .search-provider-icon:highlighted, .list-search-result:highlighted, .overview-tile:selected, .grid-search-result:selected, .search-provider-icon:selected, .list-search-result:selected {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+  transition-duration: 0ms;
+  border-image: none;
+  background-image: none;
+}
+
+.overview-tile:active, .grid-search-result:active, .search-provider-icon:active, .list-search-result:active, .overview-tile:checked, .grid-search-result:checked, .search-provider-icon:checked, .list-search-result:checked {
+  background-color: rgba(255, 255, 255, 0.15);
+  transition-duration: 150ms;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.overview-tile .overview-icon.overview-icon-with-label > StBoxLayout, .grid-search-result .overview-icon.overview-icon-with-label > StBoxLayout, .search-provider-icon .overview-icon.overview-icon-with-label > StBoxLayout, .list-search-result .overview-icon.overview-icon-with-label > StBoxLayout {
+  spacing: 4px;
+}
+
+.app-folder {
+  background-color: rgba(255, 255, 255, 0.13);
+}
+
+.app-folder:focus {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.app-folder:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.app-folder:active {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.app-folder:highlighted, .app-folder:selected, .app-folder:checked {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.app-folder:insensitive {
+  background-color: transparent;
+}
+
+.app-grid-running-dot {
+  width: 6px;
+  height: 3px;
+  border-radius: 2px;
+  background-color: rgba(255, 255, 255, 0.5);
+  margin-bottom: 1px;
+}
+
+StWidget.focused .app-grid-running-dot {
+  width: 18px;
+  background-color: #1A73E8;
+}
+
+.app-folder-dialog-container {
+  padding-top: 30px;
+}
+
+.app-folder-dialog {
+  width: 720px;
+  height: 720px;
+  border-radius: 12px;
+  background-color: rgba(34, 34, 34, 0.95);
+  color: white;
+  border: none;
+  box-shadow: none;
+}
+
+.app-folder-dialog .folder-name-container {
+  padding: 24px 36px 0;
+  spacing: 12px;
+  /* FIXME: this is to keep the label in sync with the entry */
+}
+
+.app-folder-dialog .folder-name-container .folder-name-label, .app-folder-dialog .folder-name-container .folder-name-entry {
+  font-size: 18pt;
+  font-weight: 800;
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry {
+  border: none;
+  color: #FFFFFF;
+  background-color: rgba(255, 255, 255, 0.15);
+  caret-color: #FFFFFF;
+  selection-background-color: #1A73E8;
+  selected-color: #FFFFFF;
+  width: 300px;
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:focus {
+  color: #FFFFFF;
+  background-color: rgba(255, 255, 255, 0.25);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry .search-entry-icon {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:hover .search-entry-icon, .app-folder-dialog .folder-name-container .folder-name-entry:focus .search-entry-icon {
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:insensitive, .app-folder-dialog .folder-name-container .folder-name-entry StLabel.hint-text {
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-label {
+  padding: 5px 7px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.app-folder-dialog .folder-name-container .icon-button, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button {
+  background-color: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.7);
+  border: none;
+  padding: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 18px;
+}
+
+.app-folder-dialog .folder-name-container .icon-button > StIcon, .app-folder-dialog .folder-name-container .background-app-item .icon-button > StIcon, .app-folder-dialog .folder-name-container .message-notification-group .background-app-item .message-collapse-button > StIcon, .app-folder-dialog .folder-name-container .message .message-header .background-app-item .message-expand-button > StIcon,
+.app-folder-dialog .folder-name-container .message .message-header .background-app-item .message-close-button > StIcon, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button > StIcon, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button > StIcon, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button > StIcon, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button > StIcon,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button > StIcon,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button > StIcon {
+  icon-size: 16px;
+}
+
+.app-folder-dialog .folder-name-container .icon-button:hover, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button:hover, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button:hover, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:hover, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:hover,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:hover,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.app-folder-dialog .folder-name-container .icon-button:focus, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button:focus, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button:focus, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:focus, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:focus,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:focus,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:focus {
+  border: none !important;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.app-folder-dialog .folder-name-container .icon-button:checked, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button:checked, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button:checked, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:checked, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:checked,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:checked,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:checked, .app-folder-dialog .folder-name-container .icon-button:active, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button:active, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button:active, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:active, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:active,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:active,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:active {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.app-folder-dialog .icon-grid {
+  row-spacing: 12px;
+  column-spacing: 30px;
+  page-padding-top: 0;
+  page-padding-bottom: 0;
+  page-padding-left: 0;
+  page-padding-right: 0;
+}
+
+.app-folder-dialog .page-indicators {
+  margin-bottom: 18px;
+}
+
+.rename-folder-popup .rename-folder-popup-item {
+  spacing: 4px;
+}
+
+.rename-folder-popup .rename-folder-popup-item:ltr, .rename-folder-popup .rename-folder-popup-item:rtl {
+  padding: 0 8px;
+}
+
+.app-menu,
+.app-well-menu {
+  max-width: 27.25em;
+}
+
+.page-indicator {
+  padding: 4px 8px 0;
+}
+
+.page-indicator .page-indicator-icon {
+  width: 10px;
+  height: 10px;
+  border-radius: 10px;
+  background-color: white;
+  transition-duration: 400ms;
+}
+
+.apps-scroll-view {
+  padding: 0;
+}
+
+.system-action-icon {
+  background-color: rgba(0, 0, 0, 0.8);
+  color: white;
+  border-radius: 9999px;
+  icon-size: 8px;
+}
+
+.page-navigation-hint.dnd {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.page-navigation-hint.next:ltr, .page-navigation-hint.previous:rtl {
+  background-gradient-start: rgba(255, 255, 255, 0.05);
+  background-gradient-end: transparent;
+  background-gradient-direction: horizontal;
+  border-radius: 15px 0px 0px 15px;
+}
+
+.page-navigation-hint.previous:ltr, .page-navigation-hint.next:rtl {
+  background-gradient-start: transparent;
+  background-gradient-end: rgba(255, 255, 255, 0.05);
+  background-gradient-direction: horizontal;
+  border-radius: 0px 15px 15px 0px;
+}
+
+.page-navigation-arrow {
+  margin: 6px;
+  padding: 18px;
+  width: 24px;
+  height: 24px;
+  border-radius: 9999px;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+}
+
+.page-navigation-arrow > StIcon {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.page-navigation-arrow:insensitive {
+  background-color: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.page-navigation-arrow:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+  color: white;
+}
+
+.page-navigation-arrow:active {
+  background-color: rgba(255, 255, 255, 0.2);
+  color: white;
+}
+
+/* Workspace pager */
+.workspace-thumbnails .workspace-thumbnail {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.13);
+  border: none;
+}
+
+.workspace-thumbnails {
+  visible-width: 32px;
+  spacing: 4px;
+  padding: 4px;
+}
+
+.workspace-thumbnails .workspace-thumbnail {
+  border-radius: 3px;
+}
+
+.workspace-thumbnails .placeholder {
+  background-image: url("resource:///org/gnome/shell/theme/dash-placeholder.svg");
+  background-size: contain;
+  width: 18px;
+}
+
+.workspace-thumbnail-indicator {
+  border: 3px solid #1A73E8;
+  border-radius: 6px;
+  padding: 0px;
+}
+
+.ripple-pointer-location {
+  width: 48px;
+  height: 48px;
+  border-radius: 24px;
+  background-color: rgba(165, 200, 246, 0.3);
+  box-shadow: 0 0 2px 2px #77acf1;
+}
+
+.pie-timer {
+  width: 60px;
+  height: 60px;
+  -pie-border-width: 3px;
+  -pie-border-color: #1A73E8;
+  -pie-background-color: rgba(211, 228, 251, 0.3);
+}
+
+.magnifier-zoom-region {
+  border: 2px solid #1A73E8;
+}
+
+.magnifier-zoom-region.full-screen {
+  border-width: 0;
+}
+
+.select-area-rubberband {
+  background-color: rgba(26, 115, 232, 0.3);
+  border: 1px solid #1A73E8;
+}
+
+.user-icon {
+  background-size: contain;
+  color: rgba(255, 255, 255, 0.7);
+  border-radius: 9999px;
+  icon-size: 64px;
+}
+
+.user-icon:hover {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.user-icon StIcon {
+  background-color: rgba(255, 255, 255, 0.05);
+  border-radius: 99px;
+  padding: 8px;
+  width: 40px;
+  height: 40px;
+}
+
+.user-icon.user-avatar {
+  border: 2px rgba(255, 255, 255, 0.7);
+}
+
+.user-widget.vertical .user-icon {
+  icon-size: 128px;
+}
+
+.user-widget.vertical .user-icon StIcon {
+  padding: 14px;
+  padding-top: 12px;
+  padding-bottom: 16px;
+  width: 88px;
+  height: 88px;
+}
+
+.lightbox {
+  background-color: black;
+}
+
+.flashspot {
+  background-color: white;
+}
+
+.hidden {
+  color: rgba(0, 0, 0, 0);
+}
+
+.caps-lock-warning-label {
+  text-align: center;
+  padding-bottom: 8px;
+  font-size: 9.75pt;
+  font-weight: 400;
+  color: #FF6D00;
+}
+
+/* Workspace animation */
+.workspace-animation {
+  background-color: #222222;
+}
+
+/* Tiled window previews */
+.tile-preview {
+  background-color: rgba(22, 108, 221, 0.3);
+  border: 1px solid #166cdd;
+}
+
+.tile-preview-left.on-primary {
+  border-radius: 4px 0 0 0;
+}
+
+.tile-preview-right.on-primary {
+  border-radius: 0 4px 0 0;
+}
+
+.tile-preview-left.tile-preview-right.on-primary {
+  border-radius: 4px 4px 0 0;
+}
+
+/* On-screen Keyboard */
+#keyboard {
+  background-color: rgba(238, 238, 238, 0.95);
+  border: none;
+  border-top-width: 0;
+  box-shadow: none;
+}
+
+#keyboard .page-indicator {
+  padding: 4px;
+}
+
+#keyboard .page-indicator .page-indicator-icon {
+  width: 8px;
+  height: 8px;
+}
+
+.key-container {
+  padding: 2px;
+  spacing: 2px;
+}
+
+.keyboard-key {
+  min-height: 2em;
+  min-width: 2em;
+  font-size: 14pt;
+  font-weight: bold;
+  border-radius: 3px;
+  border: none;
+  color: inherit;
+  background-color: #FAFAFA;
+  box-shadow: inset 0 -1px rgba(0, 0, 0, 0.25);
+}
+
+.keyboard-key:focus, .keyboard-key:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #e1e1e1;
+}
+
+.keyboard-key:checked, .keyboard-key:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #c7c7c7;
+}
+
+.keyboard-key:grayed {
+  background-color: rgba(32, 32, 32, 0.75);
+  color: rgba(255, 255, 255, 0.85);
+  border-color: rgba(32, 32, 32, 0.75);
+}
+
+.keyboard-key.default-key {
+  background-color: #c7c7c7;
+}
+
+.keyboard-key.default-key:focus, .keyboard-key.default-key:hover {
+  color: rgba(0, 0, 0, 0.62);
+  background-color: #b7b7b7;
+}
+
+.keyboard-key.default-key:checked, .keyboard-key.default-key:active {
+  color: rgba(0, 0, 0, 0.62);
+  background-color: #adadad;
+}
+
+.keyboard-key.enter-key {
+  background-color: #1A73E8;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.keyboard-key.enter-key:focus, .keyboard-key.enter-key:hover {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #3181ea;
+}
+
+.keyboard-key.enter-key:checked, .keyboard-key.enter-key:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #135cbc;
+}
+
+.keyboard-key.shift-key-uppercase {
+  color: #1A73E8;
+}
+
+.keyboard-key StIcon {
+  icon-size: 1.125em;
+}
+
+.keyboard-subkeys {
+  color: inherit;
+  -arrow-border-radius: 3px;
+  -arrow-background-color: rgba(0, 0, 0, 0.45);
+  -arrow-border-width: 0;
+  -arrow-border-color: transparent;
+  -arrow-base: 20px;
+  -arrow-rise: 10px;
+  -boxpointer-gap: 5px;
+}
+
+.emoji-page .keyboard-key {
+  background-color: transparent;
+  border: none;
+  color: initial;
+}
+
+.emoji-panel .keyboard-key:latched {
+  border-color: #3181ea;
+  background-color: #1A73E8;
+}
+
+.word-suggestions {
+  font-size: 14pt;
+  spacing: 12px;
+  min-height: 20pt;
+}
+
+/* Looking Glass */
+#LookingGlassDialog {
+  color: rgba(0, 0, 0, 0.54);
+  background-color: #ffffff;
+  spacing: 4px;
+  padding: 6px;
+  border: none;
+  border-radius: 3px;
+  box-shadow: 0 14px 14px rgba(0, 0, 0, 0.5);
+}
+
+#LookingGlassDialog > #Toolbar {
+  padding: 0 8px;
+  border: none;
+  border-radius: 0;
+  background-color: rgba(255, 255, 255, 0.01);
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.12);
+  color: rgba(0, 0, 0, 0.54);
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button {
+  color: rgba(0, 0, 0, 0.54);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+  box-shadow: none;
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: none;
+}
+
+#LookingGlassDialog .labels {
+  spacing: 0;
+}
+
+#LookingGlassDialog .notebook-tab {
+  -natural-hpadding: 12px;
+  -minimum-hpadding: 6px;
+  font-weight: bold;
+  color: rgba(0, 0, 0, 0.38);
+  transition-duration: 150ms;
+  padding-left: 16px;
+  padding-right: 16px;
+  min-height: 32px;
+  padding: 0 32px;
+  border-radius: 0;
+}
+
+#LookingGlassDialog .notebook-tab:hover {
+  box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.2);
+  color: rgba(0, 0, 0, 0.87);
+  text-shadow: none;
+}
+
+#LookingGlassDialog .notebook-tab:selected {
+  background-color: rgba(255, 255, 255, 0.01);
+  box-shadow: inset 0 -2px 0 #1A73E8;
+  color: rgba(0, 0, 0, 0.87);
+  text-shadow: none;
+}
+
+#LookingGlassDialog StBoxLayout#EvalBox {
+  padding: 4px;
+  spacing: 4px;
+}
+
+#LookingGlassDialog StBoxLayout#ResultsArea {
+  spacing: 4px;
+}
+
+.lg-dialog StEntry {
+  selection-background-color: #1A73E8;
+  selected-color: rgba(255, 255, 255, 0.85) !important;
+}
+
+.lg-dialog .shell-link {
+  color: #1A73E8;
+}
+
+.lg-dialog .shell-link:hover {
+  color: #1A73E8;
+}
+
+.lg-completions-text {
+  font-size: 1em;
+  font-style: italic;
+}
+
+.lg-obj-inspector-title {
+  spacing: 4px;
+}
+
+.lg-obj-inspector-button {
+  min-height: 32px;
+  padding: 0 16px;
+  border: none;
+  border-radius: 3px;
+  font-size: 9.75pt;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.54);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.lg-obj-inspector-button:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+  box-shadow: none;
+}
+
+.lg-obj-inspector-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+.lg-obj-inspector-button:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.lg-obj-inspector-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: none;
+}
+
+.lg-obj-inspector-button:hover {
+  border: none;
+}
+
+#lookingGlassExtensions {
+  padding: 4px;
+}
+
+.lg-extensions-list {
+  padding: 4px;
+  spacing: 6px;
+}
+
+.lg-extension {
+  border: none;
+  border-radius: 3px;
+  background-color: #bfbfbf;
+  padding: 4px;
+}
+
+.lg-extension-name {
+  font-size: 18pt;
+  font-weight: 400;
+}
+
+.lg-extension-meta {
+  spacing: 6px;
+}
+
+#LookingGlassPropertyInspector {
+  background: #ffffff;
+  border: none;
+  border-radius: 3px;
+  padding: 6px;
+  box-shadow: 0 14px 14px rgba(0, 0, 0, 0.5);
+}
+
+.quick-settings {
+  border-radius: 3px !important;
+  margin: 4px !important;
+  padding: 8px 10px 12px !important;
+}
+
+.quick-settings .icon-button, .quick-settings .message-notification-group .message-collapse-button, .message-notification-group .quick-settings .message-collapse-button, .quick-settings .message .message-header .message-expand-button, .message .message-header .quick-settings .message-expand-button,
+.quick-settings .message .message-header .message-close-button,
+.message .message-header .quick-settings .message-close-button, .quick-settings .button {
+  padding: 6px;
+}
+
+.quick-settings .icon-button > StIcon, .quick-settings .background-app-item .icon-button > StIcon, .quick-settings .message-notification-group .background-app-item .message-collapse-button > StIcon, .quick-settings .message .message-header .background-app-item .message-expand-button > StIcon,
+.quick-settings .message .message-header .background-app-item .message-close-button > StIcon, .quick-settings .message-notification-group .message-collapse-button > StIcon, .message-notification-group .quick-settings .message-collapse-button > StIcon, .quick-settings .message .message-header .message-expand-button > StIcon, .message .message-header .quick-settings .message-expand-button > StIcon,
+.quick-settings .message .message-header .message-close-button > StIcon,
+.message .message-header .quick-settings .message-close-button > StIcon, .quick-settings .button > StIcon {
+  icon-size: 16px;
+}
+
+.quick-settings-grid {
+  spacing-rows: 8px;
+  spacing-columns: 8px;
+}
+
+.quick-toggle, .quick-menu-toggle {
+  border-radius: 3px;
+  min-width: 12em;
+  max-width: 12em;
+  min-height: 38px;
+  padding: 0;
+  border: none;
+}
+
+.quick-toggle {
+  background-color: rgba(0, 0, 0, 0.06) !important;
+  /* Move padding into the box; this is to allow menu arrows
+       to extend to the border */
+}
+
+.quick-toggle:hover {
+  background-color: rgba(0, 0, 0, 0.12) !important;
+}
+
+.quick-toggle:active {
+  background-color: rgba(0, 0, 0, 0.15) !important;
+}
+
+.quick-toggle:checked {
+  background-color: #1A73E8 !important;
+  color: white;
+}
+
+.quick-toggle:checked:hover {
+  background-color: rgba(25, 110, 221, 0.9922) !important;
+  color: white;
+}
+
+.quick-toggle:checked:active {
+  background-color: rgba(23, 101, 204, 0.9805) !important;
+  color: white;
+}
+
+.quick-toggle > StBoxLayout {
+  spacing: 6px;
+}
+
+.quick-toggle.button {
+  padding: 0;
+}
+
+.quick-toggle > StBoxLayout {
+  padding: 0 8px;
+}
+
+.quick-toggle:ltr > StBoxLayout {
+  padding-left: 16px;
+}
+
+.quick-toggle:rtl > StBoxLayout {
+  padding-right: 16px;
+}
+
+.quick-toggle .quick-toggle-title {
+  font-weight: bold;
+}
+
+.quick-toggle StBoxLayout > .quick-toggle-subtitle {
+  font-weight: normal;
+  font-size: 12px;
+}
+
+.quick-toggle .quick-toggle-icon {
+  icon-size: 16px;
+}
+
+.quick-toggle-has-menu .quick-toggle {
+  min-width: auto;
+  max-width: auto;
+}
+
+.quick-toggle-has-menu .quick-toggle:ltr {
+  border-radius: 3px 0 0 3px;
+}
+
+.quick-toggle-has-menu .quick-toggle:ltr > StBoxLayout {
+  padding-right: 8px;
+}
+
+.quick-toggle-has-menu .quick-toggle:rtl {
+  border-radius: 0 3px 3px 0;
+}
+
+.quick-toggle-has-menu .quick-toggle:rtr > StBoxLayout {
+  padding-left: 8px;
+}
+
+.quick-toggle-has-menu .quick-toggle:ltr:last-child {
+  border-radius: 3px;
+}
+
+.quick-toggle-has-menu .quick-toggle:rtl:last-child {
+  border-radius: 3px;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button {
+  padding: 4px 8px;
+  border: none;
+  background-color: rgba(0, 0, 0, 0.06) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:hover {
+  background-color: rgba(0, 0, 0, 0.12) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:active {
+  background-color: rgba(0, 0, 0, 0.15) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:checked {
+  background-color: #1A73E8 !important;
+  color: white;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:checked:hover {
+  color: white;
+  background-color: st-mix(rgba(0, 0, 0, 0.87), #1A73E8, 6%) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:checked:active {
+  color: white;
+  background-color: st-mix(rgba(0, 0, 0, 0.87), #1A73E8, 15%) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:ltr {
+  border-radius: 0 3px 3px 0;
+  border-left-width: 0;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:rtl {
+  border-radius: 3px 0 0 3px;
+  border-right-width: 0;
+}
+
+.quick-toggle-has-menu .quick-toggle-separator {
+  width: 0;
+}
+
+.quick-slider > StBoxLayout {
+  spacing: 4px;
+}
+
+.quick-slider .slider-bin {
+  min-height: 16px;
+  padding: 4px;
+  border-radius: 9999px;
+}
+
+.quick-slider .slider-bin:focus {
+  color: #1A73E8;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.quick-slider .slider-bin:focus:hover, .quick-slider .slider-bin:focus:active {
+  color: #1A73E8;
+}
+
+.quick-slider .quick-toggle-icon {
+  icon-size: 16px;
+}
+
+.quick-slider .icon-button, .quick-slider .message-notification-group .message-collapse-button, .message-notification-group .quick-slider .message-collapse-button, .quick-slider .message .message-header .message-expand-button, .message .message-header .quick-slider .message-expand-button,
+.quick-slider .message .message-header .message-close-button,
+.message .message-header .quick-slider .message-close-button {
+  min-width: 22px;
+  min-height: 22px;
+  background-color: transparent;
+  color: rgba(0, 0, 0, 0.87) !important;
+}
+
+.quick-slider .icon-button:hover, .quick-slider .message-notification-group .message-collapse-button:hover, .message-notification-group .quick-slider .message-collapse-button:hover, .quick-slider .message .message-header .message-expand-button:hover, .message .message-header .quick-slider .message-expand-button:hover,
+.quick-slider .message .message-header .message-close-button:hover,
+.message .message-header .quick-slider .message-close-button:hover {
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.quick-slider .icon-button:active, .quick-slider .message-notification-group .message-collapse-button:active, .message-notification-group .quick-slider .message-collapse-button:active, .quick-slider .message .message-header .message-expand-button:active, .message .message-header .quick-slider .message-expand-button:active,
+.quick-slider .message .message-header .message-close-button:active,
+.message .message-header .quick-slider .message-close-button:active {
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+.quick-toggle-menu {
+  background-color: white !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+  border-radius: 3px !important;
+  padding: 12px;
+  margin: 8px 24px 0;
+  border: none !important;
+}
+
+.quick-toggle-menu .popup-menu-item {
+  border-radius: 3px !important;
+  min-height: 20px;
+}
+
+.quick-toggle-menu .popup-menu-item:focus, .quick-toggle-menu .popup-menu-item:hover, .quick-toggle-menu .popup-menu-item.selected {
+  color: rgba(0, 0, 0, 0.87) !important;
+  background-color: rgba(0, 0, 0, 0.1) !important;
+}
+
+.quick-toggle-menu .popup-menu-item:active {
+  color: rgba(0, 0, 0, 0.87) !important;
+  background-color: rgba(0, 0, 0, 0.2) !important;
+}
+
+.quick-toggle-menu .popup-menu-item > StIcon {
+  -st-icon-style: symbolic;
+}
+
+.quick-toggle-menu .header {
+  spacing-rows: 2px;
+  spacing-columns: 8px;
+  padding-bottom: 8px;
+}
+
+.quick-toggle-menu .header .icon {
+  icon-size: 24px;
+  border-radius: 3px;
+  padding: 6px;
+  background-color: rgba(0, 0, 0, 0.06) !important;
+}
+
+.quick-toggle-menu .header .icon.active {
+  background-color: #1A73E8 !important;
+  color: white;
+}
+
+.quick-settings-system-item > StBoxLayout {
+  spacing: 8px;
+}
+
+.quick-settings-system-item .icon-button, .quick-settings-system-item .message-notification-group .message-collapse-button, .message-notification-group .quick-settings-system-item .message-collapse-button, .quick-settings-system-item .message .message-header .message-expand-button, .message .message-header .quick-settings-system-item .message-expand-button,
+.quick-settings-system-item .message .message-header .message-close-button,
+.message .message-header .quick-settings-system-item .message-close-button {
+  background-color: rgba(0, 0, 0, 0.06);
+  color: rgba(0, 0, 0, 0.87);
+  border-radius: 3px;
+  min-height: 22px;
+  min-width: 22px !important;
+}
+
+.quick-settings-system-item .icon-button:hover, .quick-settings-system-item .message-notification-group .message-collapse-button:hover, .message-notification-group .quick-settings-system-item .message-collapse-button:hover, .quick-settings-system-item .message .message-header .message-expand-button:hover, .message .message-header .quick-settings-system-item .message-expand-button:hover,
+.quick-settings-system-item .message .message-header .message-close-button:hover,
+.message .message-header .quick-settings-system-item .message-close-button:hover {
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+.quick-settings-system-item .icon-button:active, .quick-settings-system-item .message-notification-group .message-collapse-button:active, .message-notification-group .quick-settings-system-item .message-collapse-button:active, .quick-settings-system-item .message .message-header .message-expand-button:active, .message .message-header .quick-settings-system-item .message-expand-button:active,
+.quick-settings-system-item .message .message-header .message-close-button:active,
+.message .message-header .quick-settings-system-item .message-close-button:active {
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.quick-settings-system-item .icon-button > StIcon, .quick-settings-system-item .background-app-item .icon-button > StIcon, .quick-settings-system-item .message-notification-group .background-app-item .message-collapse-button > StIcon, .quick-settings-system-item .message .message-header .background-app-item .message-expand-button > StIcon,
+.quick-settings-system-item .message .message-header .background-app-item .message-close-button > StIcon, .quick-settings-system-item .message-notification-group .message-collapse-button > StIcon, .message-notification-group .quick-settings-system-item .message-collapse-button > StIcon, .quick-settings-system-item .message .message-header .message-expand-button > StIcon, .message .message-header .quick-settings-system-item .message-expand-button > StIcon,
+.quick-settings-system-item .message .message-header .message-close-button > StIcon,
+.message .message-header .quick-settings-system-item .message-close-button > StIcon {
+  -st-icon-style: symbolic;
+  icon-size: 16px;
+}
+
+.quick-settings-system-item .power-item {
+  min-height: 0;
+  min-width: 0;
+}
+
+.quick-settings-system-item .power-item:insensitive {
+  color: rgba(0, 0, 0, 0.62);
+  background-color: #ffffff;
+  border-color: #d9d9d9;
+  box-shadow: none;
+  background-color: transparent;
+}
+
+.nm-network-item .wireless-secure-icon {
+  icon-size: 8px;
+}
+
+.bt-device-item .popup-menu-icon {
+  -st-icon-style: symbolic;
+}
+
+.bt-menu-placeholder.popup-menu-item {
+  text-align: center;
+  padding: 2em 4em;
+}
+
+.device-subtitle {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.keyboard-brightness-level {
+  spacing: 4px;
+}
+
+.background-apps-quick-toggle {
+  min-height: 40px;
+  background-color: transparent;
+}
+
+.background-apps-quick-toggle StIcon {
+  icon-size: 16px !important;
+}
+
+.background-app-item .popup-menu-icon {
+  icon-size: 24px !important;
+  -st-icon-style: regular !important;
+}
+
+.background-app-item .icon-button, .background-app-item .message-notification-group .message-collapse-button, .message-notification-group .background-app-item .message-collapse-button, .background-app-item .message .message-header .message-expand-button, .message .message-header .background-app-item .message-expand-button,
+.background-app-item .message .message-header .message-close-button,
+.message .message-header .background-app-item .message-close-button {
+  padding: 4px;
+}
+
+.background-app-item .spinner {
+  padding: 4px;
+}
+
+.background-app-item.popup-inactive-menu-item {
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.icon-label-button-container {
+  spacing: 4px;
+  font-size: 9pt;
+  font-weight: 400;
+}
+
+.icon-label-button-container StIcon {
+  icon-size: 32px;
+}
+
+.screenshot-ui-panel {
+  border-radius: 27px;
+  padding: 12px;
+  padding-bottom: 6px;
+  margin-bottom: 4em;
+  spacing: 8px;
+}
+
+.screenshot-ui-close-button {
+  padding: 4px;
+}
+
+.screenshot-ui-close-button.left {
+  margin-left: 8px;
+}
+
+.screenshot-ui-close-button.right {
+  margin-right: 8px;
+}
+
+.screenshot-ui-type-button {
+  padding: 8px 12px !important;
+  border-radius: 15px;
+}
+
+.screenshot-ui-capture-button {
+  width: 36px;
+  height: 36px;
+  border-radius: 9999px;
+  border: 4px rgba(255, 255, 255, 0.85);
+  padding: 4px;
+}
+
+.screenshot-ui-capture-button .screenshot-ui-capture-button-circle {
+  background-color: rgba(255, 255, 255, 0.85);
+  transition-duration: 200ms;
+  border-radius: 9999px;
+}
+
+.screenshot-ui-capture-button .screenshot-ui-capture-button-circle:hover, .screenshot-ui-capture-button .screenshot-ui-capture-button-circle:focus {
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+.screenshot-ui-capture-button:hover .screenshot-ui-capture-button-circle, .screenshot-ui-capture-button:focus .screenshot-ui-capture-button-circle {
+  background-color: rgba(217, 217, 217, 0.85);
+}
+
+.screenshot-ui-capture-button:active .screenshot-ui-capture-button-circle {
+  background-color: rgba(128, 128, 128, 0.85);
+}
+
+.screenshot-ui-capture-button:cast .screenshot-ui-capture-button-circle {
+  background-color: #DD2C00;
+}
+
+.screenshot-ui-capture-button:cast:hover .screenshot-ui-capture-button-circle, .screenshot-ui-capture-button:cast:focus .screenshot-ui-capture-button-circle {
+  background-color: #911d00;
+}
+
+.screenshot-ui-capture-button:cast:active .screenshot-ui-capture-button-circle {
+  background-color: #440e00;
+}
+
+.screenshot-ui-shot-cast-container {
+  background-color: rgba(0, 0, 0, 0.12);
+  border-radius: 6px;
+  padding: 3px;
+  spacing: 3px;
+}
+
+.screenshot-ui-shot-cast-container:ltr {
+  margin-left: 9px;
+}
+
+.screenshot-ui-shot-cast-container:rtl {
+  margin-right: 9px;
+}
+
+.screenshot-ui-shot-cast-button {
+  padding: 4px 8px;
+  background-color: transparent;
+  border-radius: 3px;
+}
+
+.screenshot-ui-shot-cast-button:hover, .screenshot-ui-shot-cast-button:focus {
+  background-color: rgba(13, 13, 13, 0.12);
+}
+
+.screenshot-ui-shot-cast-button:active {
+  background-color: rgba(13, 13, 13, 0.2);
+}
+
+.screenshot-ui-shot-cast-button:checked {
+  background-color: white;
+  color: black;
+}
+
+.screenshot-ui-shot-cast-button StIcon {
+  icon-size: 16px;
+}
+
+.screenshot-ui-show-pointer-button {
+  border-radius: 9999px;
+  padding: 8px !important;
+}
+
+.screenshot-ui-show-pointer-button StIcon {
+  icon-size: 16px;
+}
+
+.screenshot-ui-area-indicator-shade {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.screenshot-ui-area-selector .screenshot-ui-area-indicator-shade {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.screenshot-ui-area-selector .screenshot-ui-area-indicator-selection {
+  border: 2px white;
+}
+
+.screenshot-ui-area-selector-handle {
+  border-radius: 9999px;
+  background-color: white;
+  box-shadow: 0 1px 3px 2px rgba(0, 0, 0, 0.2);
+  width: 24px;
+  height: 24px;
+}
+
+.screenshot-ui-window-selector {
+  background-color: #222222;
+}
+
+.screenshot-ui-window-selector .screenshot-ui-window-selector-window-container {
+  margin: 100px;
+}
+
+.screenshot-ui-window-selector:primary-monitor .screenshot-ui-window-selector-window-container {
+  margin-bottom: 200px;
+}
+
+.screenshot-ui-window-selector-window-border {
+  transition-duration: 200ms;
+  border-radius: 6px;
+  border: 6px transparent;
+}
+
+.screenshot-ui-window-selector-check {
+  transition-duration: 200ms;
+  color: transparent;
+  border-radius: 9999px;
+  border-width: 12px;
+  icon-size: 24px;
+}
+
+.screenshot-ui-window-selector-window:hover .screenshot-ui-window-selector-window-border {
+  border-color: #1151a5;
+}
+
+.screenshot-ui-window-selector-window:checked .screenshot-ui-window-selector-window-border {
+  border-color: #1A73E8;
+  background-color: rgba(26, 115, 232, 0.2);
+}
+
+.screenshot-ui-window-selector-window:checked .screenshot-ui-window-selector-check {
+  color: white;
+  background-color: #1A73E8;
+}
+
+.screenshot-ui-screen-selector {
+  transition-duration: 200ms;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.screenshot-ui-screen-selector:hover {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.screenshot-ui-screen-selector:active {
+  background-color: rgba(0, 0, 0, 0.7);
+}
+
+.screenshot-ui-screen-selector:checked {
+  background-color: transparent;
+  border: 2px white;
+}
+
+.screenshot-ui-tooltip {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #222222;
+  border-radius: 99px;
+  padding: 4px 8px;
+  text-align: center;
+  -y-offset: 24px;
+}
+
+/* Login Dialog */
+.login-dialog-banner-view {
+  padding-top: 24px;
+  max-width: 23em;
+}
+
+.login-dialog,
+.unlock-dialog {
+  border: none;
+  background-color: transparent;
+}
+
+.login-dialog StEntry,
+.unlock-dialog StEntry {
+  selection-background-color: #1A73E8;
+  selected-color: rgba(255, 255, 255, 0.85) !important;
+  caret-color: rgba(0, 0, 0, 0.54);
+  color: rgba(0, 0, 0, 0.54);
+  background-color: #ffffff;
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+.login-dialog StEntry:focus,
+.unlock-dialog StEntry:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #1A73E8 !important;
+}
+
+.login-dialog StEntry:insensitive,
+.unlock-dialog StEntry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog .modal-dialog-button-box,
+.unlock-dialog .modal-dialog-button-box {
+  spacing: 3px;
+}
+
+.login-dialog .modal-dialog-button,
+.unlock-dialog .modal-dialog-button {
+  padding: 4px 18px;
+  box-shadow: none;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:hover, .login-dialog .modal-dialog-button:focus,
+.unlock-dialog .modal-dialog-button:hover,
+.unlock-dialog .modal-dialog-button:focus {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.15);
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:active,
+.unlock-dialog .modal-dialog-button:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.3);
+  box-shadow: 0 0 transparent;
+}
+
+.login-dialog .modal-dialog-button:insensitive,
+.unlock-dialog .modal-dialog-button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default,
+.unlock-dialog .modal-dialog-button:default {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #287ce9;
+  border-color: #1257b3;
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:hover, .login-dialog .modal-dialog-button:default:focus,
+.unlock-dialog .modal-dialog-button:default:hover,
+.unlock-dialog .modal-dialog-button:default:focus {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #287ce9;
+  border-color: #104c9c;
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:active,
+.unlock-dialog .modal-dialog-button:default:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #176ee1;
+  border-color: #104c9c;
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:active:hover, .login-dialog .modal-dialog-button:default:active:focus,
+.unlock-dialog .modal-dialog-button:default:active:hover,
+.unlock-dialog .modal-dialog-button:default:active:focus {
+  background-color: #176ee1;
+}
+
+.login-dialog .modal-dialog-button:default:insensitive,
+.unlock-dialog .modal-dialog-button:default:insensitive {
+  color: rgba(255, 255, 255, 0.5);
+  background-color: rgba(255, 255, 255, 0.15);
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.login-dialog .cancel-button,
+.login-dialog .switch-user-button,
+.login-dialog .login-dialog-session-list-button,
+.unlock-dialog .cancel-button,
+.unlock-dialog .switch-user-button,
+.unlock-dialog .login-dialog-session-list-button {
+  padding: 0;
+  border-radius: 99px;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog .cancel-button:hover, .login-dialog .cancel-button:focus,
+.login-dialog .switch-user-button:hover,
+.login-dialog .switch-user-button:focus,
+.login-dialog .login-dialog-session-list-button:hover,
+.login-dialog .login-dialog-session-list-button:focus,
+.unlock-dialog .cancel-button:hover,
+.unlock-dialog .cancel-button:focus,
+.unlock-dialog .switch-user-button:hover,
+.unlock-dialog .switch-user-button:focus,
+.unlock-dialog .login-dialog-session-list-button:hover,
+.unlock-dialog .login-dialog-session-list-button:focus {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog .cancel-button:active,
+.login-dialog .switch-user-button:active,
+.login-dialog .login-dialog-session-list-button:active,
+.unlock-dialog .cancel-button:active,
+.unlock-dialog .switch-user-button:active,
+.unlock-dialog .login-dialog-session-list-button:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.login-dialog .cancel-button StIcon,
+.login-dialog .switch-user-button StIcon,
+.login-dialog .login-dialog-session-list-button StIcon,
+.unlock-dialog .cancel-button StIcon,
+.unlock-dialog .switch-user-button StIcon,
+.unlock-dialog .login-dialog-session-list-button StIcon {
+  icon-size: 16px;
+}
+
+.login-dialog .caps-lock-warning-label,
+.login-dialog .login-dialog-message-warning,
+.unlock-dialog .caps-lock-warning-label,
+.unlock-dialog .login-dialog-message-warning {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-logo-bin {
+  padding: 24px 0px;
+}
+
+.login-dialog-banner {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog-button-box {
+  width: 23em;
+  spacing: 5px;
+}
+
+.login-dialog-message {
+  text-align: center;
+}
+
+.login-dialog-user-selection-box {
+  padding: 100px 0px;
+}
+
+.login-dialog-not-listed-label {
+  padding-left: 2px;
+  font-size: 1em;
+  font-weight: bold;
+  color: rgba(255, 255, 255, 0.7);
+  padding-top: 1em;
+}
+
+.login-dialog-not-listed-label:hover {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-not-listed-label:focus {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.login-dialog-not-listed-button:focus .login-dialog-not-listed-label, .login-dialog-not-listed-button:hover .login-dialog-not-listed-label {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-view {
+  -st-vfade-offset: 1em;
+}
+
+.login-dialog-user-list {
+  spacing: 12px;
+  width: 23em;
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:selected {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:active {
+  background-color: rgba(255, 255, 255, 0.3);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:logged-in {
+  border-right: 2px solid rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-item {
+  border-radius: 3px;
+  padding: 6px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog-user-list-item:ltr {
+  padding-right: 1em;
+}
+
+.login-dialog-user-list-item:rtl {
+  padding-left: 1em;
+}
+
+.login-dialog-user-list-item:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-item:active {
+  background-color: rgba(255, 255, 255, 0.3);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-item .login-dialog-timed-login-indicator {
+  height: 2px;
+  margin: 6px 0 0 0;
+  background-color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-item:focus .login-dialog-timed-login-indicator {
+  background-color: rgba(255, 255, 255, 0.85);
+}
+
+.user-widget-label {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.user-widget.horizontal .user-widget-label {
+  font-size: 15pt;
+  font-weight: 500;
+  font-weight: bold;
+  padding-left: 15px;
+}
+
+.user-widget.horizontal .user-widget-label:ltr {
+  padding-left: 14px;
+  text-align: left;
+}
+
+.user-widget.horizontal .user-widget-label:rtl {
+  padding-right: 14px;
+  text-align: right;
+}
+
+.user-widget.vertical .user-widget-label {
+  font-size: 15pt;
+  font-weight: 500;
+  text-align: center;
+  font-weight: normal;
+  padding-top: 16px;
+}
+
+.login-dialog-prompt-layout {
+  padding-top: 24px;
+  padding-bottom: 12px;
+  spacing: 8px;
+  width: 23em;
+}
+
+.login-dialog-prompt-entry {
+  height: 1.5em;
+}
+
+.login-dialog-prompt-label {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 1em;
+  padding-top: 1em;
+}
+
+/* Screen Shield */
+.unlock-dialog-clock {
+  color: white;
+  font-weight: 300;
+  text-align: center;
+  spacing: 24px;
+  padding-bottom: 2.5em;
+}
+
+.unlock-dialog-clock-time {
+  font-size: 64pt;
+  padding-top: 42px;
+  font-feature-settings: "tnum";
+}
+
+.unlock-dialog-clock-date {
+  font-size: 16pt;
+  font-weight: normal;
+}
+
+.unlock-dialog-clock-hint {
+  font-weight: normal;
+  padding-top: 48px;
+}
+
+.unlock-dialog-notifications-container {
+  margin: 12px 0;
+  spacing: 6px;
+  width: 23em;
+  background-color: transparent;
+}
+
+.unlock-dialog-notifications-container .summary-notification-stack-scrollview {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.unlock-dialog-notifications-container .notification,
+.unlock-dialog-notifications-container .unlock-dialog-notification-source {
+  padding: 12px 6px;
+  border: none;
+  background-color: rgba(32, 32, 32, 0.9);
+  color: rgba(255, 255, 255, 0.85);
+  border-radius: 3px;
+}
+
+.unlock-dialog-notifications-container .notification.critical,
+.unlock-dialog-notifications-container .unlock-dialog-notification-source.critical {
+  background-color: rgba(34, 34, 34, 0.9);
+}
+
+.unlock-dialog-notification-label {
+  padding: 0px 0px 0px 12px;
+}
+
+.unlock-dialog-notification-count-text {
+  weight: bold;
+  padding: 0 6px;
+  color: rgba(32, 32, 32, 0.9);
+  background-color: rgba(255, 255, 255, 0.7);
+  border-radius: 99px;
+  margin-right: 12px;
+}
+
+.screen-shield-background {
+  background: black;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.6);
+}
+
+#lockDialogGroup {
+  background-color: #222222;
+}
+
+#unlockDialogNotifications StButton#vhandle, #unlockDialogNotifications StButton#hhandle {
+  background-color: rgba(32, 32, 32, 0.2);
+}
+
+#unlockDialogNotifications StButton#vhandle:hover, #unlockDialogNotifications StButton#vhandle:focus, #unlockDialogNotifications StButton#hhandle:hover, #unlockDialogNotifications StButton#hhandle:focus {
+  background-color: rgba(32, 32, 32, 0.4);
+}
+
+#unlockDialogNotifications StButton#vhandle:active, #unlockDialogNotifications StButton#hhandle:active {
+  background-color: rgba(26, 115, 232, 0.5);
+}
+
+.bottom #dashtodockDashScrollview,
+.top #dashtodockDashScrollview {
+  -st-hfade-offset: 24px;
+}
+
+.left #dashtodockDashScrollview,
+.right #dashtodockDashScrollview {
+  -st-vfade-offset: 24px;
+}
+
+#dashtodockContainer {
+  background-color: transparent;
+  box-shadow: none;
+}
+
+#dashtodockContainer .number-overlay {
+  color: #FFFFFF;
+  background-color: rgba(0, 0, 0, 0.75);
+  text-align: center;
+}
+
+#dashtodockContainer .notification-badge {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #1A73E8;
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.25);
+  border-radius: 9999px;
+  margin: 2px 3px 5px;
+  padding: 0.2em 0.6em;
+  font-weight: bold;
+  text-align: center;
+}
+
+#dashtodockContainer.top.straight-corner #dash, #dashtodockContainer.top.shrink.straight-corner #dash, #dashtodockContainer.top.extended #dash, #dashtodockContainer.top.extended:overview #dash {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.straight-corner #dash .dash-background, #dashtodockContainer.top.shrink.straight-corner #dash .dash-background, #dashtodockContainer.top.extended #dash .dash-background, #dashtodockContainer.top.extended:overview #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.top.straight-corner #dash .show-apps,
+#dashtodockContainer.top.straight-corner #dash .overview-tile,
+#dashtodockContainer.top.straight-corner #dash .grid-search-result,
+#dashtodockContainer.top.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.top.straight-corner #dash .list-search-result, #dashtodockContainer.top.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.top.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.top.extended #dash .show-apps,
+#dashtodockContainer.top.extended #dash .overview-tile,
+#dashtodockContainer.top.extended #dash .grid-search-result,
+#dashtodockContainer.top.extended #dash .search-provider-icon,
+#dashtodockContainer.top.extended #dash .list-search-result, #dashtodockContainer.top.extended:overview #dash .show-apps,
+#dashtodockContainer.top.extended:overview #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash, #dashtodockContainer.bottom.shrink.straight-corner #dash, #dashtodockContainer.bottom.extended #dash, #dashtodockContainer.bottom.extended:overview #dash {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash .dash-background, #dashtodockContainer.bottom.shrink.straight-corner #dash .dash-background, #dashtodockContainer.bottom.extended #dash .dash-background, #dashtodockContainer.bottom.extended:overview #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash .show-apps,
+#dashtodockContainer.bottom.straight-corner #dash .overview-tile,
+#dashtodockContainer.bottom.straight-corner #dash .grid-search-result,
+#dashtodockContainer.bottom.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.bottom.straight-corner #dash .list-search-result, #dashtodockContainer.bottom.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.bottom.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.bottom.extended #dash .show-apps,
+#dashtodockContainer.bottom.extended #dash .overview-tile,
+#dashtodockContainer.bottom.extended #dash .grid-search-result,
+#dashtodockContainer.bottom.extended #dash .search-provider-icon,
+#dashtodockContainer.bottom.extended #dash .list-search-result, #dashtodockContainer.bottom.extended:overview #dash .show-apps,
+#dashtodockContainer.bottom.extended:overview #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash, #dashtodockContainer.left.shrink.straight-corner #dash, #dashtodockContainer.left.extended #dash, #dashtodockContainer.left.extended:overview #dash {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash .dash-background, #dashtodockContainer.left.shrink.straight-corner #dash .dash-background, #dashtodockContainer.left.extended #dash .dash-background, #dashtodockContainer.left.extended:overview #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash .show-apps,
+#dashtodockContainer.left.straight-corner #dash .overview-tile,
+#dashtodockContainer.left.straight-corner #dash .grid-search-result,
+#dashtodockContainer.left.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.left.straight-corner #dash .list-search-result, #dashtodockContainer.left.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.left.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.left.extended #dash .show-apps,
+#dashtodockContainer.left.extended #dash .overview-tile,
+#dashtodockContainer.left.extended #dash .grid-search-result,
+#dashtodockContainer.left.extended #dash .search-provider-icon,
+#dashtodockContainer.left.extended #dash .list-search-result, #dashtodockContainer.left.extended:overview #dash .show-apps,
+#dashtodockContainer.left.extended:overview #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash, #dashtodockContainer.right.shrink.straight-corner #dash, #dashtodockContainer.right.extended #dash, #dashtodockContainer.right.extended:overview #dash {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash .dash-background, #dashtodockContainer.right.shrink.straight-corner #dash .dash-background, #dashtodockContainer.right.extended #dash .dash-background, #dashtodockContainer.right.extended:overview #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash .show-apps,
+#dashtodockContainer.right.straight-corner #dash .overview-tile,
+#dashtodockContainer.right.straight-corner #dash .grid-search-result,
+#dashtodockContainer.right.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.right.straight-corner #dash .list-search-result, #dashtodockContainer.right.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.right.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.right.extended #dash .show-apps,
+#dashtodockContainer.right.extended #dash .overview-tile,
+#dashtodockContainer.right.extended #dash .grid-search-result,
+#dashtodockContainer.right.extended #dash .search-provider-icon,
+#dashtodockContainer.right.extended #dash .list-search-result, #dashtodockContainer.right.extended:overview #dash .show-apps,
+#dashtodockContainer.right.extended:overview #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.extended #dash .dash-background, #dashtodockContainer.straight-corner #dash .dash-background {
+  border-radius: 0;
+}
+
+#dashtodockContainer.shrink #dash .dash-background {
+  padding: 0 !important;
+  border-radius: 3px;
+}
+
+#dashtodockContainer.shrink #dash .show-apps,
+#dashtodockContainer.shrink #dash .overview-tile,
+#dashtodockContainer.shrink #dash .grid-search-result,
+#dashtodockContainer.shrink #dash .search-provider-icon,
+#dashtodockContainer.shrink #dash .list-search-result {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left #dash .overview-tile, #dashtodockContainer.left #dash .grid-search-result, #dashtodockContainer.left #dash .search-provider-icon, #dashtodockContainer.left #dash .list-search-result, #dashtodockContainer.right #dash .overview-tile, #dashtodockContainer.right #dash .grid-search-result, #dashtodockContainer.right #dash .search-provider-icon, #dashtodockContainer.right #dash .list-search-result {
+  padding: 1px 4px !important;
+}
+
+#dashtodockContainer.left #dash .show-apps, #dashtodockContainer.right #dash .show-apps {
+  padding-bottom: 4px !important;
+}
+
+#dashtodockContainer.left.shrink #dash .show-apps,
+#dashtodockContainer.left.shrink #dash .overview-tile,
+#dashtodockContainer.left.shrink #dash .grid-search-result,
+#dashtodockContainer.left.shrink #dash .search-provider-icon,
+#dashtodockContainer.left.shrink #dash .list-search-result, #dashtodockContainer.right.shrink #dash .show-apps,
+#dashtodockContainer.right.shrink #dash .overview-tile,
+#dashtodockContainer.right.shrink #dash .grid-search-result,
+#dashtodockContainer.right.shrink #dash .search-provider-icon,
+#dashtodockContainer.right.shrink #dash .list-search-result {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.extended #dash .show-apps,
+#dashtodockContainer.left.extended #dash .overview-tile,
+#dashtodockContainer.left.extended #dash .grid-search-result,
+#dashtodockContainer.left.extended #dash .search-provider-icon,
+#dashtodockContainer.left.extended #dash .list-search-result, #dashtodockContainer.left.straight-corner #dash .show-apps,
+#dashtodockContainer.left.straight-corner #dash .overview-tile,
+#dashtodockContainer.left.straight-corner #dash .grid-search-result,
+#dashtodockContainer.left.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.left.straight-corner #dash .list-search-result, #dashtodockContainer.right.extended #dash .show-apps,
+#dashtodockContainer.right.extended #dash .overview-tile,
+#dashtodockContainer.right.extended #dash .grid-search-result,
+#dashtodockContainer.right.extended #dash .search-provider-icon,
+#dashtodockContainer.right.extended #dash .list-search-result, #dashtodockContainer.right.straight-corner #dash .show-apps,
+#dashtodockContainer.right.straight-corner #dash .overview-tile,
+#dashtodockContainer.right.straight-corner #dash .grid-search-result,
+#dashtodockContainer.right.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.right.straight-corner #dash .list-search-result {
+  padding: 1px 8px !important;
+}
+
+#dashtodockContainer.top.shrink #dash .dash-background, #dashtodockContainer.bottom.shrink #dash .dash-background {
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.shrink #dash .show-apps,
+#dashtodockContainer.top.shrink #dash .overview-tile,
+#dashtodockContainer.top.shrink #dash .grid-search-result,
+#dashtodockContainer.top.shrink #dash .search-provider-icon,
+#dashtodockContainer.top.shrink #dash .list-search-result, #dashtodockContainer.bottom.shrink #dash .show-apps,
+#dashtodockContainer.bottom.shrink #dash .overview-tile,
+#dashtodockContainer.bottom.shrink #dash .grid-search-result,
+#dashtodockContainer.bottom.shrink #dash .search-provider-icon,
+#dashtodockContainer.bottom.shrink #dash .list-search-result {
+  margin: 0 !important;
+  padding: 0 0 18px !important;
+}
+
+#dashtodockContainer.top.extended #dash .dash-separator, #dashtodockContainer.top.straight-corner #dash .dash-separator, #dashtodockContainer.bottom.extended #dash .dash-separator, #dashtodockContainer.bottom.straight-corner #dash .dash-separator {
+  margin: 0 5px !important;
+}
+
+#dashtodockContainer.top.extended #dash .show-apps,
+#dashtodockContainer.top.extended #dash .overview-tile,
+#dashtodockContainer.top.extended #dash .grid-search-result,
+#dashtodockContainer.top.extended #dash .search-provider-icon,
+#dashtodockContainer.top.extended #dash .list-search-result, #dashtodockContainer.top.straight-corner #dash .show-apps,
+#dashtodockContainer.top.straight-corner #dash .overview-tile,
+#dashtodockContainer.top.straight-corner #dash .grid-search-result,
+#dashtodockContainer.top.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.top.straight-corner #dash .list-search-result, #dashtodockContainer.bottom.extended #dash .show-apps,
+#dashtodockContainer.bottom.extended #dash .overview-tile,
+#dashtodockContainer.bottom.extended #dash .grid-search-result,
+#dashtodockContainer.bottom.extended #dash .search-provider-icon,
+#dashtodockContainer.bottom.extended #dash .list-search-result, #dashtodockContainer.bottom.straight-corner #dash .show-apps,
+#dashtodockContainer.bottom.straight-corner #dash .overview-tile,
+#dashtodockContainer.bottom.straight-corner #dash .grid-search-result,
+#dashtodockContainer.bottom.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.bottom.straight-corner #dash .list-search-result {
+  padding: 8px 1px !important;
+}
+
+#dashtodockContainer #dash {
+  background: none;
+  box-shadow: none;
+}
+
+#dashtodockContainer #dash .dash-background {
+  background-color: rgba(0, 0, 0, 0.5);
+  background-clip: padding-box;
+}
+
+#dashtodockContainer #dash .show-apps .overview-icon,
+#dashtodockContainer #dash .overview-tile .overview-icon,
+#dashtodockContainer #dash .grid-search-result .overview-icon,
+#dashtodockContainer #dash .search-provider-icon .overview-icon,
+#dashtodockContainer #dash .list-search-result .overview-icon {
+  color: rgba(255, 255, 255, 0.75) !important;
+}
+
+#dashtodockContainer #dash .show-apps:hover .overview-icon, #dashtodockContainer #dash .show-apps:focus .overview-icon, #dashtodockContainer #dash .show-apps:selected .overview-icon,
+#dashtodockContainer #dash .overview-tile:hover .overview-icon,
+#dashtodockContainer #dash .grid-search-result:hover .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:hover .overview-icon,
+#dashtodockContainer #dash .list-search-result:hover .overview-icon,
+#dashtodockContainer #dash .overview-tile:focus .overview-icon,
+#dashtodockContainer #dash .grid-search-result:focus .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:focus .overview-icon,
+#dashtodockContainer #dash .list-search-result:focus .overview-icon,
+#dashtodockContainer #dash .overview-tile:selected .overview-icon,
+#dashtodockContainer #dash .grid-search-result:selected .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:selected .overview-icon,
+#dashtodockContainer #dash .list-search-result:selected .overview-icon {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+  color: #FFFFFF !important;
+}
+
+#dashtodockContainer #dash .show-apps:active .overview-icon, #dashtodockContainer #dash .show-apps:checked .overview-icon,
+#dashtodockContainer #dash .overview-tile:active .overview-icon,
+#dashtodockContainer #dash .grid-search-result:active .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:active .overview-icon,
+#dashtodockContainer #dash .list-search-result:active .overview-icon,
+#dashtodockContainer #dash .overview-tile:checked .overview-icon,
+#dashtodockContainer #dash .grid-search-result:checked .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:checked .overview-icon,
+#dashtodockContainer #dash .list-search-result:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+  color: #FFFFFF !important;
+}
+
+#dashtodockContainer .dash-separator {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#dashtodockContainer .app-grid-running-dot {
+  background-color: rgba(255, 255, 255, 0.55) !important;
+  margin: 0 0 3px !important;
+  offset-y: 0 !important;
+}
+
+#dashtodockContainer StWidget.focused .overview-icon {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+}
+
+#dashtodockContainer StWidget.focused:hover .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#dashtodockContainer StWidget.focused .app-grid-running-dot {
+  background-color: #1A73E8 !important;
+}
+
+#dashtodockContainer.opaque #dash .dash-background {
+  background-color: #202020;
+}
+
+#dashtodockContainer.transparent #dash .dash-background {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+#dashtodockContainer:overview #dash .dash-background {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+#dashtodockContainer:overview #dash .show-apps .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result .overview-icon {
+  color: rgba(255, 255, 255, 0.7) !important;
+}
+
+#dashtodockContainer:overview #dash .show-apps:hover .overview-icon, #dashtodockContainer:overview #dash .show-apps:focus .overview-icon, #dashtodockContainer:overview #dash .show-apps:selected .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:hover .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:hover .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:hover .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:hover .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:focus .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:focus .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:focus .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:focus .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:selected .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:selected .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:selected .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:selected .overview-icon {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+  color: rgba(255, 255, 255, 0.85) !important;
+}
+
+#dashtodockContainer:overview #dash .show-apps:active .overview-icon, #dashtodockContainer:overview #dash .show-apps:checked .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:active .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:active .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:active .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:active .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:checked .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:checked .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:checked .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+  color: rgba(255, 255, 255, 0.85) !important;
+}
+
+#dashtodockContainer:overview #dash .dash-separator {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#dashtodockContainer:overview #dash .app-grid-running-dot {
+  background-color: rgba(255, 255, 255, 0.5) !important;
+}
+
+#dashtodockContainer:overview #dash StWidget.focused .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#dashtodockContainer:overview #dash StWidget.focused:hover .overview-icon {
+  background-color: rgba(255, 255, 255, 0.3) !important;
+}
+
+#dashtodockContainer:overview #dash StWidget.focused .app-grid-running-dot {
+  background-color: #1A73E8 !important;
+}
+
+#dashtodockContainer.opaque:overview #dash, #dashtodockContainer.transparent:overview #dash {
+  background-color: transparent !important;
+  box-shadow: none !important;
+}
+
+#dashtodockContainer.opaque:overview #dash .dash-background, #dashtodockContainer.transparent:overview #dash .dash-background {
+  background-color: transparent !important;
+}
+
+#dashtodockContainer.extended:overview #dash, #dashtodockContainer.opaque.extended:overview #dash, #dashtodockContainer.transparent.extended:overview #dash {
+  background: none;
+}
+
+#dashtodockContainer.extended:overview .dash-background, #dashtodockContainer.opaque.extended:overview .dash-background, #dashtodockContainer.transparent.extended:overview .dash-background {
+  background-color: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#dashtodockContainer.running-dots .dash-item-container > StButton, #dashtodockContainer.dashtodock .dash-item-container > StButton {
+  transition-duration: 250ms;
+  background-size: contain;
+}
+
+#dashtodockContainer.extended .show-apps .overview-icon,
+#dashtodockContainer.extended .overview-tile .overview-icon,
+#dashtodockContainer.extended .grid-search-result .overview-icon,
+#dashtodockContainer.extended .search-provider-icon .overview-icon,
+#dashtodockContainer.extended .list-search-result .overview-icon, #dashtodockContainer.extended:overview .show-apps .overview-icon,
+#dashtodockContainer.extended:overview .overview-tile .overview-icon {
+  border-radius: 3px;
+}
+
+#dashtodockContainer .metro .overview-icon {
+  border-radius: 0;
+}
+
+.dashtodock-app-well-preview-menu-item {
+  padding: 1em 1em 0.5em 1em;
+}
+
+#dashtodockPreviewSeparator.popup-separator-menu-item-horizontal {
+  width: 1px;
+  height: auto;
+  border-right-width: 1px;
+  margin: 32px 0;
+}
+
+.dashtopanelMainPanel .show-apps,
+.dashtopanelMainPanel .overview-tile,
+.dashtopanelMainPanel .grid-search-result,
+.dashtopanelMainPanel .search-provider-icon,
+.dashtopanelMainPanel .list-search-result {
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+}
+
+.dashtopanelMainPanel .show-apps .overview-icon,
+.dashtopanelMainPanel .overview-tile .overview-icon,
+.dashtopanelMainPanel .grid-search-result .overview-icon,
+.dashtopanelMainPanel .search-provider-icon .overview-icon,
+.dashtopanelMainPanel .list-search-result .overview-icon {
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+}
+
+.dashtopanelMainPanel .show-apps .overview-icon {
+  border-radius: 3px !important;
+  color: rgba(255, 255, 255, 0.75) !important;
+}
+
+.dashtopanelMainPanel .show-apps:hover .overview-icon, .dashtopanelMainPanel .show-apps:focus .overview-icon, .dashtopanelMainPanel .show-apps:selected .overview-icon {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+  color: #FFFFFF !important;
+  box-shadow: none !important;
+}
+
+.dashtopanelMainPanel .show-apps:active .overview-icon, .dashtopanelMainPanel .show-apps:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+  color: #FFFFFF !important;
+  box-shadow: none !important;
+}
+
+.dashtopanelMainPanel .panel-button {
+  color: rgba(255, 255, 255, 0.75) !important;
+}
+
+.openweather-button, .openweather-button-action, .openweather-menu-button-container, .openweather-button-box {
+  border: 1px solid transparent !important;
+}
+
+.openweather-provider {
+  padding: 0 16px;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.54);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.openweather-provider:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+  box-shadow: none;
+}
+
+.openweather-provider:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: none;
+}
+
+.openweather-provider:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+.openweather-current-icon, .openweather-current-summary, .openweather-current-summarybox {
+  background: none;
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.openweather-current-databox-values {
+  background: none;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.openweather-current-databox-captions {
+  background: none;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.openweather-forecast-icon, .openweather-forecast-summary {
+  background: none;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.openweather-forecast-day, .openweather-forecast-temperature {
+  background: none;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.openweather-sunrise-icon, .openweather-sunset-icon, .openweather-build-icon {
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.gsconnect-device-menu .popup-menu-item {
+  height: 20px !important;
+  padding: 2px 0;
+}
+
+.gsconnect-device-menu .popup-menu-item > :last-child:ltr {
+  padding-right: 4px !important;
+  margin-right: 8px !important;
+}
+
+.gsconnect-device-menu .popup-menu-item > :last-child:rtl {
+  padding-left: 4px !important;
+  padding-left: 8px !important;
+}
+
+#panel.light-panel .panel-button,
+#panel.dark-panel .panel-button,
+#panel.transparent-panel .panel-button {
+  color: rgba(255, 255, 255, 0.7) !important;
+}
+
+#panel.light-panel .panel-button.clock-display .clock,
+#panel.dark-panel .panel-button.clock-display .clock,
+#panel.transparent-panel .panel-button.clock-display .clock {
+  color: rgba(255, 255, 255, 0.7) !important;
+}
+
+#panel.light-panel .panel-button:hover,
+#panel.dark-panel .panel-button:hover,
+#panel.transparent-panel .panel-button:hover {
+  color: rgba(255, 255, 255, 0.7) !important;
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#panel.light-panel .panel-button:active, #panel.light-panel .panel-button:checked, #panel.light-panel .panel-button:focus,
+#panel.dark-panel .panel-button:active,
+#panel.dark-panel .panel-button:checked,
+#panel.dark-panel .panel-button:focus,
+#panel.transparent-panel .panel-button:active,
+#panel.transparent-panel .panel-button:checked,
+#panel.transparent-panel .panel-button:focus {
+  color: rgba(255, 255, 255, 0.85) !important;
+  background-color: rgba(255, 255, 255, 0.3) !important;
+}
+
+#panel.light-panel .panel-button:hover.clock-display .clock, #panel.light-panel .panel-button:active.clock-display .clock, #panel.light-panel .panel-button:overview.clock-display .clock, #panel.light-panel .panel-button:focus.clock-display .clock, #panel.light-panel .panel-button:checked.clock-display .clock,
+#panel.dark-panel .panel-button:hover.clock-display .clock,
+#panel.dark-panel .panel-button:active.clock-display .clock,
+#panel.dark-panel .panel-button:overview.clock-display .clock,
+#panel.dark-panel .panel-button:focus.clock-display .clock,
+#panel.dark-panel .panel-button:checked.clock-display .clock,
+#panel.transparent-panel .panel-button:hover.clock-display .clock,
+#panel.transparent-panel .panel-button:active.clock-display .clock,
+#panel.transparent-panel .panel-button:overview.clock-display .clock,
+#panel.transparent-panel .panel-button:focus.clock-display .clock,
+#panel.transparent-panel .panel-button:checked.clock-display .clock {
+  color: rgba(255, 255, 255, 0.85) !important;
+}
+
+.overview-components-transparent .search-entry,
+.overview-components-light .search-entry,
+.overview-components-dark .search-entry {
+  caret-color: rgba(255, 255, 255, 0.75) !important;
+}
+
+.overview-components-transparent .search-entry .search-entry-icon,
+.overview-components-light .search-entry .search-entry-icon,
+.overview-components-dark .search-entry .search-entry-icon {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.overview-components-transparent .search-entry StLabel.hint-text,
+.overview-components-light .search-entry StLabel.hint-text,
+.overview-components-dark .search-entry StLabel.hint-text {
+  color: rgba(255, 255, 255, 0.35) !important;
+}
+
+.arcmenu-menu {
+  border-image: none !important;
+  border-radius: 3px !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+}
+
+.arcmenu-menu .popup-menu-content {
+  padding: 4px !important;
+  margin: 4px !important;
+  border: none !important;
+  background-color: rgba(255, 255, 255, 0.97);
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.1) !important;
+  border-radius: 3px !important;
+}

--- a/src/gnome-shell/shell-48-0/gnome-shell-compact.scss
+++ b/src/gnome-shell/shell-48-0/gnome-shell-compact.scss
@@ -1,0 +1,10 @@
+$variant: 'light';
+$laptop: 'true';
+$panel: 'dark';
+
+@import '../sass/variables';
+@import '../sass/colors';
+@import '../sass/drawing';
+@import '../sass/common-40-0';
+@import '../sass/widgets-48-0';
+@import '../sass/extensions-46-0';

--- a/src/gnome-shell/shell-48-0/gnome-shell.css
+++ b/src/gnome-shell/shell-48-0/gnome-shell.css
@@ -1,0 +1,4945 @@
+/* This stylesheet is generated, DO NOT EDIT */
+stage {
+  font-size: 10.5pt;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.87);
+}
+
+/* Common Stylings */
+#dash .dash-item-container .show-apps,
+#dash .dash-item-container .overview-tile,
+#dash .dash-item-container .grid-search-result,
+#dash .dash-item-container .search-provider-icon,
+#dash .dash-item-container .list-search-result {
+  background: none;
+  box-shadow: none;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  margin: 0;
+}
+
+#dash .dash-item-container .show-apps .overview-icon,
+#dash .dash-item-container .overview-tile .overview-icon,
+#dash .dash-item-container .grid-search-result .overview-icon,
+#dash .dash-item-container .search-provider-icon .overview-icon,
+#dash .dash-item-container .list-search-result .overview-icon {
+  border-radius: 6px;
+  padding: 6px;
+  spacing: 6px;
+  text-align: center;
+  transition-duration: 100ms;
+}
+
+.search-statustext {
+  font-size: 45px;
+  font-weight: 400;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.popup-menu-content {
+  background: rgba(255, 255, 255, 0.97);
+  color: rgba(0, 0, 0, 0.87);
+  border-radius: 3px;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.1);
+}
+
+.modal-dialog {
+  background: rgba(255, 255, 255, 0.97);
+  color: rgba(0, 0, 0, 0.87);
+  border-radius: 6px;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2);
+}
+
+/* General Typography */
+.message-notification-group .message-group-header .message-group-title, .message-list .message-list-placeholder {
+  font-weight: 800;
+  font-size: 1.364em;
+}
+
+.quick-toggle-menu .header .title {
+  font-weight: 700;
+  font-size: 1.364em;
+}
+
+.bt-menu-placeholder.popup-menu-item {
+  font-weight: 700;
+  font-size: 1.182em;
+}
+
+.background-app-item .title, .message-list-controls, .calendar .calendar-month-header .calendar-month-label {
+  font-weight: 700;
+  font-size: 1em;
+}
+
+.quick-toggle-menu .header .subtitle {
+  font-weight: 700;
+  font-size: 0.818em;
+}
+
+.background-app-item .subtitle, .message .message-header .message-header-content .event-time {
+  font-weight: 400;
+  font-size: 0.818em;
+}
+
+/* WIDGETS */
+.shell-link {
+  border-radius: 3px;
+  color: #1A73E8;
+  background-color: transparent;
+}
+
+.shell-link:hover {
+  color: #1A73E8;
+  background-color: rgba(26, 115, 232, 0.15);
+}
+
+.shell-link:active {
+  color: #1A73E8;
+  background-color: rgba(26, 115, 232, 0.3);
+}
+
+.lowres-icon {
+  icon-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+}
+
+.icon-dropshadow {
+  icon-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+}
+
+/* Entries */
+StEntry {
+  min-height: 24px;
+  padding: 3px 9px;
+  border-radius: 3px;
+  border-width: 0;
+  caret-color: rgba(0, 0, 0, 0.54);
+  selection-background-color: #1A73E8;
+  selected-color: #FFFFFF !important;
+  font-size: 12pt;
+  font-weight: 400;
+  caret-color: rgba(0, 0, 0, 0.54);
+  color: rgba(0, 0, 0, 0.54);
+  background-color: #ffffff;
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+StEntry:hover {
+  border: 2px solid rgba(0, 0, 0, 0.2) !important;
+}
+
+StEntry:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #1A73E8 !important;
+}
+
+StEntry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+StEntry StIcon.capslock-warning {
+  icon-size: 16px;
+  warning-color: #FF6D00;
+  padding: 0 0;
+}
+
+StEntry StIcon.peek-password {
+  icon-size: 16px;
+  padding: 0 4px;
+}
+
+StEntry StLabel.hint-text {
+  margin-left: 2px;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+/* Buttons */
+.screenshot-ui-show-pointer-button, .screenshot-ui-type-button {
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:focus, .screenshot-ui-type-button:focus {
+  color: rgba(255, 255, 255, 0.85);
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:hover, .screenshot-ui-type-button:hover {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.15);
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:active, .screenshot-ui-type-button:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.3);
+  box-shadow: 0 0 transparent;
+}
+
+.screenshot-ui-show-pointer-button:checked, .screenshot-ui-type-button:checked {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #1A73E8;
+  border-color: #1A73E8;
+  box-shadow: none;
+}
+
+.screenshot-ui-show-pointer-button:checked:hover, .screenshot-ui-type-button:checked:hover, .screenshot-ui-show-pointer-button:checked:focus, .screenshot-ui-type-button:checked:focus {
+  background-color: #1A73E8;
+}
+
+.screenshot-ui-show-pointer-button:insensitive, .screenshot-ui-type-button:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.icon-button.flat, .message .message-header .flat.message-expand-button,
+.message .message-header .flat.message-close-button, .message-notification-group .flat.message-collapse-button, .button.flat {
+  color: rgba(0, 0, 0, 0.54);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.icon-button.flat:focus, .message .message-header .flat.message-expand-button:focus,
+.message .message-header .flat.message-close-button:focus, .message-notification-group .flat.message-collapse-button:focus, .button.flat:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: none;
+}
+
+.icon-button.flat:hover, .message .message-header .flat.message-expand-button:hover,
+.message .message-header .flat.message-close-button:hover, .message-notification-group .flat.message-collapse-button:hover, .button.flat:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+  box-shadow: none;
+}
+
+.icon-button.flat:selected, .message .message-header .flat.message-expand-button:selected,
+.message .message-header .flat.message-close-button:selected, .message-notification-group .flat.message-collapse-button:selected, .button.flat:selected, .icon-button.flat:active, .message .message-header .flat.message-expand-button:active,
+.message .message-header .flat.message-close-button:active, .message-notification-group .flat.message-collapse-button:active, .button.flat:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+.icon-button.flat:checked, .message .message-header .flat.message-expand-button:checked,
+.message .message-header .flat.message-close-button:checked, .message-notification-group .flat.message-collapse-button:checked, .button.flat:checked {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+.icon-button.flat:insensitive, .message .message-header .flat.message-expand-button:insensitive,
+.message .message-header .flat.message-close-button:insensitive, .message-notification-group .flat.message-collapse-button:insensitive, .button.flat:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:checked, .icon-button.default, .message .message-header .default.message-expand-button,
+.message .message-header .default.message-close-button, .message-notification-group .default.message-collapse-button, .button.default {
+  color: #FFFFFF;
+  background-color: #1A73E8;
+  border-color: #1151a5;
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:focus:checked, .icon-button.default:focus, .message .message-header .default.message-expand-button:focus,
+.message .message-header .default.message-close-button:focus, .message-notification-group .default.message-collapse-button:focus, .button.default:focus {
+  color: #1A73E8;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.keyboard-brightness-level .button:focus:hover:checked, .icon-button.default:focus:hover, .message .message-header .default.message-expand-button:focus:hover,
+.message .message-header .default.message-close-button:focus:hover, .message-notification-group .default.message-collapse-button:focus:hover, .button.default:focus:hover, .keyboard-brightness-level .button:focus:active:checked, .icon-button.default:focus:active, .message .message-header .default.message-expand-button:focus:active,
+.message .message-header .default.message-close-button:focus:active, .message-notification-group .default.message-collapse-button:focus:active, .button.default:focus:active {
+  color: #1A73E8;
+}
+
+.keyboard-brightness-level .button:hover:checked, .icon-button.default:hover, .message .message-header .default.message-expand-button:hover,
+.message .message-header .default.message-close-button:hover, .message-notification-group .default.message-collapse-button:hover, .button.default:hover {
+  color: #FFFFFF;
+  background-color: #1A73E8;
+  border-color: #0e458e;
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:insensitive:checked, .icon-button.default:insensitive, .message .message-header .default.message-expand-button:insensitive,
+.message .message-header .default.message-close-button:insensitive, .message-notification-group .default.message-collapse-button:insensitive, .button.default:insensitive {
+  color: #FFFFFF;
+  background-color: #1A73E8;
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:active:checked, .icon-button.default:active, .message .message-header .default.message-expand-button:active,
+.message .message-header .default.message-close-button:active, .message-notification-group .default.message-collapse-button:active, .button.default:active {
+  color: #FFFFFF;
+  background-color: #1567d3;
+  border-color: #0e458e;
+  box-shadow: none;
+}
+
+.keyboard-brightness-level .button:active:hover:checked, .icon-button.default:active:hover, .message .message-header .default.message-expand-button:active:hover,
+.message .message-header .default.message-close-button:active:hover, .message-notification-group .default.message-collapse-button:active:hover, .button.default:active:hover, .keyboard-brightness-level .button:active:focus:checked, .icon-button.default:active:focus, .message .message-header .default.message-expand-button:active:focus,
+.message .message-header .default.message-close-button:active:focus, .message-notification-group .default.message-collapse-button:active:focus, .button.default:active:focus {
+  background-color: #1567d3;
+}
+
+.icon-button, .background-app-item .icon-button, .background-app-item .message-notification-group .message-collapse-button, .message-notification-group .background-app-item .message-collapse-button, .background-app-item .message .message-header .message-expand-button, .message .message-header .background-app-item .message-expand-button,
+.background-app-item .message .message-header .message-close-button,
+.message .message-header .background-app-item .message-close-button, .message .message-header .message-expand-button,
+.message .message-header .message-close-button, .message-notification-group .message-collapse-button, .button {
+  padding: 6px 12px;
+  border-width: 0;
+  border-radius: 3px;
+  font-size: 10.5pt;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.54);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.icon-button:focus, .message .message-header .message-expand-button:focus,
+.message .message-header .message-close-button:focus, .message-notification-group .message-collapse-button:focus, .button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: none;
+}
+
+.icon-button:hover, .message .message-header .message-expand-button:hover,
+.message .message-header .message-close-button:hover, .message-notification-group .message-collapse-button:hover, .button:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+  box-shadow: none;
+}
+
+.icon-button:selected, .message .message-header .message-expand-button:selected,
+.message .message-header .message-close-button:selected, .message-notification-group .message-collapse-button:selected, .button:selected, .icon-button:active, .message .message-header .message-expand-button:active,
+.message .message-header .message-close-button:active, .message-notification-group .message-collapse-button:active, .button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+.icon-button:checked, .message .message-header .message-expand-button:checked,
+.message .message-header .message-close-button:checked, .message-notification-group .message-collapse-button:checked, .button:checked {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #1A73E8;
+  border-color: #1A73E8;
+  box-shadow: none;
+}
+
+.icon-button:checked:hover, .message .message-header .message-expand-button:checked:hover,
+.message .message-header .message-close-button:checked:hover, .message-notification-group .message-collapse-button:checked:hover, .button:checked:hover, .icon-button:checked:focus, .message .message-header .message-expand-button:checked:focus,
+.message .message-header .message-close-button:checked:focus, .message-notification-group .message-collapse-button:checked:focus, .button:checked:focus {
+  background-color: #1A73E8;
+}
+
+.icon-button:insensitive, .message .message-header .message-expand-button:insensitive,
+.message .message-header .message-close-button:insensitive, .message-notification-group .message-collapse-button:insensitive, .button:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button, .notification-button {
+  border-radius: 3px;
+  border: 1px solid;
+  color: rgba(0, 0, 0, 0.62);
+  background-color: #ffffff;
+  border-color: #d9d9d9;
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button:focus, .notification-button:focus {
+  color: #1A73E8;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.modal-dialog .modal-dialog-button:focus:hover, .notification-button:focus:hover, .modal-dialog .modal-dialog-button:focus:active, .notification-button:focus:active {
+  color: #1A73E8;
+}
+
+.modal-dialog .modal-dialog-button:hover, .notification-button:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #ffffff;
+  border-color: #cccccc;
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button:selected, .notification-button:selected, .modal-dialog .modal-dialog-button:active, .notification-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #f2f2f2;
+  border-color: #cccccc;
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button:selected:hover, .notification-button:selected:hover, .modal-dialog .modal-dialog-button:selected:focus, .notification-button:selected:focus, .modal-dialog .modal-dialog-button:active:hover, .notification-button:active:hover, .modal-dialog .modal-dialog-button:active:focus, .notification-button:active:focus {
+  background-color: #f2f2f2;
+}
+
+.modal-dialog .modal-dialog-button:checked, .notification-button:checked {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #1A73E8;
+  border-color: #1A73E8;
+  box-shadow: none;
+}
+
+.modal-dialog .modal-dialog-button:checked:hover, .notification-button:checked:hover, .modal-dialog .modal-dialog-button:checked:focus, .notification-button:checked:focus {
+  background-color: #1A73E8;
+}
+
+.modal-dialog .modal-dialog-button:insensitive, .notification-button:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: rgba(0, 0, 0, 0.06);
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.button {
+  min-height: 1.5em;
+}
+
+.icon-button, .background-app-item .icon-button, .background-app-item .message-notification-group .message-collapse-button, .message-notification-group .background-app-item .message-collapse-button, .background-app-item .message .message-header .message-expand-button, .message .message-header .background-app-item .message-expand-button,
+.background-app-item .message .message-header .message-close-button,
+.message .message-header .background-app-item .message-close-button, .message .message-header .message-expand-button,
+.message .message-header .message-close-button, .message-notification-group .message-collapse-button {
+  border-radius: 9999px;
+  padding: 0.818em;
+  min-height: 1.091em;
+}
+
+.icon-button StIcon, .background-app-item .icon-button StIcon, .background-app-item .message-notification-group .message-collapse-button StIcon, .message-notification-group .background-app-item .message-collapse-button StIcon, .background-app-item .message .message-header .message-expand-button StIcon, .message .message-header .background-app-item .message-expand-button StIcon,
+.background-app-item .message .message-header .message-close-button StIcon,
+.message .message-header .background-app-item .message-close-button StIcon, .message .message-header .message-expand-button StIcon,
+.message .message-header .message-close-button StIcon, .message-notification-group .message-collapse-button StIcon {
+  icon-size: 1.091em;
+  -st-icon-style: symbolic;
+}
+
+/* Check Boxes */
+.check-box StBoxLayout {
+  spacing: .8em;
+}
+
+.check-box StBin {
+  width: 24px;
+  height: 24px;
+  padding: 6px;
+  border-radius: 100px;
+  background-image: url("assets/checkbox-off.svg");
+}
+
+.check-box:focus StBin {
+  background-image: url("assets/checkbox-off.svg");
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.check-box:hover StBin {
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.check-box:active StBin {
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.check-box:checked StBin {
+  background-image: url("assets/checkbox.svg");
+}
+
+.check-box:focus:checked StBin {
+  background-image: url("assets/checkbox.svg");
+}
+
+.check-box:hover:checked StBin {
+  background-color: rgba(40, 124, 233, 0.15);
+}
+
+.check-box:active:checked StBin {
+  background-color: rgba(40, 124, 233, 0.3);
+}
+
+.check-box StIcon {
+  icon-size: 0;
+  padding: 0;
+  border: none;
+  background-color: transparent;
+  color: transparent;
+}
+
+.check-box:checked StIcon {
+  background-color: transparent;
+  color: transparent;
+}
+
+.check-box:checked:hover StIcon {
+  background-color: transparent;
+  color: transparent;
+}
+
+.check-box:checked:active StIcon {
+  background-color: transparent;
+  color: transparent;
+}
+
+/* Switches */
+.toggle-switch {
+  width: 40px;
+  height: 20px;
+  background: transparent;
+  color: rgba(0, 0, 0, 0.87);
+  border: 1px solid rgba(0, 0, 0, 0.38);
+}
+
+.toggle-switch:hover {
+  background: transparent;
+  color: rgba(0, 0, 0, 0.87);
+  border: 1px solid rgba(0, 0, 0, 0.54);
+}
+
+.toggle-switch StIcon {
+  icon-size: 10px;
+}
+
+.toggle-switch .handle {
+  margin: 4px;
+  width: 12px;
+  height: 12px;
+  border-radius: 9999px;
+  background: rgba(0, 0, 0, 0.54);
+  box-shadow: none;
+  transition-duration: 100ms;
+}
+
+.toggle-switch:checked {
+  background: #1A73E8;
+  color: white;
+  border-color: #1A73E8;
+}
+
+.toggle-switch:checked:hover {
+  background-color: #3181ea;
+  color: white;
+  border-color: #3181ea;
+}
+
+.toggle-switch:checked .handle {
+  background: white;
+}
+
+/* Slider */
+.slider {
+  height: 12px;
+  color: #287ce9;
+  -barlevel-height: 2px;
+  -barlevel-background-color: rgba(0, 0, 0, 0.2);
+  -barlevel-active-background-color: #287ce9;
+  -barlevel-overdrive-color: #FF5252;
+  -barlevel-overdrive-separator-width: 2px;
+  -slider-handle-radius: 6px;
+}
+
+.slider:hover {
+  color: #3f8aec;
+}
+
+.slider:active {
+  color: #176ee1;
+}
+
+/* Scrollbars */
+StScrollView.vfade {
+  -st-vfade-offset: 32px;
+}
+
+StScrollView.hfade {
+  -st-hfade-offset: 32px;
+}
+
+StScrollBar {
+  padding: 0;
+}
+
+StScrollView StScrollBar {
+  min-width: 8px;
+  min-height: 8px;
+}
+
+StScrollBar StBin#trough {
+  border-radius: 9999px;
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+StScrollBar StButton#vhandle, StScrollBar StButton#hhandle {
+  border-radius: 9999px;
+  background-color: rgba(0, 0, 0, 0.38);
+  border: 4px solid transparent;
+}
+
+StScrollBar StButton#vhandle:hover, StScrollBar StButton#hhandle:hover {
+  background-color: rgba(0, 0, 0, 0.54);
+}
+
+StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
+  background-color: rgba(0, 0, 0, 0.87);
+}
+
+/* Popovers/Menus */
+.popup-menu-boxpointer, .candidate-popup-boxpointer {
+  -arrow-border-radius: 3px;
+  -arrow-background-color: transparent;
+  -arrow-border-width: 0;
+  -arrow-border-color: transparent;
+  -arrow-base: 27px;
+  -arrow-rise: 0;
+  -arrow-box-shadow: none;
+}
+
+.popup-menu {
+  min-width: 15em;
+  color: rgba(0, 0, 0, 0.87);
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+.popup-menu.panel-menu {
+  -boxpointer-gap: 4px;
+  margin-bottom: 1.75em;
+}
+
+.popup-menu-content {
+  padding: 6px;
+  margin: 2px 6px 10px;
+  border: none;
+}
+
+.popup-menu-item {
+  spacing: 6px;
+  padding: 6px 12px;
+  margin: 0;
+  color: rgba(0, 0, 0, 0.87);
+  transition-duration: 100ms;
+  border-radius: 3px;
+  background-image: none;
+  background-gradient-direction: none !important;
+}
+
+.popup-menu-item:ltr {
+  padding-right: 12px;
+  padding-left: 12px;
+}
+
+.popup-menu-item:rtl {
+  padding-right: 12px;
+  padding-left: 12px;
+}
+
+.popup-menu-item:checked {
+  background-color: rgba(0, 0, 0, 0.08) !important;
+  font-weight: normal;
+  border-radius: 3px 3px 0 0 !important;
+  border: none;
+  box-shadow: none;
+  color: rgba(0, 0, 0, 0.87) !important;
+  background-gradient-direction: none !important;
+}
+
+.popup-menu-item:checked.selected, .popup-menu-item:checked:hover, .popup-menu-item:checked:focus {
+  background-color: rgba(0, 0, 0, 0.1) !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+}
+
+.popup-menu-item:checked:active, .popup-menu-item:checked.selected:active {
+  background-color: rgba(0, 0, 0, 0.08) !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+}
+
+.popup-menu-item:checked:insensitive {
+  color: rgba(0, 0, 0, 0.38) !important;
+}
+
+.popup-menu-item.selected, .popup-menu-item:hover, .popup-menu-item:focus {
+  background-color: rgba(0, 0, 0, 0.06) !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+  transition-duration: 0ms;
+  background-gradient-direction: none !important;
+}
+
+.popup-menu-item:active {
+  background-color: rgba(0, 0, 0, 0.2) !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+  transition-duration: 150ms;
+  background-gradient-direction: none !important;
+}
+
+.popup-menu-item.selected:active {
+  color: rgba(0, 0, 0, 0.87) !important;
+}
+
+.popup-menu-item:insensitive {
+  color: rgba(0, 0, 0, 0.38) !important;
+}
+
+.popup-inactive-menu-item {
+  color: rgba(0, 0, 0, 0.87) !important;
+}
+
+.popup-inactive-menu-item:insensitive {
+  color: rgba(0, 0, 0, 0.38) !important;
+}
+
+.popup-menu-arrow,
+.popup-menu-icon {
+  icon-size: 16px;
+}
+
+.popup-sub-menu {
+  margin: 0;
+  background-color: rgba(0, 0, 0, 0.08) !important;
+  border-radius: 0 0 3px 3px !important;
+  border: none;
+  box-shadow: none;
+  background-image: none !important;
+}
+
+.popup-sub-menu .popup-menu-item {
+  margin: 0;
+  border-radius: 0;
+  background-image: none !important;
+  background-color: transparent !important;
+}
+
+.popup-sub-menu .popup-menu-item.selected, .popup-sub-menu .popup-menu-item:hover, .popup-sub-menu .popup-menu-item:focus {
+  background-color: rgba(0, 0, 0, 0.06) !important;
+}
+
+.popup-sub-menu .popup-menu-item:active {
+  background-color: rgba(0, 0, 0, 0.2) !important;
+}
+
+.popup-sub-menu .popup-menu-item:last-child {
+  border-radius: 0 0 3px 3px !important;
+  border-bottom-width: 0;
+}
+
+.popup-sub-menu .popup-menu-section .popup-menu-item:last-child:hover, .popup-sub-menu .popup-menu-section .popup-menu-item:last-child:focus {
+  border-radius: 0;
+}
+
+.popup-sub-menu .popup-menu-section:last-child .popup-menu-item:last-child {
+  border-radius: 0 0 3px 3px !important;
+}
+
+.popup-menu-ornament {
+  width: 1.2em;
+}
+
+.popup-menu-ornament:ltr {
+  text-align: right;
+}
+
+.popup-menu-ornament:rtl {
+  text-align: left;
+}
+
+.popup-separator-menu-item {
+  background: none;
+  border: none;
+  padding: 0 0;
+  margin: 0 0;
+  height: 4px;
+}
+
+.popup-separator-menu-item .popup-separator-menu-item-separator {
+  height: 1px;
+  margin: 0 0;
+  padding: 0 0;
+  background: none;
+}
+
+.popup-sub-menu .popup-separator-menu-item .popup-separator-menu-item-separator {
+  margin: 0 0;
+  padding: 0 0;
+  background: none;
+}
+
+.background-menu {
+  -boxpointer-gap: 4px;
+  -arrow-rise: 0px;
+}
+
+.aggregate-menu {
+  min-width: 21em;
+}
+
+.aggregate-menu .popup-menu-icon {
+  padding: 0;
+  margin: 0;
+  -st-icon-style: symbolic;
+}
+
+.aggregate-menu .popup-menu-icon:ltr {
+  margin-right: 4px;
+}
+
+.aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
+  padding-left: 12px !important;
+  margin-left: 0 !important;
+}
+
+.aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
+  padding-right: 12px !important;
+  margin-right: 0 !important;
+}
+
+/* Date/Time Menu */
+#calendarArea {
+  padding: 6px 0;
+}
+
+.datemenu-popover {
+  border-radius: 9px !important;
+}
+
+.calendar {
+  padding: 0;
+  margin: 0 6px;
+  border: none;
+  box-shadow: none;
+  background: none;
+  text-shadow: none;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.calendar .calendar-month-header .calendar-change-month-back StIcon,
+.calendar .calendar-month-header .calendar-change-month-forward StIcon {
+  icon-size: 1.091em;
+}
+
+.calendar .calendar-month-header .calendar-month-label {
+  background-color: transparent !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+  padding: 8px 0;
+  width: 10em;
+  text-align: center;
+}
+
+.calendar .calendar-day-heading {
+  width: 32px;
+  height: 25px;
+  margin-top: 2px;
+  padding: 7px 0 0;
+  border-radius: 9999px;
+  background-color: transparent !important;
+  color: rgba(0, 0, 0, 0.38) !important;
+  font-size: 9pt;
+  font-weight: 400;
+  font-weight: bold;
+  text-align: center;
+}
+
+.datemenu-calendar-column {
+  spacing: 6px;
+  border: none;
+  padding: 0;
+  margin: 0;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.datemenu-calendar-column:hover, .datemenu-calendar-column:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.datemenu-calendar-column:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.datemenu-calendar-column:ltr {
+  margin-right: 4px;
+  margin-left: 10px;
+  border-left-width: 0;
+}
+
+.datemenu-calendar-column:rtl {
+  margin-left: 4px;
+  margin-right: 10px;
+  border-right-width: 0;
+}
+
+.datemenu-calendar-column .datemenu-displays-section {
+  padding-bottom: 0;
+}
+
+.datemenu-calendar-column .datemenu-displays-box {
+  spacing: 6px;
+}
+
+.datemenu-today-button {
+  min-height: 56px;
+  padding: 6px;
+  border-radius: 3px;
+  border: none;
+  box-shadow: none;
+  text-shadow: none;
+  background: none;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.datemenu-today-button .day-label {
+  font-size: 15pt;
+  font-weight: 500;
+  font-weight: bold;
+}
+
+.datemenu-today-button .date-label {
+  font-size: 18pt;
+  font-weight: 400;
+}
+
+.datemenu-today-button:hover, .datemenu-today-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.datemenu-today-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.pager-button {
+  width: 32px;
+  height: 32px;
+  margin: 2px !important;
+  padding: 0 !important;
+  border-radius: 9999px;
+  background-color: transparent;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.pager-button:hover, .pager-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.pager-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.calendar-change-month-back {
+  padding: 2px !important;
+  background-image: url("assets/calendar-arrow-left.svg");
+}
+
+.calendar-change-month-back:rtl {
+  background-image: url("assets/calendar-arrow-right.svg");
+}
+
+.calendar-change-month-forward {
+  padding: 2px !important;
+  background-image: url("assets/calendar-arrow-right.svg");
+}
+
+.calendar-change-month-forward:rtl {
+  background-image: url("assets/calendar-arrow-left.svg");
+}
+
+.calendar-day {
+  font-size: 9pt;
+  font-weight: 400;
+  text-align: center;
+  width: 32px !important;
+  height: 32px !important;
+  padding: 2px !important;
+  margin: 2px !important;
+  border-radius: 9999px;
+  color: rgba(0, 0, 0, 0.54) !important;
+  background-color: transparent !important;
+  border: none;
+  font-feature-settings: "tnum";
+  text-shadow: none;
+}
+
+.calendar-day:hover, .calendar-day:focus {
+  background-color: rgba(0, 0, 0, 0.06) !important;
+  box-shadow: none !important;
+}
+
+.calendar-day:active {
+  color: rgba(0, 0, 0, 0.54) !important;
+  background-color: rgba(0, 0, 0, 0.2) !important;
+  border-color: transparent;
+}
+
+.calendar-day:selected {
+  color: rgba(0, 0, 0, 0.87) !important;
+  background-color: rgba(0, 0, 0, 0.2) !important;
+  border-color: transparent;
+  box-shadow: none !important;
+}
+
+.calendar-day {
+  border-width: 0;
+}
+
+.calendar-day-top {
+  border-top-width: 0;
+}
+
+.calendar-day-left {
+  border-left-width: 0;
+}
+
+.calendar-nonwork-day {
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.calendar-today {
+  font-weight: bold !important;
+  color: white !important;
+  background-color: #1A73E8 !important;
+  border: none;
+}
+
+.calendar-today:hover, .calendar-today:focus {
+  background-color: #287ce9 !important;
+  color: white !important;
+  box-shadow: none !important;
+}
+
+.calendar-today:active, .calendar-today:selected {
+  background-color: #1A73E8 !important;
+  color: white !important;
+  box-shadow: none !important;
+}
+
+.calendar-today:active:hover, .calendar-today:active:focus, .calendar-today:selected:hover, .calendar-today:selected:focus {
+  background-color: #287ce9 !important;
+  color: white !important;
+}
+
+.calendar-day-with-events {
+  color: rgba(0, 0, 0, 0.38);
+  background-image: url("assets/calendar-today.svg");
+}
+
+.calendar-day-with-events.calendar-work-day {
+  color: rgba(0, 0, 0, 0.38);
+  font-weight: bold;
+}
+
+.calendar-weekend {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.calendar-other-month {
+  color: rgba(0, 0, 0, 0.26) !important;
+  opacity: 1;
+  font-weight: normal;
+}
+
+.calendar-other-month.calendar-weekend {
+  color: rgba(0, 0, 0, 0.26) !important;
+}
+
+.calendar-week-number {
+  height: 1.8em !important;
+  width: 2.6em !important;
+  padding: 1px 0 !important;
+  margin: 6px 0 !important;
+  border-radius: 9999px;
+  background-color: rgba(0, 0, 0, 0.04);
+  color: rgba(0, 0, 0, 0.38);
+  font-size: inherit;
+  font-weight: bold;
+  text-align: center;
+  text-shadow: none;
+}
+
+.world-clocks-button,
+.weather-button,
+.events-button {
+  padding: 6px 8px;
+  border-radius: 3px;
+  box-shadow: none;
+  text-shadow: none;
+  color: rgba(0, 0, 0, 0.54);
+  background-color: rgba(255, 255, 255, 0.35) !important;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.world-clocks-button:hover, .world-clocks-button:focus,
+.weather-button:hover,
+.weather-button:focus,
+.events-button:hover,
+.events-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06) !important;
+  border-color: rgba(0, 0, 0, 0.15);
+  box-shadow: none;
+}
+
+.world-clocks-button:active,
+.weather-button:active,
+.events-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.08) !important;
+  box-shadow: none;
+}
+
+.world-clocks-header,
+.weather-header,
+.message-list-section-title,
+.events-section-title,
+.events-title {
+  color: rgba(0, 0, 0, 0.38);
+  font-weight: bold;
+  margin-bottom: 4px;
+  text-shadow: none;
+}
+
+.weather-grid,
+.world-clocks-grid {
+  spacing-rows: 8px;
+  spacing-columns: 16px;
+}
+
+.world-clocks-header,
+.weather-header,
+.events-section-title {
+  color: rgba(0, 0, 0, 0.38);
+  font-weight: bold;
+}
+
+.events-button .events-box {
+  spacing: 6px;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.events-button .events-list {
+  spacing: 12px;
+  text-shadow: none;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.events-button .event-time {
+  color: rgba(0, 0, 0, 0.26);
+  font-feature-settings: "tnum";
+}
+
+.world-clocks-button .world-clocks-city {
+  color: rgba(0, 0, 0, 0.38);
+  font-weight: normal;
+  font-size: 1em;
+}
+
+.world-clocks-button .world-clocks-time {
+  color: rgba(0, 0, 0, 0.38);
+  font-feature-settings: "tnum";
+  font-weight: bold;
+  font-size: 1em;
+}
+
+.world-clocks-button .world-clocks-time:ltr {
+  text-align: right;
+}
+
+.world-clocks-button .world-clocks-time:rtl {
+  text-align: left;
+}
+
+.world-clocks-button .world-clocks-timezone {
+  color: rgba(0, 0, 0, 0.38);
+  font-feature-settings: "tnum";
+  font-size: 1em;
+}
+
+.weather-button .weather-box {
+  spacing: 6px;
+}
+
+.weather-button .weather-header-box {
+  spacing: 6px;
+}
+
+.weather-button .weather-header.location {
+  font-weight: normal;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.weather-button .weather-forecast-icon {
+  icon-size: 32px;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.weather-button .weather-forecast-time {
+  color: rgba(0, 0, 0, 0.38);
+  font-size: 0.8em;
+  font-feature-settings: "tnum";
+  font-weight: normal;
+  padding-top: 0.2em;
+  padding-bottom: 0.4em;
+}
+
+.weather-button .weather-forecast-temp {
+  font-weight: bold;
+  color: rgba(0, 0, 0, 0.52);
+  text-shadow: none;
+}
+
+/* Message List */
+.message-list {
+  width: 29em;
+  padding: 0;
+  color: rgba(0, 0, 0, 0.54);
+  text-shadow: none;
+  box-shadow: none;
+  border: 0 solid rgba(0, 0, 0, 0.12);
+}
+
+.message-list:ltr {
+  margin-left: 6px;
+  margin-right: 0;
+  padding-right: 12px;
+  border-right-width: 1px;
+}
+
+.message-list:rtl {
+  margin-right: 6px;
+  margin-left: 0;
+  padding-left: 12px;
+  border-left-width: 1px;
+}
+
+.message-list .message-list-placeholder {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.message-list .message-list-placeholder > StIcon {
+  icon-size: 96px;
+  margin-bottom: 12px;
+  -st-icon-style: symbolic;
+}
+
+.message-view {
+  -st-vfade-offset: 68px;
+}
+
+.message-view:ltr {
+  margin-right: 0;
+}
+
+.message-view:rtl {
+  margin-left: 0;
+}
+
+.message-view .message {
+  margin-bottom: 12px !important;
+}
+
+.message-list-controls {
+  padding: 12px;
+  padding-bottom: 6px;
+  spacing: 6px;
+}
+
+.message-list-controls .dnd-button {
+  border-width: 2px;
+  border-color: transparent;
+  border-radius: 32px;
+  border-style: solid;
+}
+
+.message-list-controls .dnd-button:focus {
+  border-color: rgba(26, 115, 232, 0.6);
+}
+
+.message-notification-group {
+  spacing: 12px;
+}
+
+.message-notification-group .message-group-header {
+  padding: 6px;
+}
+
+.message-notification-group .message-group-header .message-group-title {
+  margin: 0 4px;
+}
+
+.message-notification-group .message-collapse-button {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.07);
+  padding: 4px;
+}
+
+.message-notification-group .message-collapse-button:hover {
+  background-color: rgba(0, 0, 0, 0.17);
+}
+
+.message-notification-group .message-collapse-button:active {
+  background-color: rgba(0, 0, 0, 0.07);
+}
+
+.message {
+  background-color: rgba(255, 255, 255, 0.35);
+  border-radius: 3px;
+  color: rgba(0, 0, 0, 0.54);
+  text-shadow: none;
+  padding: 0;
+  margin: 4px;
+  box-shadow: 0 3px 8px -2px rgba(0, 0, 0, 0.15);
+  background-color: rgba(255, 255, 255, 0.95);
+  border: 1px solid transparent;
+  border-left: none;
+  border-bottom: none;
+}
+
+.message:hover, .message:focus, .message:active {
+  background-color: #ffffff;
+}
+
+.popup-menu .message {
+  margin: 0 0 4px;
+  box-shadow: none;
+  background-color: rgba(255, 255, 255, 0.35);
+  border-radius: 3px;
+  color: rgba(0, 0, 0, 0.54);
+  border: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.popup-menu .message:hover, .popup-menu .message:focus {
+  background-color: rgba(0, 0, 0, 0.06);
+  border-color: rgba(0, 0, 0, 0.15);
+}
+
+.popup-menu .message:active {
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.message:second-in-stack {
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.message:lower-in-stack {
+  box-shadow: none;
+}
+
+.message .message-header {
+  padding: 0 0.409em;
+  spacing: 6px;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.message .message-header:ltr {
+  padding-right: 0;
+}
+
+.message .message-header:rtl {
+  padding-left: 0;
+}
+
+.message .message-header .message-source-icon {
+  icon-size: 1.091em;
+  -st-icon-style: symbolic;
+}
+
+.message .message-header .message-header-content {
+  spacing: 6px;
+  min-height: 1.637em;
+  padding-bottom: 6px;
+}
+
+.message .message-header .message-header-content .message-source-title {
+  font-weight: bold;
+}
+
+.message .message-header .message-header-content .event-time {
+  color: rgba(0, 0, 0, 0.38);
+  padding-bottom: 0.068em;
+}
+
+.message .message-header .message-header-content .event-time:ltr {
+  text-align: right;
+}
+
+.message .message-header .message-header-content .event-time:rtl {
+  text-align: left;
+}
+
+.message .message-header .message-expand-button,
+.message .message-header .message-close-button {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0);
+  padding: 4px;
+}
+
+.message .message-header .message-expand-button:hover,
+.message .message-header .message-close-button:hover {
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.message .message-header .message-expand-button:active, .message .message-header .message-expand-button:active:hover,
+.message .message-header .message-close-button:active,
+.message .message-header .message-close-button:active:hover {
+  background-color: rgba(0, 0, 0, 0.11);
+}
+
+.message .message-header .message-expand-button:insensitive,
+.message .message-header .message-close-button:insensitive {
+  background-color: rgba(0, 0, 0, 0);
+}
+
+.message .message-header .message-expand-button {
+  padding: 6px;
+}
+
+.message .message-header .message-expand-button:ltr {
+  margin-right: 6px;
+}
+
+.message .message-header .message-expand-button:rtl {
+  margin-left: 6px;
+}
+
+.message .message-box {
+  padding: 6px;
+  margin: 6px;
+  margin-top: 0;
+  spacing: 6px;
+}
+
+.message .message-box .message-icon {
+  icon-size: 48px;
+  -st-icon-style: symbolic;
+}
+
+.message .message-box .message-icon:ltr {
+  margin-right: 6px;
+}
+
+.message .message-box .message-icon:rtl {
+  margin-left: 6px;
+}
+
+.message .message-box .message-icon.message-themed-icon {
+  border-radius: 9999px;
+  background-color: rgba(0, 0, 0, 0.07);
+  icon-size: 16px;
+  min-width: 48px;
+  min-height: 48px;
+}
+
+.message .message-box:first-child {
+  margin-top: 12px;
+}
+
+.message .message-box .message-content {
+  spacing: 4px;
+}
+
+.message .message-box .message-content .message-title {
+  font-weight: bold;
+}
+
+.url-highlighter {
+  link-color: #1A73E8;
+}
+
+/* Media Controls */
+.message-media-control {
+  margin: 4px 0;
+  padding: 0 12px;
+  border-radius: 9999px;
+  color: rgba(0, 0, 0, 0.54);
+  border: none;
+}
+
+.message-media-control:hover, .message-media-control:focus {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.message-media-control:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.message-media-control:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.message-media-control StIcon {
+  icon-size: 16px;
+}
+
+.media-message .message-icon {
+  border-radius: 3px !important;
+}
+
+.media-message .message-icon.message-themed-icon {
+  icon-size: 32px !important;
+}
+
+.candidate-popup-content {
+  background-color: rgba(255, 255, 255, 0.97);
+  border-radius: 3px;
+  box-shadow: 0 3px 8px -2px rgba(0, 0, 0, 0.25) !important;
+  margin: 3px 8px 11px;
+  padding: 6px;
+  spacing: 6px;
+  border: 1px solid transparent;
+}
+
+.candidate-index {
+  padding: 0 0.5em 0 0;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.candidate-box {
+  padding: 0.3em 0.5em 0.3em 0.5em;
+  margin-right: 3px;
+  border-radius: 3px;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.candidate-box:hover {
+  background-color: rgba(0, 0, 0, 0.06);
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.candidate-box:active {
+  background-color: rgba(0, 0, 0, 0.2);
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.candidate-box:selected {
+  background-color: rgba(0, 0, 0, 0.06);
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.candidate-box:last-child {
+  margin-right: 0;
+}
+
+.candidate-page-button-box {
+  height: 2em;
+}
+
+.vertical .candidate-page-button-box {
+  padding-top: 0.5em;
+}
+
+.horizontal .candidate-page-button-box {
+  padding-left: 0.5em;
+}
+
+.candidate-page-button {
+  padding: 4px;
+}
+
+.candidate-page-button-previous {
+  border-radius: 3px 0px 0px 3px;
+  border-right-width: 0;
+}
+
+.candidate-page-button-next {
+  border-radius: 0px 3px 3px 0px;
+}
+
+.candidate-page-button-icon {
+  icon-size: 1em;
+}
+
+/* Notifications & Message Tray */
+.notification-banner {
+  min-height: 64px;
+  width: 34em;
+  margin: 6px;
+  border-radius: 6px;
+}
+
+.notification-buttons-bin {
+  spacing: 0;
+  padding: 0 6px 6px;
+  margin: 0;
+  border: none;
+}
+
+.notification-button {
+  min-height: 24px;
+  padding: 6px 12px;
+  font-weight: bold;
+}
+
+.hotplug-notification-item {
+  padding: 2px 10px;
+  border-top: 1px solid rgba(0, 0, 0, 0.12);
+  text-shadow: none;
+  font-size: 10.5pt;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.54);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.hotplug-notification-item:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+  box-shadow: none;
+}
+
+.hotplug-notification-item:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+.hotplug-notification-item:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.hotplug-notification-item:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: none;
+}
+
+.hotplug-notification-item:first-child {
+  border-radius: 0 0 0 3px;
+}
+
+.hotplug-notification-item:last-child {
+  border-radius: 0 0 3px 0;
+}
+
+.hotplug-notification-item:first-child:last-child {
+  border-radius: 0 0 3px 3px;
+}
+
+.hotplug-notification-item-icon {
+  icon-size: 24px;
+  padding: 0 4px;
+}
+
+/* Modal Dialogs */
+.headline {
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+.modal-dialog {
+  padding: 0;
+}
+
+.modal-dialog .modal-dialog-content-box {
+  margin: 32px 40px 42px;
+  spacing: 32px;
+  max-width: 28em;
+}
+
+.modal-dialog .modal-dialog-button-box {
+  padding: 12px;
+  background: rgba(0, 0, 0, 0.06);
+  border-radius: 0 0 6px 6px;
+  border-top: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.modal-dialog .modal-dialog-button {
+  font-weight: bold;
+  background-gradient-direction: none !important;
+  margin: 0 !important;
+}
+
+/* End Session Dialog */
+.end-session-dialog {
+  width: 30em;
+}
+
+.end-session-dialog .end-session-dialog-battery-warning,
+.end-session-dialog .dialog-list-title {
+  color: #FF6D00;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child {
+  background-color: #FF5252 !important;
+  color: white !important;
+  border-color: rgba(224, 72, 72, 0.9805) !important;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child:hover {
+  background-color: #ff8080 !important;
+  border-color: rgba(203, 65, 65, 0.9675) !important;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child:active {
+  background-color: #ff5c5c !important;
+  border-color: rgba(203, 65, 65, 0.9675) !important;
+}
+
+.end-session-dialog .modal-dialog-linked-button:last-child:insensitive {
+  color: rgba(255, 255, 255, 0.5) !important;
+  background-color: rgba(255, 82, 82, 0.35) !important;
+  border-color: rgba(235, 76, 76, 0.987) !important;
+}
+
+/* Message Dialog */
+.message-dialog-content {
+  spacing: 18px;
+}
+
+.message-dialog-content .message-dialog-title {
+  text-align: center;
+  font-size: 18pt;
+  font-weight: 800;
+}
+
+.message-dialog-content .message-dialog-title.lightweight {
+  font-size: 13pt;
+  font-weight: 800;
+}
+
+.message-dialog-content .message-dialog-description {
+  text-align: center;
+}
+
+/* Dialog List */
+.dialog-list {
+  spacing: 18px;
+}
+
+.dialog-list .dialog-list-title {
+  text-align: center;
+  font-weight: bold;
+}
+
+.dialog-list .dialog-list-scrollview {
+  max-height: 200px;
+}
+
+.dialog-list .dialog-list-box {
+  spacing: 1em;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item {
+  spacing: 1em;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item .dialog-list-item-title {
+  font-weight: bold;
+}
+
+.dialog-list .dialog-list-box .dialog-list-item .dialog-list-item-description {
+  color: rgba(0, 0, 0, 0.54);
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+/* Run Dialog */
+.run-dialog .modal-dialog-content-box {
+  margin-top: 24px;
+  margin-bottom: 14px;
+}
+
+.run-dialog .run-dialog-entry {
+  width: 20em;
+}
+
+.run-dialog .run-dialog-description {
+  font-size: 12pt;
+  font-weight: 400;
+  text-align: center;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+/* Password or Authentication Dialog */
+.prompt-dialog {
+  width: 28em;
+}
+
+.prompt-dialog .modal-dialog-content-box {
+  margin-bottom: 24px;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child {
+  background-color: #287ce9 !important;
+  color: white !important;
+  border-color: rgba(35, 109, 205, 0.9805) !important;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:hover {
+  background-color: #5295ee !important;
+  border-color: rgba(32, 98, 186, 0.9675) !important;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:active {
+  background-color: #3181ea !important;
+  border-color: rgba(32, 98, 186, 0.9675) !important;
+}
+
+.prompt-dialog .modal-dialog-linked-button:last-child:insensitive {
+  color: rgba(255, 255, 255, 0.5) !important;
+  background-color: rgba(40, 124, 233, 0.35) !important;
+  border-color: rgba(37, 114, 215, 0.987) !important;
+}
+
+.prompt-dialog-password-grid {
+  spacing-rows: 8px;
+  spacing-columns: 4px;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry {
+  width: auto;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry:ltr {
+  margin-left: 20px;
+}
+
+.prompt-dialog-password-grid .prompt-dialog-password-entry:rtl {
+  margin-right: 20px;
+}
+
+.prompt-dialog-password-layout {
+  spacing: 8px;
+}
+
+.prompt-dialog-password-entry {
+  width: 20em;
+}
+
+.prompt-dialog-error-label,
+.prompt-dialog-info-label,
+.prompt-dialog-null-label {
+  text-align: center;
+  font-size: 15pt;
+  font-weight: 500;
+}
+
+.prompt-dialog-error-label {
+  color: #FF6D00;
+}
+
+/* Polkit Dialog */
+.polkit-dialog-user-layout {
+  text-align: center;
+  spacing: 8px;
+  margin-bottom: 6px;
+}
+
+.polkit-dialog-user-layout .polkit-dialog-user-root-label {
+  color: #FF6D00;
+}
+
+/* Audio selection dialog */
+.audio-device-selection-dialog .modal-dialog-content-box {
+  margin-bottom: 28px;
+}
+
+.audio-device-selection-dialog .audio-selection-box {
+  spacing: 20px;
+}
+
+.audio-selection-device {
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 3px;
+}
+
+.audio-selection-device:active, .audio-selection-device:hover, .audio-selection-device:focus {
+  background-color: #1A73E8;
+}
+
+.audio-selection-device-box {
+  padding: 20px;
+  spacing: 20px;
+}
+
+.audio-selection-device-icon {
+  icon-size: 64px;
+}
+
+/* Welcome dialog */
+.welcome-dialog-image {
+  background-image: url("resource:///org/gnome/shell/theme/gnome-shell-start.svg");
+  background-size: contain;
+  /* Reasonable maximum dimensions */
+  height: 300px;
+  width: 300px;
+}
+
+/* Network Dialogs */
+.nm-dialog {
+  max-height: 34em;
+  min-height: 31em;
+  min-width: 32em;
+}
+
+.nm-dialog-content {
+  spacing: 20px;
+  padding: 24px;
+}
+
+.nm-dialog-airplane-box {
+  spacing: 12px;
+}
+
+.nm-dialog-airplane-headline {
+  font-weight: bold;
+  text-align: center;
+}
+
+.nm-dialog-airplane-text {
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.nm-dialog-header {
+  font-weight: bold;
+}
+
+.nm-dialog-header-icon {
+  icon-size: 32px;
+}
+
+.nm-dialog-header-hbox {
+  spacing: 10px;
+}
+
+.nm-dialog-scroll-view {
+  border: none;
+  background-color: rgba(0, 0, 0, 0.06);
+  border-radius: 3px;
+  padding: 12px;
+  padding-right: 0;
+}
+
+.nm-dialog-item {
+  font-size: 1em;
+  border-bottom: none;
+  border-radius: -3px;
+  padding: 12px;
+  spacing: 0px;
+}
+
+.nm-dialog-item:hover, .nm-dialog-item:focus {
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.nm-dialog-item:active {
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.nm-dialog-item:selected {
+  background-color: #1A73E8;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.nm-dialog-icon {
+  icon-size: 16px;
+}
+
+.nm-dialog-icons {
+  spacing: 12px;
+}
+
+.no-networks-label {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.no-networks-box {
+  spacing: 6px;
+}
+
+/* OSD */
+.screenshot-ui-panel, .workspace-switcher-container, .switcher-list, .resize-popup, .osd-window {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #222222;
+  border: none;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.35);
+  border-radius: 3px;
+  padding: 12px;
+}
+
+.osd-window {
+  text-align: center;
+  font-weight: bold;
+  spacing: 12px;
+  padding: 12px 18px;
+  margin-bottom: 4em;
+}
+
+.osd-window > * {
+  spacing: 8px;
+}
+
+.osd-window StIcon {
+  icon-size: 32px;
+}
+
+.osd-window StLabel:ltr {
+  margin-right: 6px;
+}
+
+.osd-window StLabel:rtl {
+  margin-left: 6px;
+}
+
+.osd-window .osd-monitor-label {
+  font-size: 3em;
+}
+
+.osd-window .level {
+  height: 4px;
+  -barlevel-height: 4px;
+  -barlevel-background-color: rgba(26, 115, 232, 0.3);
+  -barlevel-active-background-color: #1A73E8;
+  -barlevel-overdrive-color: #FF5252;
+  -barlevel-overdrive-separator-width: 3px;
+  -barlevel-border-width: 0;
+}
+
+/* Pad OSD */
+.pad-osd-window {
+  padding: 32px;
+  background-color: rgba(0, 0, 0, 0.8);
+  border: none;
+}
+
+.pad-osd-window .pad-osd-title-box {
+  spacing: 12px;
+}
+
+.pad-osd-window .pad-osd-title-menu-box {
+  spacing: 6px;
+}
+
+.combo-box-label {
+  width: 15em;
+}
+
+/* App Switcher */
+.switcher-popup {
+  padding: 8px;
+  spacing: 24px;
+}
+
+.switcher-list .item-box {
+  padding: 8px;
+  border-radius: 3px;
+  border: none;
+}
+
+.switcher-list .item-box:outlined {
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.switcher-list .item-box:selected {
+  background-color: #1A73E8;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.switcher-list .thumbnail-box {
+  padding: 2px;
+  spacing: 6px;
+}
+
+.switcher-list .thumbnail {
+  width: 256px;
+}
+
+.switcher-list .separator {
+  width: 1px;
+  background: rgba(0, 0, 0, 0.12);
+}
+
+.switcher-list .switcher-list-item-container {
+  spacing: 12px;
+}
+
+.switcher-arrow {
+  border-color: rgba(0, 0, 0, 0);
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.switcher-arrow:highlighted {
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.input-source-switcher-symbol {
+  font-size: 34pt;
+  width: 96px;
+  height: 96px;
+}
+
+.cycler-highlight {
+  border: 5px solid #1A73E8;
+}
+
+/* Workspace Switcher */
+.workspace-switcher-group {
+  padding: 12px;
+}
+
+.workspace-switcher {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  spacing: 12px;
+}
+
+.ws-switcher-box {
+  height: 50px;
+  background-size: 32px;
+  border: none;
+  background: rgba(0, 0, 0, 0.06);
+  border-radius: 3px;
+}
+
+.ws-switcher-active-up,
+.ws-switcher-active-down,
+.ws-switcher-active-left,
+.ws-switcher-active-right {
+  height: 52px;
+  background-color: #1A73E8;
+  border: none;
+  border-radius: 6px;
+  color: #FFFFFF;
+}
+
+/* Top Bar */
+#panel .panel-button#panelActivities {
+  -natural-hpadding: 15px;
+}
+
+#panel .panel-button#panelActivities StBoxLayout {
+  spacing: 6px;
+}
+
+#panel .panel-button#panelActivities .workspace-dot {
+  border-radius: 9999px;
+  min-width: 8px;
+  min-height: 8px;
+  background-color: #FFFFFF;
+}
+
+#panel {
+  font-weight: normal;
+  font-feature-settings: "tnum";
+  transition-duration: 250ms;
+  border: none;
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.5);
+  margin: 0;
+  border-radius: 0;
+  height: 34px;
+}
+
+#panel #panelLeft, #panel #panelCenter {
+  spacing: 0;
+}
+
+#panel .panel-corner {
+  -panel-corner-radius: 0;
+  -panel-corner-background-color: rgba(0, 0, 0, 0.5);
+  -panel-corner-border-width: 0;
+  -panel-corner-border-color: transparent;
+  -panel-corner-opacity: 0;
+  transition-duration: 250ms;
+}
+
+#panel .panel-button {
+  -natural-hpadding: 8px;
+  -minimum-hpadding: 8px;
+  font-weight: normal;
+  color: rgba(255, 255, 255, 0.75);
+  transition-duration: 150ms;
+  text-shadow: none;
+  border-radius: 0;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#panel .panel-button StLabel {
+  padding: 0;
+}
+
+#panel .panel-button:hover {
+  color: rgba(255, 255, 255, 0.75);
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+#panel .panel-button:active, #panel .panel-button:checked, #panel .panel-button:focus {
+  color: #FFFFFF;
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#panel .panel-button:hover, #panel .panel-button:active, #panel .panel-button:overview, #panel .panel-button:focus, #panel .panel-button:checked {
+  text-shadow: none;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#panel .panel-button.clock-display {
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#panel .panel-button.clock-display:hover {
+  color: rgba(255, 255, 255, 0.75);
+  background-color: rgba(255, 255, 255, 0.1) !important;
+}
+
+#panel .panel-button.clock-display:active, #panel .panel-button.clock-display:checked, #panel .panel-button.clock-display:focus {
+  color: #FFFFFF;
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#panel .panel-button.clock-display:active .clock, #panel .panel-button.clock-display:checked .clock, #panel .panel-button.clock-display:focus .clock {
+  box-shadow: none;
+  background: none;
+  color: #FFFFFF;
+}
+
+#panel .panel-button.clock-display:hover, #panel .panel-button.clock-display:active, #panel .panel-button.clock-display:checked, #panel .panel-button.clock-display:focus {
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#panel .panel-button.clock-display .clock {
+  color: rgba(255, 255, 255, 0.75);
+  transition-duration: 150ms;
+  border: none;
+  border-radius: 0;
+}
+
+#panel .panel-button.clock-display .messages-indicator {
+  icon-size: 1.091em;
+}
+
+#panel .panel-button .system-status-icon {
+  icon-size: 16px;
+  padding: 6px;
+  margin: 0 3px;
+}
+
+#panel .panel-button .panel-status-menu-box .system-status-icon {
+  margin: 0;
+}
+
+#panel .panel-button .panel-status-menu-box StLabel {
+  padding: 0 0 0 3px;
+}
+
+#panel .panel-button .panel-status-menu-box,
+#panel .panel-button .panel-status-indicators-box {
+  spacing: 3px;
+}
+
+#panel .panel-button .appindicator-trayicons-box,
+#panel .panel-button .panel-status-indicators-box.appindicator-box {
+  margin: 0 6px;
+}
+
+#panel .panel-button .clipboard-indicator-icon {
+  margin: 0 6px;
+}
+
+#panel .panel-button .app-menu-icon {
+  -st-icon-style: symbolic;
+}
+
+#panel.unlock-screen, #panel.login-screen, #panel.lock-screen, #panel:overview {
+  background-color: transparent;
+}
+
+#panel.unlock-screen .panel-button, #panel.login-screen .panel-button, #panel.lock-screen .panel-button, #panel:overview .panel-button {
+  border-radius: 3px;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+}
+
+#panel.unlock-screen .panel-button:hover, #panel.login-screen .panel-button:hover, #panel.lock-screen .panel-button:hover, #panel:overview .panel-button:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#panel.unlock-screen .panel-button:active, #panel.unlock-screen .panel-button:checked, #panel.unlock-screen .panel-button:focus, #panel.login-screen .panel-button:active, #panel.login-screen .panel-button:checked, #panel.login-screen .panel-button:focus, #panel.lock-screen .panel-button:active, #panel.lock-screen .panel-button:checked, #panel.lock-screen .panel-button:focus, #panel:overview .panel-button:active, #panel:overview .panel-button:checked, #panel:overview .panel-button:focus {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+#panel.unlock-screen .panel-button.clock-display:hover, #panel.login-screen .panel-button.clock-display:hover, #panel.lock-screen .panel-button.clock-display:hover, #panel:overview .panel-button.clock-display:hover {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#panel.unlock-screen .panel-button.clock-display:active, #panel.unlock-screen .panel-button.clock-display:checked, #panel.unlock-screen .panel-button.clock-display:focus, #panel.login-screen .panel-button.clock-display:active, #panel.login-screen .panel-button.clock-display:checked, #panel.login-screen .panel-button.clock-display:focus, #panel.lock-screen .panel-button.clock-display:active, #panel.lock-screen .panel-button.clock-display:checked, #panel.lock-screen .panel-button.clock-display:focus, #panel:overview .panel-button.clock-display:active, #panel:overview .panel-button.clock-display:checked, #panel:overview .panel-button.clock-display:focus {
+  background-color: rgba(255, 255, 255, 0.3) !important;
+}
+
+#panel.unlock-screen .panel-button.clock-display .clock, #panel.login-screen .panel-button.clock-display .clock, #panel.lock-screen .panel-button.clock-display .clock, #panel:overview .panel-button.clock-display .clock {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+#panel.unlock-screen .panel-button#panelActivities, #panel.login-screen .panel-button#panelActivities, #panel.lock-screen .panel-button#panelActivities, #panel:overview .panel-button#panelActivities {
+  box-shadow: none;
+  border: none;
+  background-color: transparent;
+}
+
+#panel.unlock-screen .panel-button#panelActivities:hover, #panel.login-screen .panel-button#panelActivities:hover, #panel.lock-screen .panel-button#panelActivities:hover, #panel:overview .panel-button#panelActivities:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#panel.unlock-screen .panel-button#panelActivities .workspace-dot, #panel.login-screen .panel-button#panelActivities .workspace-dot, #panel.lock-screen .panel-button#panelActivities .workspace-dot, #panel:overview .panel-button#panelActivities .workspace-dot {
+  background-color: rgba(255, 255, 255, 0.85);
+}
+
+#panel.unlock-screen .panel-corner, #panel.login-screen .panel-corner, #panel.lock-screen .panel-corner, #panel:overview .panel-corner {
+  -panel-corner-opacity: 0;
+  -panel-corner-radius: 0;
+  -panel-corner-background-color: transparent;
+  -panel-corner-border-color: transparent;
+}
+
+#panel Gjs_ui_panel_AggregateMenu.panel-button .system-status-icon {
+  margin: 0 !important;
+  padding: 6px !important;
+}
+
+#panel Gjs_kimpanel_kde_org_indicator_KimIndicator.panel-button .panel-status-menu-box {
+  margin: 0 6px;
+}
+
+#panel .screencast-indicator,
+#panel .remote-access-indicator {
+  color: #FF6D00;
+}
+
+#appMenu {
+  spacing: 6px;
+}
+
+#appMenu .label-shadow {
+  color: transparent;
+}
+
+#appMenu .panel-status-menu-box {
+  padding: 0 6px;
+  spacing: 6px;
+}
+
+/* Activities Ripple */
+.ripple-box {
+  background-color: rgba(26, 115, 232, 0.35);
+  width: 52px;
+  height: 52px;
+  border-radius: 0 0 52px 0;
+}
+
+.ripple-box:rtl {
+  border-radius: 0 0 0 52px;
+}
+
+/* OVERVIEW */
+.controls-manager, .secondary-monitor-workspaces {
+  spacing: 12px;
+}
+
+#overviewGroup {
+  background-color: #222222;
+}
+
+.overview-controls {
+  padding-bottom: 32px;
+}
+
+/* Window Picker */
+.window-picker {
+  spacing: 6px;
+}
+
+.window-caption {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(32, 32, 32, 0.9);
+  border-radius: 6px;
+  padding: 6px 12px;
+}
+
+.window-close, .screenshot-ui-close-button {
+  background-color: #1A73E8;
+  color: white;
+  border-radius: 9999px;
+  padding: 3px;
+  height: 30px;
+  width: 30px;
+  box-shadow: -1px 1px 5px 0px rgba(0, 0, 0, 0.5);
+  transition-duration: 300ms;
+}
+
+.window-close StIcon, .screenshot-ui-close-button StIcon {
+  icon-size: 24px;
+}
+
+.window-close:hover, .screenshot-ui-close-button:hover {
+  background-color: #609eef;
+}
+
+.window-close:active, .screenshot-ui-close-button:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #1567d3;
+}
+
+.workspace-background {
+  border-radius: 30px;
+  background-color: #222222;
+  box-shadow: 0 4px 16px 4px rgba(0, 0, 0, 0.3);
+  border: none;
+}
+
+.search-entry {
+  min-height: 24px;
+  padding: 3px 6px;
+  width: 320px;
+  border: none !important;
+  border-radius: 3px;
+  selection-background-color: #1A73E8;
+  selected-color: #FFFFFF !important;
+  caret-color: rgba(0, 0, 0, 0.54);
+  color: rgba(0, 0, 0, 0.54);
+  background-color: #ffffff;
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+.search-entry:hover {
+  border: 2px solid rgba(0, 0, 0, 0.2) !important;
+}
+
+.search-entry:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #1A73E8 !important;
+}
+
+.search-entry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.search-entry .search-entry-icon {
+  icon-size: 16px;
+  padding: 0 4px;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.search-entry StLabel.hint-text {
+  margin-left: 2px;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+#overview .search-entry {
+  min-height: 24px;
+  padding: 6px 9px;
+  margin-top: 12px;
+  margin-bottom: 6px;
+  border-radius: 5px;
+  caret-color: rgba(0, 0, 0, 0.75);
+  color: rgba(0, 0, 0, 0.75);
+  background-color: rgba(255, 255, 255, 0.75) !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#overview .search-entry:hover {
+  color: rgba(0, 0, 0, 0.75);
+  background-color: rgba(255, 255, 255, 0.85) !important;
+}
+
+#overview .search-entry:focus {
+  color: rgba(0, 0, 0, 0.85);
+  background-color: rgba(255, 255, 255, 0.95) !important;
+  border: none !important;
+  selection-background-color: #1A73E8;
+  selected-color: #FFFFFF !important;
+}
+
+#overview .search-entry .search-entry-icon {
+  color: rgba(0, 0, 0, 0.65);
+}
+
+#overview .search-entry:hover .search-entry-icon, #overview .search-entry:focus .search-entry-icon {
+  color: rgba(0, 0, 0, 0.75);
+}
+
+#overview .search-entry StLabel.hint-text {
+  color: rgba(0, 0, 0, 0.35);
+}
+
+/* Search */
+#searchResults {
+  margin: 0 8px;
+}
+
+#searchResultsContent {
+  max-width: 1044px;
+}
+
+.search-section {
+  spacing: 12px;
+}
+
+.search-section .search-section-separator {
+  height: 8px;
+  background-color: transparent;
+}
+
+.search-section-content {
+  background-color: rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.1);
+  text-shadow: none;
+  color: rgba(255, 255, 255, 0.85);
+  padding: 18px;
+  spacing: 8px;
+}
+
+.list-search-result, .search-provider-icon {
+  border-radius: 6px;
+}
+
+.search-statustext {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.grid-search-results {
+  spacing: 36px;
+  margin: 0 12px;
+}
+
+.search-provider-icon:ltr {
+  margin-right: 4px;
+}
+
+.search-provider-icon:rtl {
+  margin-left: 4px;
+}
+
+.search-provider-icon .list-search-provider-content {
+  spacing: 12px;
+}
+
+.search-provider-icon .list-search-provider-content .list-search-provider-details {
+  width: 120px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.list-search-results {
+  spacing: 6px;
+}
+
+.list-search-result .list-search-result-content {
+  spacing: 6px;
+}
+
+.list-search-result .list-search-result-title {
+  spacing: 12px;
+}
+
+.list-search-result .list-search-result-description {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+/* Dash */
+#dash {
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+#dash .dash-background {
+  background-color: rgba(255, 255, 255, 0.2);
+  border-radius: 15px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+#dash .dash-item-container .placeholder {
+  background-image: none;
+  background-size: contain;
+  height: 32px;
+}
+
+#dash .dash-item-container .empty-dash-drop-target {
+  width: 32px;
+  height: 32px;
+}
+
+#dash .dash-item-container .show-apps,
+#dash .dash-item-container .overview-tile,
+#dash .dash-item-container .grid-search-result,
+#dash .dash-item-container .search-provider-icon,
+#dash .dash-item-container .list-search-result {
+  margin: 0 2px;
+  padding-bottom: 12px;
+}
+
+#dash .dash-item-container .show-apps .overview-icon,
+#dash .dash-item-container .overview-tile .overview-icon,
+#dash .dash-item-container .grid-search-result .overview-icon,
+#dash .dash-item-container .search-provider-icon .overview-icon,
+#dash .dash-item-container .list-search-result .overview-icon {
+  background-color: transparent;
+}
+
+#dash .dash-item-container .show-apps:focus .overview-icon,
+#dash .dash-item-container .overview-tile:focus .overview-icon,
+#dash .dash-item-container .grid-search-result:focus .overview-icon,
+#dash .dash-item-container .search-provider-icon:focus .overview-icon,
+#dash .dash-item-container .list-search-result:focus .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#dash .dash-item-container .show-apps:hover .overview-icon,
+#dash .dash-item-container .overview-tile:hover .overview-icon,
+#dash .dash-item-container .grid-search-result:hover .overview-icon,
+#dash .dash-item-container .search-provider-icon:hover .overview-icon,
+#dash .dash-item-container .list-search-result:hover .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#dash .dash-item-container .show-apps:active .overview-icon,
+#dash .dash-item-container .overview-tile:active .overview-icon,
+#dash .dash-item-container .grid-search-result:active .overview-icon,
+#dash .dash-item-container .search-provider-icon:active .overview-icon,
+#dash .dash-item-container .list-search-result:active .overview-icon {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+#dash .dash-item-container .show-apps:checked .overview-icon,
+#dash .dash-item-container .overview-tile:checked .overview-icon,
+#dash .dash-item-container .grid-search-result:checked .overview-icon,
+#dash .dash-item-container .search-provider-icon:checked .overview-icon,
+#dash .dash-item-container .list-search-result:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+#dash .dash-item-container .show-apps:insensitive .overview-icon,
+#dash .dash-item-container .overview-tile:insensitive .overview-icon,
+#dash .dash-item-container .grid-search-result:insensitive .overview-icon,
+#dash .dash-item-container .search-provider-icon:insensitive .overview-icon,
+#dash .dash-item-container .list-search-result:insensitive .overview-icon {
+  background-color: transparent;
+}
+
+#dash .dash-item-container .app-grid-running-dot {
+  offset-y: -12px;
+}
+
+#dash .dash-separator {
+  width: 1px;
+  margin-left: 4px;
+  margin-right: 4px;
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+#dash .dash-separator,
+#dash .dash-background {
+  margin-bottom: 12px;
+}
+
+.dash-label {
+  border-radius: 3px;
+  padding: 6px 12px;
+  margin: 6px;
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(0, 0, 0, 0.75);
+  border: none;
+  box-shadow: none;
+  text-align: center;
+  -y-offset: 4px;
+}
+
+/* App Grid */
+.icon-grid {
+  row-spacing: 12px;
+  column-spacing: 12px;
+  max-row-spacing: 36px;
+  max-column-spacing: 36px;
+  page-padding-top: 24px;
+  page-padding-bottom: 24px;
+  page-padding-left: 18px;
+  page-padding-right: 18px;
+}
+
+/* App Icons */
+.overview-tile, .grid-search-result, .search-provider-icon, .list-search-result {
+  border-radius: 9px;
+  padding: 12px;
+  spacing: 6px;
+  transition-duration: 150ms;
+  text-align: center;
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.85);
+  border: 1px solid transparent;
+  box-shadow: inset 0 1px transparent;
+}
+
+.overview-tile:hover, .grid-search-result:hover, .search-provider-icon:hover, .list-search-result:hover, .overview-tile:focus, .grid-search-result:focus, .search-provider-icon:focus, .list-search-result:focus, .overview-tile:highlighted, .grid-search-result:highlighted, .search-provider-icon:highlighted, .list-search-result:highlighted, .overview-tile:selected, .grid-search-result:selected, .search-provider-icon:selected, .list-search-result:selected {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+  transition-duration: 0ms;
+  border-image: none;
+  background-image: none;
+}
+
+.overview-tile:active, .grid-search-result:active, .search-provider-icon:active, .list-search-result:active, .overview-tile:checked, .grid-search-result:checked, .search-provider-icon:checked, .list-search-result:checked {
+  background-color: rgba(255, 255, 255, 0.15);
+  transition-duration: 150ms;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.overview-tile .overview-icon.overview-icon-with-label > StBoxLayout, .grid-search-result .overview-icon.overview-icon-with-label > StBoxLayout, .search-provider-icon .overview-icon.overview-icon-with-label > StBoxLayout, .list-search-result .overview-icon.overview-icon-with-label > StBoxLayout {
+  spacing: 6px;
+}
+
+.app-folder {
+  background-color: rgba(255, 255, 255, 0.13);
+}
+
+.app-folder:focus {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.app-folder:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.app-folder:active {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.app-folder:highlighted, .app-folder:selected, .app-folder:checked {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.app-folder:insensitive {
+  background-color: transparent;
+}
+
+.app-grid-running-dot {
+  width: 6px;
+  height: 3px;
+  border-radius: 2px;
+  background-color: rgba(255, 255, 255, 0.5);
+  margin-bottom: 1px;
+}
+
+StWidget.focused .app-grid-running-dot {
+  width: 18px;
+  background-color: #1A73E8;
+}
+
+.app-folder-dialog-container {
+  padding-top: 34px;
+}
+
+.app-folder-dialog {
+  width: 720px;
+  height: 720px;
+  border-radius: 12px;
+  background-color: rgba(34, 34, 34, 0.95);
+  color: white;
+  border: none;
+  box-shadow: none;
+}
+
+.app-folder-dialog .folder-name-container {
+  padding: 24px 36px 0;
+  spacing: 12px;
+  /* FIXME: this is to keep the label in sync with the entry */
+}
+
+.app-folder-dialog .folder-name-container .folder-name-label, .app-folder-dialog .folder-name-container .folder-name-entry {
+  font-size: 18pt;
+  font-weight: 800;
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry {
+  border: none;
+  color: #FFFFFF;
+  background-color: rgba(255, 255, 255, 0.15);
+  caret-color: #FFFFFF;
+  selection-background-color: #1A73E8;
+  selected-color: #FFFFFF;
+  width: 300px;
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:focus {
+  color: #FFFFFF;
+  background-color: rgba(255, 255, 255, 0.25);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry .search-entry-icon {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:hover .search-entry-icon, .app-folder-dialog .folder-name-container .folder-name-entry:focus .search-entry-icon {
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-entry:insensitive, .app-folder-dialog .folder-name-container .folder-name-entry StLabel.hint-text {
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.app-folder-dialog .folder-name-container .folder-name-label {
+  padding: 5px 7px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.app-folder-dialog .folder-name-container .icon-button, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button {
+  background-color: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.7);
+  border: none;
+  padding: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 18px;
+}
+
+.app-folder-dialog .folder-name-container .icon-button > StIcon, .app-folder-dialog .folder-name-container .background-app-item .icon-button > StIcon, .app-folder-dialog .folder-name-container .message-notification-group .background-app-item .message-collapse-button > StIcon, .app-folder-dialog .folder-name-container .message .message-header .background-app-item .message-expand-button > StIcon,
+.app-folder-dialog .folder-name-container .message .message-header .background-app-item .message-close-button > StIcon, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button > StIcon, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button > StIcon, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button > StIcon, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button > StIcon,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button > StIcon,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button > StIcon {
+  icon-size: 16px;
+}
+
+.app-folder-dialog .folder-name-container .icon-button:hover, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button:hover, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button:hover, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:hover, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:hover,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:hover,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.app-folder-dialog .folder-name-container .icon-button:focus, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button:focus, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button:focus, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:focus, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:focus,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:focus,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:focus {
+  border: none !important;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.app-folder-dialog .folder-name-container .icon-button:checked, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button:checked, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button:checked, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:checked, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:checked,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:checked,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:checked, .app-folder-dialog .folder-name-container .icon-button:active, .app-folder-dialog .folder-name-container .message-notification-group .message-collapse-button:active, .message-notification-group .app-folder-dialog .folder-name-container .message-collapse-button:active, .app-folder-dialog .folder-name-container .message .message-header .message-expand-button:active, .message .message-header .app-folder-dialog .folder-name-container .message-expand-button:active,
+.app-folder-dialog .folder-name-container .message .message-header .message-close-button:active,
+.message .message-header .app-folder-dialog .folder-name-container .message-close-button:active {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.app-folder-dialog .icon-grid {
+  row-spacing: 12px;
+  column-spacing: 30px;
+  page-padding-top: 0;
+  page-padding-bottom: 0;
+  page-padding-left: 0;
+  page-padding-right: 0;
+}
+
+.app-folder-dialog .page-indicators {
+  margin-bottom: 18px;
+}
+
+.rename-folder-popup .rename-folder-popup-item {
+  spacing: 6px;
+}
+
+.rename-folder-popup .rename-folder-popup-item:ltr, .rename-folder-popup .rename-folder-popup-item:rtl {
+  padding: 0 12px;
+}
+
+.app-menu,
+.app-well-menu {
+  max-width: 27.25em;
+}
+
+.page-indicator {
+  padding: 6px 12px 0;
+}
+
+.page-indicator .page-indicator-icon {
+  width: 10px;
+  height: 10px;
+  border-radius: 10px;
+  background-color: white;
+  transition-duration: 400ms;
+}
+
+.apps-scroll-view {
+  padding: 0;
+}
+
+.system-action-icon {
+  background-color: rgba(0, 0, 0, 0.8);
+  color: white;
+  border-radius: 9999px;
+  icon-size: 8px;
+}
+
+.page-navigation-hint.dnd {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.page-navigation-hint.next:ltr, .page-navigation-hint.previous:rtl {
+  background-gradient-start: rgba(255, 255, 255, 0.05);
+  background-gradient-end: transparent;
+  background-gradient-direction: horizontal;
+  border-radius: 15px 0px 0px 15px;
+}
+
+.page-navigation-hint.previous:ltr, .page-navigation-hint.next:rtl {
+  background-gradient-start: transparent;
+  background-gradient-end: rgba(255, 255, 255, 0.05);
+  background-gradient-direction: horizontal;
+  border-radius: 0px 15px 15px 0px;
+}
+
+.page-navigation-arrow {
+  margin: 6px;
+  padding: 18px;
+  width: 24px;
+  height: 24px;
+  border-radius: 9999px;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+}
+
+.page-navigation-arrow > StIcon {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.page-navigation-arrow:insensitive {
+  background-color: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.page-navigation-arrow:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+  color: white;
+}
+
+.page-navigation-arrow:active {
+  background-color: rgba(255, 255, 255, 0.2);
+  color: white;
+}
+
+/* Workspace pager */
+.workspace-thumbnails .workspace-thumbnail {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.13);
+  border: none;
+}
+
+.workspace-thumbnails {
+  visible-width: 32px;
+  spacing: 6px;
+  padding: 6px;
+}
+
+.workspace-thumbnails .workspace-thumbnail {
+  border-radius: 3px;
+}
+
+.workspace-thumbnails .placeholder {
+  background-image: url("resource:///org/gnome/shell/theme/dash-placeholder.svg");
+  background-size: contain;
+  width: 18px;
+}
+
+.workspace-thumbnail-indicator {
+  border: 3px solid #1A73E8;
+  border-radius: 6px;
+  padding: 0px;
+}
+
+.ripple-pointer-location {
+  width: 48px;
+  height: 48px;
+  border-radius: 24px;
+  background-color: rgba(165, 200, 246, 0.3);
+  box-shadow: 0 0 2px 2px #77acf1;
+}
+
+.pie-timer {
+  width: 60px;
+  height: 60px;
+  -pie-border-width: 3px;
+  -pie-border-color: #1A73E8;
+  -pie-background-color: rgba(211, 228, 251, 0.3);
+}
+
+.magnifier-zoom-region {
+  border: 2px solid #1A73E8;
+}
+
+.magnifier-zoom-region.full-screen {
+  border-width: 0;
+}
+
+.select-area-rubberband {
+  background-color: rgba(26, 115, 232, 0.3);
+  border: 1px solid #1A73E8;
+}
+
+.user-icon {
+  background-size: contain;
+  color: rgba(255, 255, 255, 0.7);
+  border-radius: 9999px;
+  icon-size: 64px;
+}
+
+.user-icon:hover {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.user-icon StIcon {
+  background-color: rgba(255, 255, 255, 0.05);
+  border-radius: 99px;
+  padding: 12px;
+  width: 40px;
+  height: 40px;
+}
+
+.user-icon.user-avatar {
+  border: 2px rgba(255, 255, 255, 0.7);
+}
+
+.user-widget.vertical .user-icon {
+  icon-size: 128px;
+}
+
+.user-widget.vertical .user-icon StIcon {
+  padding: 20px;
+  padding-top: 18px;
+  padding-bottom: 22px;
+  width: 88px;
+  height: 88px;
+}
+
+.lightbox {
+  background-color: black;
+}
+
+.flashspot {
+  background-color: white;
+}
+
+.hidden {
+  color: rgba(0, 0, 0, 0);
+}
+
+.caps-lock-warning-label {
+  text-align: center;
+  padding-bottom: 8px;
+  font-size: 10.5pt;
+  font-weight: 400;
+  color: #FF6D00;
+}
+
+/* Workspace animation */
+.workspace-animation {
+  background-color: #222222;
+}
+
+/* Tiled window previews */
+.tile-preview {
+  background-color: rgba(22, 108, 221, 0.3);
+  border: 1px solid #166cdd;
+}
+
+.tile-preview-left.on-primary {
+  border-radius: 4px 0 0 0;
+}
+
+.tile-preview-right.on-primary {
+  border-radius: 0 4px 0 0;
+}
+
+.tile-preview-left.tile-preview-right.on-primary {
+  border-radius: 4px 4px 0 0;
+}
+
+/* On-screen Keyboard */
+#keyboard {
+  background-color: rgba(238, 238, 238, 0.95);
+  border: none;
+  border-top-width: 0;
+  box-shadow: none;
+}
+
+#keyboard .page-indicator {
+  padding: 6px;
+}
+
+#keyboard .page-indicator .page-indicator-icon {
+  width: 8px;
+  height: 8px;
+}
+
+.key-container {
+  padding: 4px;
+  spacing: 4px;
+}
+
+.keyboard-key {
+  min-height: 2em;
+  min-width: 2em;
+  font-size: 14pt;
+  font-weight: bold;
+  border-radius: 3px;
+  border: none;
+  color: inherit;
+  background-color: #FAFAFA;
+  box-shadow: inset 0 -1px rgba(0, 0, 0, 0.25);
+}
+
+.keyboard-key:focus, .keyboard-key:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #e1e1e1;
+}
+
+.keyboard-key:checked, .keyboard-key:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: #c7c7c7;
+}
+
+.keyboard-key:grayed {
+  background-color: rgba(32, 32, 32, 0.75);
+  color: rgba(255, 255, 255, 0.85);
+  border-color: rgba(32, 32, 32, 0.75);
+}
+
+.keyboard-key.default-key {
+  background-color: #c7c7c7;
+}
+
+.keyboard-key.default-key:focus, .keyboard-key.default-key:hover {
+  color: rgba(0, 0, 0, 0.62);
+  background-color: #b7b7b7;
+}
+
+.keyboard-key.default-key:checked, .keyboard-key.default-key:active {
+  color: rgba(0, 0, 0, 0.62);
+  background-color: #adadad;
+}
+
+.keyboard-key.enter-key {
+  background-color: #1A73E8;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.keyboard-key.enter-key:focus, .keyboard-key.enter-key:hover {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #3181ea;
+}
+
+.keyboard-key.enter-key:checked, .keyboard-key.enter-key:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #135cbc;
+}
+
+.keyboard-key.shift-key-uppercase {
+  color: #1A73E8;
+}
+
+.keyboard-key StIcon {
+  icon-size: 1.125em;
+}
+
+.keyboard-subkeys {
+  color: inherit;
+  -arrow-border-radius: 3px;
+  -arrow-background-color: rgba(0, 0, 0, 0.45);
+  -arrow-border-width: 0;
+  -arrow-border-color: transparent;
+  -arrow-base: 20px;
+  -arrow-rise: 10px;
+  -boxpointer-gap: 5px;
+}
+
+.emoji-page .keyboard-key {
+  background-color: transparent;
+  border: none;
+  color: initial;
+}
+
+.emoji-panel .keyboard-key:latched {
+  border-color: #3181ea;
+  background-color: #1A73E8;
+}
+
+.word-suggestions {
+  font-size: 14pt;
+  spacing: 12px;
+  min-height: 20pt;
+}
+
+/* Looking Glass */
+#LookingGlassDialog {
+  color: rgba(0, 0, 0, 0.54);
+  background-color: #ffffff;
+  spacing: 4px;
+  padding: 6px;
+  border: none;
+  border-radius: 3px;
+  box-shadow: 0 14px 14px rgba(0, 0, 0, 0.5);
+}
+
+#LookingGlassDialog > #Toolbar {
+  padding: 0 8px;
+  border: none;
+  border-radius: 0;
+  background-color: rgba(255, 255, 255, 0.01);
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.12);
+  color: rgba(0, 0, 0, 0.54);
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button {
+  color: rgba(0, 0, 0, 0.54);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+  box-shadow: none;
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+#LookingGlassDialog > #Toolbar .lg-toolbar-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: none;
+}
+
+#LookingGlassDialog .labels {
+  spacing: 0;
+}
+
+#LookingGlassDialog .notebook-tab {
+  -natural-hpadding: 12px;
+  -minimum-hpadding: 6px;
+  font-weight: bold;
+  color: rgba(0, 0, 0, 0.38);
+  transition-duration: 150ms;
+  padding-left: 16px;
+  padding-right: 16px;
+  min-height: 36px;
+  padding: 0 32px;
+  border-radius: 0;
+}
+
+#LookingGlassDialog .notebook-tab:hover {
+  box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.2);
+  color: rgba(0, 0, 0, 0.87);
+  text-shadow: none;
+}
+
+#LookingGlassDialog .notebook-tab:selected {
+  background-color: rgba(255, 255, 255, 0.01);
+  box-shadow: inset 0 -2px 0 #1A73E8;
+  color: rgba(0, 0, 0, 0.87);
+  text-shadow: none;
+}
+
+#LookingGlassDialog StBoxLayout#EvalBox {
+  padding: 4px;
+  spacing: 4px;
+}
+
+#LookingGlassDialog StBoxLayout#ResultsArea {
+  spacing: 4px;
+}
+
+.lg-dialog StEntry {
+  selection-background-color: #1A73E8;
+  selected-color: rgba(255, 255, 255, 0.85) !important;
+}
+
+.lg-dialog .shell-link {
+  color: #1A73E8;
+}
+
+.lg-dialog .shell-link:hover {
+  color: #1A73E8;
+}
+
+.lg-completions-text {
+  font-size: 1em;
+  font-style: italic;
+}
+
+.lg-obj-inspector-title {
+  spacing: 4px;
+}
+
+.lg-obj-inspector-button {
+  min-height: 36px;
+  padding: 0 16px;
+  border: none;
+  border-radius: 3px;
+  font-size: 10.5pt;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.54);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.lg-obj-inspector-button:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+  box-shadow: none;
+}
+
+.lg-obj-inspector-button:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+.lg-obj-inspector-button:insensitive {
+  color: rgba(0, 0, 0, 0.26);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.lg-obj-inspector-button:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: none;
+}
+
+.lg-obj-inspector-button:hover {
+  border: none;
+}
+
+#lookingGlassExtensions {
+  padding: 4px;
+}
+
+.lg-extensions-list {
+  padding: 4px;
+  spacing: 6px;
+}
+
+.lg-extension {
+  border: none;
+  border-radius: 3px;
+  background-color: #bfbfbf;
+  padding: 4px;
+}
+
+.lg-extension-name {
+  font-size: 18pt;
+  font-weight: 400;
+}
+
+.lg-extension-meta {
+  spacing: 6px;
+}
+
+#LookingGlassPropertyInspector {
+  background: #ffffff;
+  border: none;
+  border-radius: 3px;
+  padding: 6px;
+  box-shadow: 0 14px 14px rgba(0, 0, 0, 0.5);
+}
+
+.quick-settings {
+  border-radius: 3px !important;
+  margin: 6px !important;
+  padding: 10px 12px 14px !important;
+}
+
+.quick-settings .icon-button, .quick-settings .message-notification-group .message-collapse-button, .message-notification-group .quick-settings .message-collapse-button, .quick-settings .message .message-header .message-expand-button, .message .message-header .quick-settings .message-expand-button,
+.quick-settings .message .message-header .message-close-button,
+.message .message-header .quick-settings .message-close-button, .quick-settings .button {
+  padding: 9px;
+}
+
+.quick-settings .icon-button > StIcon, .quick-settings .background-app-item .icon-button > StIcon, .quick-settings .message-notification-group .background-app-item .message-collapse-button > StIcon, .quick-settings .message .message-header .background-app-item .message-expand-button > StIcon,
+.quick-settings .message .message-header .background-app-item .message-close-button > StIcon, .quick-settings .message-notification-group .message-collapse-button > StIcon, .message-notification-group .quick-settings .message-collapse-button > StIcon, .quick-settings .message .message-header .message-expand-button > StIcon, .message .message-header .quick-settings .message-expand-button > StIcon,
+.quick-settings .message .message-header .message-close-button > StIcon,
+.message .message-header .quick-settings .message-close-button > StIcon, .quick-settings .button > StIcon {
+  icon-size: 16px;
+}
+
+.quick-settings-grid {
+  spacing-rows: 12px;
+  spacing-columns: 12px;
+}
+
+.quick-toggle, .quick-menu-toggle {
+  border-radius: 3px;
+  min-width: 12em;
+  max-width: 12em;
+  min-height: 44px;
+  padding: 0;
+  border: none;
+}
+
+.quick-toggle {
+  background-color: rgba(0, 0, 0, 0.06) !important;
+  /* Move padding into the box; this is to allow menu arrows
+       to extend to the border */
+}
+
+.quick-toggle:hover {
+  background-color: rgba(0, 0, 0, 0.12) !important;
+}
+
+.quick-toggle:active {
+  background-color: rgba(0, 0, 0, 0.15) !important;
+}
+
+.quick-toggle:checked {
+  background-color: #1A73E8 !important;
+  color: white;
+}
+
+.quick-toggle:checked:hover {
+  background-color: rgba(25, 110, 221, 0.9922) !important;
+  color: white;
+}
+
+.quick-toggle:checked:active {
+  background-color: rgba(23, 101, 204, 0.9805) !important;
+  color: white;
+}
+
+.quick-toggle > StBoxLayout {
+  spacing: 9px;
+}
+
+.quick-toggle.button {
+  padding: 0;
+}
+
+.quick-toggle > StBoxLayout {
+  padding: 0 12px;
+}
+
+.quick-toggle:ltr > StBoxLayout {
+  padding-left: 24px;
+}
+
+.quick-toggle:rtl > StBoxLayout {
+  padding-right: 24px;
+}
+
+.quick-toggle .quick-toggle-title {
+  font-weight: bold;
+}
+
+.quick-toggle StBoxLayout > .quick-toggle-subtitle {
+  font-weight: normal;
+  font-size: 12px;
+}
+
+.quick-toggle .quick-toggle-icon {
+  icon-size: 16px;
+}
+
+.quick-toggle-has-menu .quick-toggle {
+  min-width: auto;
+  max-width: auto;
+}
+
+.quick-toggle-has-menu .quick-toggle:ltr {
+  border-radius: 3px 0 0 3px;
+}
+
+.quick-toggle-has-menu .quick-toggle:ltr > StBoxLayout {
+  padding-right: 12px;
+}
+
+.quick-toggle-has-menu .quick-toggle:rtl {
+  border-radius: 0 3px 3px 0;
+}
+
+.quick-toggle-has-menu .quick-toggle:rtr > StBoxLayout {
+  padding-left: 12px;
+}
+
+.quick-toggle-has-menu .quick-toggle:ltr:last-child {
+  border-radius: 3px;
+}
+
+.quick-toggle-has-menu .quick-toggle:rtl:last-child {
+  border-radius: 3px;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button {
+  padding: 6px 12px;
+  border: none;
+  background-color: rgba(0, 0, 0, 0.06) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:hover {
+  background-color: rgba(0, 0, 0, 0.12) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:active {
+  background-color: rgba(0, 0, 0, 0.15) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:checked {
+  background-color: #1A73E8 !important;
+  color: white;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:checked:hover {
+  color: white;
+  background-color: st-mix(rgba(0, 0, 0, 0.87), #1A73E8, 6%) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:checked:active {
+  color: white;
+  background-color: st-mix(rgba(0, 0, 0, 0.87), #1A73E8, 15%) !important;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:ltr {
+  border-radius: 0 3px 3px 0;
+  border-left-width: 0;
+}
+
+.quick-toggle-has-menu .quick-toggle-menu-button:rtl {
+  border-radius: 3px 0 0 3px;
+  border-right-width: 0;
+}
+
+.quick-toggle-has-menu .quick-toggle-separator {
+  width: 0;
+}
+
+.quick-slider > StBoxLayout {
+  spacing: 6px;
+}
+
+.quick-slider .slider-bin {
+  min-height: 16px;
+  padding: 6px;
+  border-radius: 9999px;
+}
+
+.quick-slider .slider-bin:focus {
+  color: #1A73E8;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.quick-slider .slider-bin:focus:hover, .quick-slider .slider-bin:focus:active {
+  color: #1A73E8;
+}
+
+.quick-slider .quick-toggle-icon {
+  icon-size: 16px;
+}
+
+.quick-slider .icon-button, .quick-slider .message-notification-group .message-collapse-button, .message-notification-group .quick-slider .message-collapse-button, .quick-slider .message .message-header .message-expand-button, .message .message-header .quick-slider .message-expand-button,
+.quick-slider .message .message-header .message-close-button,
+.message .message-header .quick-slider .message-close-button {
+  min-width: 22px;
+  min-height: 22px;
+  background-color: transparent;
+  color: rgba(0, 0, 0, 0.87) !important;
+}
+
+.quick-slider .icon-button:hover, .quick-slider .message-notification-group .message-collapse-button:hover, .message-notification-group .quick-slider .message-collapse-button:hover, .quick-slider .message .message-header .message-expand-button:hover, .message .message-header .quick-slider .message-expand-button:hover,
+.quick-slider .message .message-header .message-close-button:hover,
+.message .message-header .quick-slider .message-close-button:hover {
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.quick-slider .icon-button:active, .quick-slider .message-notification-group .message-collapse-button:active, .message-notification-group .quick-slider .message-collapse-button:active, .quick-slider .message .message-header .message-expand-button:active, .message .message-header .quick-slider .message-expand-button:active,
+.quick-slider .message .message-header .message-close-button:active,
+.message .message-header .quick-slider .message-close-button:active {
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+.quick-toggle-menu {
+  background-color: white !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+  border-radius: 3px !important;
+  padding: 18px;
+  margin: 12px 36px 0;
+  border: none !important;
+}
+
+.quick-toggle-menu .popup-menu-item {
+  border-radius: 3px !important;
+  min-height: 20px;
+}
+
+.quick-toggle-menu .popup-menu-item:focus, .quick-toggle-menu .popup-menu-item:hover, .quick-toggle-menu .popup-menu-item.selected {
+  color: rgba(0, 0, 0, 0.87) !important;
+  background-color: rgba(0, 0, 0, 0.1) !important;
+}
+
+.quick-toggle-menu .popup-menu-item:active {
+  color: rgba(0, 0, 0, 0.87) !important;
+  background-color: rgba(0, 0, 0, 0.2) !important;
+}
+
+.quick-toggle-menu .popup-menu-item > StIcon {
+  -st-icon-style: symbolic;
+}
+
+.quick-toggle-menu .header {
+  spacing-rows: 3px;
+  spacing-columns: 12px;
+  padding-bottom: 12px;
+}
+
+.quick-toggle-menu .header .icon {
+  icon-size: 24px;
+  border-radius: 3px;
+  padding: 9px;
+  background-color: rgba(0, 0, 0, 0.06) !important;
+}
+
+.quick-toggle-menu .header .icon.active {
+  background-color: #1A73E8 !important;
+  color: white;
+}
+
+.quick-settings-system-item > StBoxLayout {
+  spacing: 12px;
+}
+
+.quick-settings-system-item .icon-button, .quick-settings-system-item .message-notification-group .message-collapse-button, .message-notification-group .quick-settings-system-item .message-collapse-button, .quick-settings-system-item .message .message-header .message-expand-button, .message .message-header .quick-settings-system-item .message-expand-button,
+.quick-settings-system-item .message .message-header .message-close-button,
+.message .message-header .quick-settings-system-item .message-close-button {
+  background-color: rgba(0, 0, 0, 0.06);
+  color: rgba(0, 0, 0, 0.87);
+  border-radius: 3px;
+  min-height: 22px;
+  min-width: 22px !important;
+}
+
+.quick-settings-system-item .icon-button:hover, .quick-settings-system-item .message-notification-group .message-collapse-button:hover, .message-notification-group .quick-settings-system-item .message-collapse-button:hover, .quick-settings-system-item .message .message-header .message-expand-button:hover, .message .message-header .quick-settings-system-item .message-expand-button:hover,
+.quick-settings-system-item .message .message-header .message-close-button:hover,
+.message .message-header .quick-settings-system-item .message-close-button:hover {
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+.quick-settings-system-item .icon-button:active, .quick-settings-system-item .message-notification-group .message-collapse-button:active, .message-notification-group .quick-settings-system-item .message-collapse-button:active, .quick-settings-system-item .message .message-header .message-expand-button:active, .message .message-header .quick-settings-system-item .message-expand-button:active,
+.quick-settings-system-item .message .message-header .message-close-button:active,
+.message .message-header .quick-settings-system-item .message-close-button:active {
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.quick-settings-system-item .icon-button > StIcon, .quick-settings-system-item .background-app-item .icon-button > StIcon, .quick-settings-system-item .message-notification-group .background-app-item .message-collapse-button > StIcon, .quick-settings-system-item .message .message-header .background-app-item .message-expand-button > StIcon,
+.quick-settings-system-item .message .message-header .background-app-item .message-close-button > StIcon, .quick-settings-system-item .message-notification-group .message-collapse-button > StIcon, .message-notification-group .quick-settings-system-item .message-collapse-button > StIcon, .quick-settings-system-item .message .message-header .message-expand-button > StIcon, .message .message-header .quick-settings-system-item .message-expand-button > StIcon,
+.quick-settings-system-item .message .message-header .message-close-button > StIcon,
+.message .message-header .quick-settings-system-item .message-close-button > StIcon {
+  -st-icon-style: symbolic;
+  icon-size: 16px;
+}
+
+.quick-settings-system-item .power-item {
+  min-height: 0;
+  min-width: 0;
+}
+
+.quick-settings-system-item .power-item:insensitive {
+  color: rgba(0, 0, 0, 0.62);
+  background-color: #ffffff;
+  border-color: #d9d9d9;
+  box-shadow: none;
+  background-color: transparent;
+}
+
+.nm-network-item .wireless-secure-icon {
+  icon-size: 8px;
+}
+
+.bt-device-item .popup-menu-icon {
+  -st-icon-style: symbolic;
+}
+
+.bt-menu-placeholder.popup-menu-item {
+  text-align: center;
+  padding: 2em 4em;
+}
+
+.device-subtitle {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.keyboard-brightness-level {
+  spacing: 6px;
+}
+
+.background-apps-quick-toggle {
+  min-height: 40px;
+  background-color: transparent;
+}
+
+.background-apps-quick-toggle StIcon {
+  icon-size: 16px !important;
+}
+
+.background-app-item .popup-menu-icon {
+  icon-size: 24px !important;
+  -st-icon-style: regular !important;
+}
+
+.background-app-item .icon-button, .background-app-item .message-notification-group .message-collapse-button, .message-notification-group .background-app-item .message-collapse-button, .background-app-item .message .message-header .message-expand-button, .message .message-header .background-app-item .message-expand-button,
+.background-app-item .message .message-header .message-close-button,
+.message .message-header .background-app-item .message-close-button {
+  padding: 6px;
+}
+
+.background-app-item .spinner {
+  padding: 6px;
+}
+
+.background-app-item.popup-inactive-menu-item {
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.icon-label-button-container {
+  spacing: 6px;
+  font-size: 9pt;
+  font-weight: 400;
+}
+
+.icon-label-button-container StIcon {
+  icon-size: 32px;
+}
+
+.screenshot-ui-panel {
+  border-radius: 27px;
+  padding: 18px;
+  padding-bottom: 12px;
+  margin-bottom: 4em;
+  spacing: 12px;
+}
+
+.screenshot-ui-close-button {
+  padding: 6px;
+}
+
+.screenshot-ui-close-button.left {
+  margin-left: 8px;
+}
+
+.screenshot-ui-close-button.right {
+  margin-right: 8px;
+}
+
+.screenshot-ui-type-button {
+  padding: 12px 18px !important;
+  border-radius: 9px;
+}
+
+.screenshot-ui-capture-button {
+  width: 36px;
+  height: 36px;
+  border-radius: 9999px;
+  border: 4px rgba(255, 255, 255, 0.85);
+  padding: 4px;
+}
+
+.screenshot-ui-capture-button .screenshot-ui-capture-button-circle {
+  background-color: rgba(255, 255, 255, 0.85);
+  transition-duration: 200ms;
+  border-radius: 9999px;
+}
+
+.screenshot-ui-capture-button .screenshot-ui-capture-button-circle:hover, .screenshot-ui-capture-button .screenshot-ui-capture-button-circle:focus {
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+.screenshot-ui-capture-button:hover .screenshot-ui-capture-button-circle, .screenshot-ui-capture-button:focus .screenshot-ui-capture-button-circle {
+  background-color: rgba(217, 217, 217, 0.85);
+}
+
+.screenshot-ui-capture-button:active .screenshot-ui-capture-button-circle {
+  background-color: rgba(128, 128, 128, 0.85);
+}
+
+.screenshot-ui-capture-button:cast .screenshot-ui-capture-button-circle {
+  background-color: #DD2C00;
+}
+
+.screenshot-ui-capture-button:cast:hover .screenshot-ui-capture-button-circle, .screenshot-ui-capture-button:cast:focus .screenshot-ui-capture-button-circle {
+  background-color: #911d00;
+}
+
+.screenshot-ui-capture-button:cast:active .screenshot-ui-capture-button-circle {
+  background-color: #440e00;
+}
+
+.screenshot-ui-shot-cast-container {
+  background-color: rgba(0, 0, 0, 0.12);
+  border-radius: 6px;
+  padding: 3px;
+  spacing: 3px;
+}
+
+.screenshot-ui-shot-cast-container:ltr {
+  margin-left: 3px;
+}
+
+.screenshot-ui-shot-cast-container:rtl {
+  margin-right: 3px;
+}
+
+.screenshot-ui-shot-cast-button {
+  padding: 6px 12px;
+  background-color: transparent;
+  border-radius: 3px;
+}
+
+.screenshot-ui-shot-cast-button:hover, .screenshot-ui-shot-cast-button:focus {
+  background-color: rgba(13, 13, 13, 0.12);
+}
+
+.screenshot-ui-shot-cast-button:active {
+  background-color: rgba(13, 13, 13, 0.2);
+}
+
+.screenshot-ui-shot-cast-button:checked {
+  background-color: white;
+  color: black;
+}
+
+.screenshot-ui-shot-cast-button StIcon {
+  icon-size: 16px;
+}
+
+.screenshot-ui-show-pointer-button {
+  border-radius: 9999px;
+  padding: 12px !important;
+}
+
+.screenshot-ui-show-pointer-button StIcon {
+  icon-size: 16px;
+}
+
+.screenshot-ui-area-indicator-shade {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.screenshot-ui-area-selector .screenshot-ui-area-indicator-shade {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.screenshot-ui-area-selector .screenshot-ui-area-indicator-selection {
+  border: 2px white;
+}
+
+.screenshot-ui-area-selector-handle {
+  border-radius: 9999px;
+  background-color: white;
+  box-shadow: 0 1px 3px 2px rgba(0, 0, 0, 0.2);
+  width: 24px;
+  height: 24px;
+}
+
+.screenshot-ui-window-selector {
+  background-color: #222222;
+}
+
+.screenshot-ui-window-selector .screenshot-ui-window-selector-window-container {
+  margin: 100px;
+}
+
+.screenshot-ui-window-selector:primary-monitor .screenshot-ui-window-selector-window-container {
+  margin-bottom: 200px;
+}
+
+.screenshot-ui-window-selector-window-border {
+  transition-duration: 200ms;
+  border-radius: 6px;
+  border: 6px transparent;
+}
+
+.screenshot-ui-window-selector-check {
+  transition-duration: 200ms;
+  color: transparent;
+  border-radius: 9999px;
+  border-width: 12px;
+  icon-size: 24px;
+}
+
+.screenshot-ui-window-selector-window:hover .screenshot-ui-window-selector-window-border {
+  border-color: #1151a5;
+}
+
+.screenshot-ui-window-selector-window:checked .screenshot-ui-window-selector-window-border {
+  border-color: #1A73E8;
+  background-color: rgba(26, 115, 232, 0.2);
+}
+
+.screenshot-ui-window-selector-window:checked .screenshot-ui-window-selector-check {
+  color: white;
+  background-color: #1A73E8;
+}
+
+.screenshot-ui-screen-selector {
+  transition-duration: 200ms;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.screenshot-ui-screen-selector:hover {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.screenshot-ui-screen-selector:active {
+  background-color: rgba(0, 0, 0, 0.7);
+}
+
+.screenshot-ui-screen-selector:checked {
+  background-color: transparent;
+  border: 2px white;
+}
+
+.screenshot-ui-tooltip {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #222222;
+  border-radius: 99px;
+  padding: 6px 12px;
+  text-align: center;
+  -y-offset: 24px;
+}
+
+/* Login Dialog */
+.login-dialog-banner-view {
+  padding-top: 24px;
+  max-width: 23em;
+}
+
+.login-dialog,
+.unlock-dialog {
+  border: none;
+  background-color: transparent;
+}
+
+.login-dialog StEntry,
+.unlock-dialog StEntry {
+  selection-background-color: #1A73E8;
+  selected-color: rgba(255, 255, 255, 0.85) !important;
+  caret-color: rgba(0, 0, 0, 0.54);
+  color: rgba(0, 0, 0, 0.54);
+  background-color: #ffffff;
+  margin: 2px 6px 6px;
+  border: 2px solid transparent !important;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 5px 8px rgba(0, 0, 0, 0.05) !important;
+}
+
+.login-dialog StEntry:focus,
+.unlock-dialog StEntry:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2), 0 5px 8px rgba(0, 0, 0, 0.08) !important;
+  border: 2px solid #1A73E8 !important;
+}
+
+.login-dialog StEntry:insensitive,
+.unlock-dialog StEntry:insensitive {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog .modal-dialog-button-box,
+.unlock-dialog .modal-dialog-button-box {
+  spacing: 3px;
+}
+
+.login-dialog .modal-dialog-button,
+.unlock-dialog .modal-dialog-button {
+  padding: 4px 18px;
+  box-shadow: none;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:hover, .login-dialog .modal-dialog-button:focus,
+.unlock-dialog .modal-dialog-button:hover,
+.unlock-dialog .modal-dialog-button:focus {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.15);
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:active,
+.unlock-dialog .modal-dialog-button:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.3);
+  box-shadow: 0 0 transparent;
+}
+
+.login-dialog .modal-dialog-button:insensitive,
+.unlock-dialog .modal-dialog-button:insensitive {
+  color: rgba(255, 255, 255, 0.3);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default,
+.unlock-dialog .modal-dialog-button:default {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #287ce9;
+  border-color: #1257b3;
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:hover, .login-dialog .modal-dialog-button:default:focus,
+.unlock-dialog .modal-dialog-button:default:hover,
+.unlock-dialog .modal-dialog-button:default:focus {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #287ce9;
+  border-color: #104c9c;
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:active,
+.unlock-dialog .modal-dialog-button:default:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #176ee1;
+  border-color: #104c9c;
+  box-shadow: none;
+}
+
+.login-dialog .modal-dialog-button:default:active:hover, .login-dialog .modal-dialog-button:default:active:focus,
+.unlock-dialog .modal-dialog-button:default:active:hover,
+.unlock-dialog .modal-dialog-button:default:active:focus {
+  background-color: #176ee1;
+}
+
+.login-dialog .modal-dialog-button:default:insensitive,
+.unlock-dialog .modal-dialog-button:default:insensitive {
+  color: rgba(255, 255, 255, 0.5);
+  background-color: rgba(255, 255, 255, 0.15);
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.login-dialog .cancel-button,
+.login-dialog .switch-user-button,
+.login-dialog .login-dialog-session-list-button,
+.unlock-dialog .cancel-button,
+.unlock-dialog .switch-user-button,
+.unlock-dialog .login-dialog-session-list-button {
+  padding: 0;
+  border-radius: 99px;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog .cancel-button:hover, .login-dialog .cancel-button:focus,
+.login-dialog .switch-user-button:hover,
+.login-dialog .switch-user-button:focus,
+.login-dialog .login-dialog-session-list-button:hover,
+.login-dialog .login-dialog-session-list-button:focus,
+.unlock-dialog .cancel-button:hover,
+.unlock-dialog .cancel-button:focus,
+.unlock-dialog .switch-user-button:hover,
+.unlock-dialog .switch-user-button:focus,
+.unlock-dialog .login-dialog-session-list-button:hover,
+.unlock-dialog .login-dialog-session-list-button:focus {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog .cancel-button:active,
+.login-dialog .switch-user-button:active,
+.login-dialog .login-dialog-session-list-button:active,
+.unlock-dialog .cancel-button:active,
+.unlock-dialog .switch-user-button:active,
+.unlock-dialog .login-dialog-session-list-button:active {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.login-dialog .cancel-button StIcon,
+.login-dialog .switch-user-button StIcon,
+.login-dialog .login-dialog-session-list-button StIcon,
+.unlock-dialog .cancel-button StIcon,
+.unlock-dialog .switch-user-button StIcon,
+.unlock-dialog .login-dialog-session-list-button StIcon {
+  icon-size: 16px;
+}
+
+.login-dialog .caps-lock-warning-label,
+.login-dialog .login-dialog-message-warning,
+.unlock-dialog .caps-lock-warning-label,
+.unlock-dialog .login-dialog-message-warning {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-logo-bin {
+  padding: 24px 0px;
+}
+
+.login-dialog-banner {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog-button-box {
+  width: 23em;
+  spacing: 5px;
+}
+
+.login-dialog-message {
+  text-align: center;
+}
+
+.login-dialog-user-selection-box {
+  padding: 100px 0px;
+}
+
+.login-dialog-not-listed-label {
+  padding-left: 2px;
+  font-size: 1em;
+  font-weight: bold;
+  color: rgba(255, 255, 255, 0.7);
+  padding-top: 1em;
+}
+
+.login-dialog-not-listed-label:hover {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-not-listed-label:focus {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.login-dialog-not-listed-button:focus .login-dialog-not-listed-label, .login-dialog-not-listed-button:hover .login-dialog-not-listed-label {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-view {
+  -st-vfade-offset: 1em;
+}
+
+.login-dialog-user-list {
+  spacing: 12px;
+  width: 23em;
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:selected {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:active {
+  background-color: rgba(255, 255, 255, 0.3);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list:expanded .login-dialog-user-list-item:logged-in {
+  border-right: 2px solid rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-item {
+  border-radius: 3px;
+  padding: 6px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-dialog-user-list-item:ltr {
+  padding-right: 1em;
+}
+
+.login-dialog-user-list-item:rtl {
+  padding-left: 1em;
+}
+
+.login-dialog-user-list-item:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-item:active {
+  background-color: rgba(255, 255, 255, 0.3);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-item .login-dialog-timed-login-indicator {
+  height: 2px;
+  margin: 6px 0 0 0;
+  background-color: rgba(255, 255, 255, 0.85);
+}
+
+.login-dialog-user-list-item:focus .login-dialog-timed-login-indicator {
+  background-color: rgba(255, 255, 255, 0.85);
+}
+
+.user-widget-label {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.user-widget.horizontal .user-widget-label {
+  font-size: 15pt;
+  font-weight: 500;
+  font-weight: bold;
+  padding-left: 15px;
+}
+
+.user-widget.horizontal .user-widget-label:ltr {
+  padding-left: 14px;
+  text-align: left;
+}
+
+.user-widget.horizontal .user-widget-label:rtl {
+  padding-right: 14px;
+  text-align: right;
+}
+
+.user-widget.vertical .user-widget-label {
+  font-size: 15pt;
+  font-weight: 500;
+  text-align: center;
+  font-weight: normal;
+  padding-top: 16px;
+}
+
+.login-dialog-prompt-layout {
+  padding-top: 24px;
+  padding-bottom: 12px;
+  spacing: 12px;
+  width: 23em;
+}
+
+.login-dialog-prompt-entry {
+  height: 1.5em;
+}
+
+.login-dialog-prompt-label {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 1em;
+  padding-top: 1em;
+}
+
+/* Screen Shield */
+.unlock-dialog-clock {
+  color: white;
+  font-weight: 300;
+  text-align: center;
+  spacing: 24px;
+  padding-bottom: 2.5em;
+}
+
+.unlock-dialog-clock-time {
+  font-size: 64pt;
+  padding-top: 42px;
+  font-feature-settings: "tnum";
+}
+
+.unlock-dialog-clock-date {
+  font-size: 16pt;
+  font-weight: normal;
+}
+
+.unlock-dialog-clock-hint {
+  font-weight: normal;
+  padding-top: 48px;
+}
+
+.unlock-dialog-notifications-container {
+  margin: 12px 0;
+  spacing: 6px;
+  width: 23em;
+  background-color: transparent;
+}
+
+.unlock-dialog-notifications-container .summary-notification-stack-scrollview {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.unlock-dialog-notifications-container .notification,
+.unlock-dialog-notifications-container .unlock-dialog-notification-source {
+  padding: 12px 6px;
+  border: none;
+  background-color: rgba(32, 32, 32, 0.9);
+  color: rgba(255, 255, 255, 0.85);
+  border-radius: 3px;
+}
+
+.unlock-dialog-notifications-container .notification.critical,
+.unlock-dialog-notifications-container .unlock-dialog-notification-source.critical {
+  background-color: rgba(34, 34, 34, 0.9);
+}
+
+.unlock-dialog-notification-label {
+  padding: 0px 0px 0px 12px;
+}
+
+.unlock-dialog-notification-count-text {
+  weight: bold;
+  padding: 0 6px;
+  color: rgba(32, 32, 32, 0.9);
+  background-color: rgba(255, 255, 255, 0.7);
+  border-radius: 99px;
+  margin-right: 12px;
+}
+
+.screen-shield-background {
+  background: black;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.6);
+}
+
+#lockDialogGroup {
+  background-color: #222222;
+}
+
+#unlockDialogNotifications StButton#vhandle, #unlockDialogNotifications StButton#hhandle {
+  background-color: rgba(32, 32, 32, 0.2);
+}
+
+#unlockDialogNotifications StButton#vhandle:hover, #unlockDialogNotifications StButton#vhandle:focus, #unlockDialogNotifications StButton#hhandle:hover, #unlockDialogNotifications StButton#hhandle:focus {
+  background-color: rgba(32, 32, 32, 0.4);
+}
+
+#unlockDialogNotifications StButton#vhandle:active, #unlockDialogNotifications StButton#hhandle:active {
+  background-color: rgba(26, 115, 232, 0.5);
+}
+
+.bottom #dashtodockDashScrollview,
+.top #dashtodockDashScrollview {
+  -st-hfade-offset: 24px;
+}
+
+.left #dashtodockDashScrollview,
+.right #dashtodockDashScrollview {
+  -st-vfade-offset: 24px;
+}
+
+#dashtodockContainer {
+  background-color: transparent;
+  box-shadow: none;
+}
+
+#dashtodockContainer .number-overlay {
+  color: #FFFFFF;
+  background-color: rgba(0, 0, 0, 0.75);
+  text-align: center;
+}
+
+#dashtodockContainer .notification-badge {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: #1A73E8;
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.25);
+  border-radius: 9999px;
+  margin: 2px 3px 5px;
+  padding: 0.2em 0.6em;
+  font-weight: bold;
+  text-align: center;
+}
+
+#dashtodockContainer.top.straight-corner #dash, #dashtodockContainer.top.shrink.straight-corner #dash, #dashtodockContainer.top.extended #dash, #dashtodockContainer.top.extended:overview #dash {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.straight-corner #dash .dash-background, #dashtodockContainer.top.shrink.straight-corner #dash .dash-background, #dashtodockContainer.top.extended #dash .dash-background, #dashtodockContainer.top.extended:overview #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.top.straight-corner #dash .show-apps,
+#dashtodockContainer.top.straight-corner #dash .overview-tile,
+#dashtodockContainer.top.straight-corner #dash .grid-search-result,
+#dashtodockContainer.top.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.top.straight-corner #dash .list-search-result, #dashtodockContainer.top.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.top.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.top.extended #dash .show-apps,
+#dashtodockContainer.top.extended #dash .overview-tile,
+#dashtodockContainer.top.extended #dash .grid-search-result,
+#dashtodockContainer.top.extended #dash .search-provider-icon,
+#dashtodockContainer.top.extended #dash .list-search-result, #dashtodockContainer.top.extended:overview #dash .show-apps,
+#dashtodockContainer.top.extended:overview #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash, #dashtodockContainer.bottom.shrink.straight-corner #dash, #dashtodockContainer.bottom.extended #dash, #dashtodockContainer.bottom.extended:overview #dash {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash .dash-background, #dashtodockContainer.bottom.shrink.straight-corner #dash .dash-background, #dashtodockContainer.bottom.extended #dash .dash-background, #dashtodockContainer.bottom.extended:overview #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.bottom.straight-corner #dash .show-apps,
+#dashtodockContainer.bottom.straight-corner #dash .overview-tile,
+#dashtodockContainer.bottom.straight-corner #dash .grid-search-result,
+#dashtodockContainer.bottom.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.bottom.straight-corner #dash .list-search-result, #dashtodockContainer.bottom.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.bottom.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.bottom.extended #dash .show-apps,
+#dashtodockContainer.bottom.extended #dash .overview-tile,
+#dashtodockContainer.bottom.extended #dash .grid-search-result,
+#dashtodockContainer.bottom.extended #dash .search-provider-icon,
+#dashtodockContainer.bottom.extended #dash .list-search-result, #dashtodockContainer.bottom.extended:overview #dash .show-apps,
+#dashtodockContainer.bottom.extended:overview #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash, #dashtodockContainer.left.shrink.straight-corner #dash, #dashtodockContainer.left.extended #dash, #dashtodockContainer.left.extended:overview #dash {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash .dash-background, #dashtodockContainer.left.shrink.straight-corner #dash .dash-background, #dashtodockContainer.left.extended #dash .dash-background, #dashtodockContainer.left.extended:overview #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.left.straight-corner #dash .show-apps,
+#dashtodockContainer.left.straight-corner #dash .overview-tile,
+#dashtodockContainer.left.straight-corner #dash .grid-search-result,
+#dashtodockContainer.left.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.left.straight-corner #dash .list-search-result, #dashtodockContainer.left.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.left.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.left.extended #dash .show-apps,
+#dashtodockContainer.left.extended #dash .overview-tile,
+#dashtodockContainer.left.extended #dash .grid-search-result,
+#dashtodockContainer.left.extended #dash .search-provider-icon,
+#dashtodockContainer.left.extended #dash .list-search-result, #dashtodockContainer.left.extended:overview #dash .show-apps,
+#dashtodockContainer.left.extended:overview #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash, #dashtodockContainer.right.shrink.straight-corner #dash, #dashtodockContainer.right.extended #dash, #dashtodockContainer.right.extended:overview #dash {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash .dash-background, #dashtodockContainer.right.shrink.straight-corner #dash .dash-background, #dashtodockContainer.right.extended #dash .dash-background, #dashtodockContainer.right.extended:overview #dash .dash-background {
+  margin: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+#dashtodockContainer.right.straight-corner #dash .show-apps,
+#dashtodockContainer.right.straight-corner #dash .overview-tile,
+#dashtodockContainer.right.straight-corner #dash .grid-search-result,
+#dashtodockContainer.right.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.right.straight-corner #dash .list-search-result, #dashtodockContainer.right.shrink.straight-corner #dash .show-apps,
+#dashtodockContainer.right.shrink.straight-corner #dash .overview-tile, #dashtodockContainer.right.extended #dash .show-apps,
+#dashtodockContainer.right.extended #dash .overview-tile,
+#dashtodockContainer.right.extended #dash .grid-search-result,
+#dashtodockContainer.right.extended #dash .search-provider-icon,
+#dashtodockContainer.right.extended #dash .list-search-result, #dashtodockContainer.right.extended:overview #dash .show-apps,
+#dashtodockContainer.right.extended:overview #dash .overview-tile {
+  margin: 0 !important;
+}
+
+#dashtodockContainer.extended #dash .dash-background, #dashtodockContainer.straight-corner #dash .dash-background {
+  border-radius: 0;
+}
+
+#dashtodockContainer.shrink #dash .dash-background {
+  padding: 0 !important;
+  border-radius: 3px;
+}
+
+#dashtodockContainer.shrink #dash .show-apps,
+#dashtodockContainer.shrink #dash .overview-tile,
+#dashtodockContainer.shrink #dash .grid-search-result,
+#dashtodockContainer.shrink #dash .search-provider-icon,
+#dashtodockContainer.shrink #dash .list-search-result {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left #dash .overview-tile, #dashtodockContainer.left #dash .grid-search-result, #dashtodockContainer.left #dash .search-provider-icon, #dashtodockContainer.left #dash .list-search-result, #dashtodockContainer.right #dash .overview-tile, #dashtodockContainer.right #dash .grid-search-result, #dashtodockContainer.right #dash .search-provider-icon, #dashtodockContainer.right #dash .list-search-result {
+  padding: 2px 6px !important;
+}
+
+#dashtodockContainer.left #dash .show-apps, #dashtodockContainer.right #dash .show-apps {
+  padding-bottom: 6px !important;
+}
+
+#dashtodockContainer.left.shrink #dash .show-apps,
+#dashtodockContainer.left.shrink #dash .overview-tile,
+#dashtodockContainer.left.shrink #dash .grid-search-result,
+#dashtodockContainer.left.shrink #dash .search-provider-icon,
+#dashtodockContainer.left.shrink #dash .list-search-result, #dashtodockContainer.right.shrink #dash .show-apps,
+#dashtodockContainer.right.shrink #dash .overview-tile,
+#dashtodockContainer.right.shrink #dash .grid-search-result,
+#dashtodockContainer.right.shrink #dash .search-provider-icon,
+#dashtodockContainer.right.shrink #dash .list-search-result {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#dashtodockContainer.left.extended #dash .show-apps,
+#dashtodockContainer.left.extended #dash .overview-tile,
+#dashtodockContainer.left.extended #dash .grid-search-result,
+#dashtodockContainer.left.extended #dash .search-provider-icon,
+#dashtodockContainer.left.extended #dash .list-search-result, #dashtodockContainer.left.straight-corner #dash .show-apps,
+#dashtodockContainer.left.straight-corner #dash .overview-tile,
+#dashtodockContainer.left.straight-corner #dash .grid-search-result,
+#dashtodockContainer.left.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.left.straight-corner #dash .list-search-result, #dashtodockContainer.right.extended #dash .show-apps,
+#dashtodockContainer.right.extended #dash .overview-tile,
+#dashtodockContainer.right.extended #dash .grid-search-result,
+#dashtodockContainer.right.extended #dash .search-provider-icon,
+#dashtodockContainer.right.extended #dash .list-search-result, #dashtodockContainer.right.straight-corner #dash .show-apps,
+#dashtodockContainer.right.straight-corner #dash .overview-tile,
+#dashtodockContainer.right.straight-corner #dash .grid-search-result,
+#dashtodockContainer.right.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.right.straight-corner #dash .list-search-result {
+  padding: 2px 12px !important;
+}
+
+#dashtodockContainer.top.shrink #dash .dash-background, #dashtodockContainer.bottom.shrink #dash .dash-background {
+  padding: 0 !important;
+}
+
+#dashtodockContainer.top.shrink #dash .show-apps,
+#dashtodockContainer.top.shrink #dash .overview-tile,
+#dashtodockContainer.top.shrink #dash .grid-search-result,
+#dashtodockContainer.top.shrink #dash .search-provider-icon,
+#dashtodockContainer.top.shrink #dash .list-search-result, #dashtodockContainer.bottom.shrink #dash .show-apps,
+#dashtodockContainer.bottom.shrink #dash .overview-tile,
+#dashtodockContainer.bottom.shrink #dash .grid-search-result,
+#dashtodockContainer.bottom.shrink #dash .search-provider-icon,
+#dashtodockContainer.bottom.shrink #dash .list-search-result {
+  margin: 0 !important;
+  padding: 0 0 18px !important;
+}
+
+#dashtodockContainer.top.extended #dash .dash-separator, #dashtodockContainer.top.straight-corner #dash .dash-separator, #dashtodockContainer.bottom.extended #dash .dash-separator, #dashtodockContainer.bottom.straight-corner #dash .dash-separator {
+  margin: 0 8px !important;
+}
+
+#dashtodockContainer.top.extended #dash .show-apps,
+#dashtodockContainer.top.extended #dash .overview-tile,
+#dashtodockContainer.top.extended #dash .grid-search-result,
+#dashtodockContainer.top.extended #dash .search-provider-icon,
+#dashtodockContainer.top.extended #dash .list-search-result, #dashtodockContainer.top.straight-corner #dash .show-apps,
+#dashtodockContainer.top.straight-corner #dash .overview-tile,
+#dashtodockContainer.top.straight-corner #dash .grid-search-result,
+#dashtodockContainer.top.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.top.straight-corner #dash .list-search-result, #dashtodockContainer.bottom.extended #dash .show-apps,
+#dashtodockContainer.bottom.extended #dash .overview-tile,
+#dashtodockContainer.bottom.extended #dash .grid-search-result,
+#dashtodockContainer.bottom.extended #dash .search-provider-icon,
+#dashtodockContainer.bottom.extended #dash .list-search-result, #dashtodockContainer.bottom.straight-corner #dash .show-apps,
+#dashtodockContainer.bottom.straight-corner #dash .overview-tile,
+#dashtodockContainer.bottom.straight-corner #dash .grid-search-result,
+#dashtodockContainer.bottom.straight-corner #dash .search-provider-icon,
+#dashtodockContainer.bottom.straight-corner #dash .list-search-result {
+  padding: 12px 2px !important;
+}
+
+#dashtodockContainer #dash {
+  background: none;
+  box-shadow: none;
+}
+
+#dashtodockContainer #dash .dash-background {
+  background-color: rgba(0, 0, 0, 0.5);
+  background-clip: padding-box;
+}
+
+#dashtodockContainer #dash .show-apps .overview-icon,
+#dashtodockContainer #dash .overview-tile .overview-icon,
+#dashtodockContainer #dash .grid-search-result .overview-icon,
+#dashtodockContainer #dash .search-provider-icon .overview-icon,
+#dashtodockContainer #dash .list-search-result .overview-icon {
+  color: rgba(255, 255, 255, 0.75) !important;
+}
+
+#dashtodockContainer #dash .show-apps:hover .overview-icon, #dashtodockContainer #dash .show-apps:focus .overview-icon, #dashtodockContainer #dash .show-apps:selected .overview-icon,
+#dashtodockContainer #dash .overview-tile:hover .overview-icon,
+#dashtodockContainer #dash .grid-search-result:hover .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:hover .overview-icon,
+#dashtodockContainer #dash .list-search-result:hover .overview-icon,
+#dashtodockContainer #dash .overview-tile:focus .overview-icon,
+#dashtodockContainer #dash .grid-search-result:focus .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:focus .overview-icon,
+#dashtodockContainer #dash .list-search-result:focus .overview-icon,
+#dashtodockContainer #dash .overview-tile:selected .overview-icon,
+#dashtodockContainer #dash .grid-search-result:selected .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:selected .overview-icon,
+#dashtodockContainer #dash .list-search-result:selected .overview-icon {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+  color: #FFFFFF !important;
+}
+
+#dashtodockContainer #dash .show-apps:active .overview-icon, #dashtodockContainer #dash .show-apps:checked .overview-icon,
+#dashtodockContainer #dash .overview-tile:active .overview-icon,
+#dashtodockContainer #dash .grid-search-result:active .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:active .overview-icon,
+#dashtodockContainer #dash .list-search-result:active .overview-icon,
+#dashtodockContainer #dash .overview-tile:checked .overview-icon,
+#dashtodockContainer #dash .grid-search-result:checked .overview-icon,
+#dashtodockContainer #dash .search-provider-icon:checked .overview-icon,
+#dashtodockContainer #dash .list-search-result:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+  color: #FFFFFF !important;
+}
+
+#dashtodockContainer .dash-separator {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#dashtodockContainer .app-grid-running-dot {
+  background-color: rgba(255, 255, 255, 0.55) !important;
+  margin: 0 0 3px !important;
+  offset-y: 0 !important;
+}
+
+#dashtodockContainer StWidget.focused .overview-icon {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+}
+
+#dashtodockContainer StWidget.focused:hover .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#dashtodockContainer StWidget.focused .app-grid-running-dot {
+  background-color: #1A73E8 !important;
+}
+
+#dashtodockContainer.opaque #dash .dash-background {
+  background-color: #202020;
+}
+
+#dashtodockContainer.transparent #dash .dash-background {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+#dashtodockContainer:overview #dash .dash-background {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+#dashtodockContainer:overview #dash .show-apps .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result .overview-icon {
+  color: rgba(255, 255, 255, 0.7) !important;
+}
+
+#dashtodockContainer:overview #dash .show-apps:hover .overview-icon, #dashtodockContainer:overview #dash .show-apps:focus .overview-icon, #dashtodockContainer:overview #dash .show-apps:selected .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:hover .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:hover .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:hover .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:hover .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:focus .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:focus .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:focus .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:focus .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:selected .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:selected .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:selected .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:selected .overview-icon {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+  color: rgba(255, 255, 255, 0.85) !important;
+}
+
+#dashtodockContainer:overview #dash .show-apps:active .overview-icon, #dashtodockContainer:overview #dash .show-apps:checked .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:active .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:active .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:active .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:active .overview-icon,
+#dashtodockContainer:overview #dash .overview-tile:checked .overview-icon,
+#dashtodockContainer:overview #dash .grid-search-result:checked .overview-icon,
+#dashtodockContainer:overview #dash .search-provider-icon:checked .overview-icon,
+#dashtodockContainer:overview #dash .list-search-result:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+  color: rgba(255, 255, 255, 0.85) !important;
+}
+
+#dashtodockContainer:overview #dash .dash-separator {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#dashtodockContainer:overview #dash .app-grid-running-dot {
+  background-color: rgba(255, 255, 255, 0.5) !important;
+}
+
+#dashtodockContainer:overview #dash StWidget.focused .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#dashtodockContainer:overview #dash StWidget.focused:hover .overview-icon {
+  background-color: rgba(255, 255, 255, 0.3) !important;
+}
+
+#dashtodockContainer:overview #dash StWidget.focused .app-grid-running-dot {
+  background-color: #1A73E8 !important;
+}
+
+#dashtodockContainer.opaque:overview #dash, #dashtodockContainer.transparent:overview #dash {
+  background-color: transparent !important;
+  box-shadow: none !important;
+}
+
+#dashtodockContainer.opaque:overview #dash .dash-background, #dashtodockContainer.transparent:overview #dash .dash-background {
+  background-color: transparent !important;
+}
+
+#dashtodockContainer.extended:overview #dash, #dashtodockContainer.opaque.extended:overview #dash, #dashtodockContainer.transparent.extended:overview #dash {
+  background: none;
+}
+
+#dashtodockContainer.extended:overview .dash-background, #dashtodockContainer.opaque.extended:overview .dash-background, #dashtodockContainer.transparent.extended:overview .dash-background {
+  background-color: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+#dashtodockContainer.running-dots .dash-item-container > StButton, #dashtodockContainer.dashtodock .dash-item-container > StButton {
+  transition-duration: 250ms;
+  background-size: contain;
+}
+
+#dashtodockContainer.extended .show-apps .overview-icon,
+#dashtodockContainer.extended .overview-tile .overview-icon,
+#dashtodockContainer.extended .grid-search-result .overview-icon,
+#dashtodockContainer.extended .search-provider-icon .overview-icon,
+#dashtodockContainer.extended .list-search-result .overview-icon, #dashtodockContainer.extended:overview .show-apps .overview-icon,
+#dashtodockContainer.extended:overview .overview-tile .overview-icon {
+  border-radius: 3px;
+}
+
+#dashtodockContainer .metro .overview-icon {
+  border-radius: 0;
+}
+
+.dashtodock-app-well-preview-menu-item {
+  padding: 1em 1em 0.5em 1em;
+}
+
+#dashtodockPreviewSeparator.popup-separator-menu-item-horizontal {
+  width: 1px;
+  height: auto;
+  border-right-width: 1px;
+  margin: 32px 0;
+}
+
+.dashtopanelMainPanel .show-apps,
+.dashtopanelMainPanel .overview-tile,
+.dashtopanelMainPanel .grid-search-result,
+.dashtopanelMainPanel .search-provider-icon,
+.dashtopanelMainPanel .list-search-result {
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+}
+
+.dashtopanelMainPanel .show-apps .overview-icon,
+.dashtopanelMainPanel .overview-tile .overview-icon,
+.dashtopanelMainPanel .grid-search-result .overview-icon,
+.dashtopanelMainPanel .search-provider-icon .overview-icon,
+.dashtopanelMainPanel .list-search-result .overview-icon {
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+}
+
+.dashtopanelMainPanel .show-apps .overview-icon {
+  border-radius: 3px !important;
+  color: rgba(255, 255, 255, 0.75) !important;
+}
+
+.dashtopanelMainPanel .show-apps:hover .overview-icon, .dashtopanelMainPanel .show-apps:focus .overview-icon, .dashtopanelMainPanel .show-apps:selected .overview-icon {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+  color: #FFFFFF !important;
+  box-shadow: none !important;
+}
+
+.dashtopanelMainPanel .show-apps:active .overview-icon, .dashtopanelMainPanel .show-apps:checked .overview-icon {
+  background-color: rgba(255, 255, 255, 0.15) !important;
+  color: #FFFFFF !important;
+  box-shadow: none !important;
+}
+
+.dashtopanelMainPanel .panel-button {
+  color: rgba(255, 255, 255, 0.75) !important;
+}
+
+.openweather-button, .openweather-button-action, .openweather-menu-button-container, .openweather-button-box {
+  border: 1px solid transparent !important;
+}
+
+.openweather-provider {
+  padding: 0 16px;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.54);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.openweather-provider:hover {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.06);
+  box-shadow: none;
+}
+
+.openweather-provider:focus {
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: none;
+}
+
+.openweather-provider:active {
+  color: rgba(0, 0, 0, 0.87);
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 transparent;
+}
+
+.openweather-current-icon, .openweather-current-summary, .openweather-current-summarybox {
+  background: none;
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.openweather-current-databox-values {
+  background: none;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.openweather-current-databox-captions {
+  background: none;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.openweather-forecast-icon, .openweather-forecast-summary {
+  background: none;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.openweather-forecast-day, .openweather-forecast-temperature {
+  background: none;
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.openweather-sunrise-icon, .openweather-sunset-icon, .openweather-build-icon {
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.gsconnect-device-menu .popup-menu-item {
+  height: 20px !important;
+  padding: 3px 0;
+}
+
+.gsconnect-device-menu .popup-menu-item > :last-child:ltr {
+  padding-right: 6px !important;
+  margin-right: 12px !important;
+}
+
+.gsconnect-device-menu .popup-menu-item > :last-child:rtl {
+  padding-left: 6px !important;
+  padding-left: 12px !important;
+}
+
+#panel.light-panel .panel-button,
+#panel.dark-panel .panel-button,
+#panel.transparent-panel .panel-button {
+  color: rgba(255, 255, 255, 0.7) !important;
+}
+
+#panel.light-panel .panel-button.clock-display .clock,
+#panel.dark-panel .panel-button.clock-display .clock,
+#panel.transparent-panel .panel-button.clock-display .clock {
+  color: rgba(255, 255, 255, 0.7) !important;
+}
+
+#panel.light-panel .panel-button:hover,
+#panel.dark-panel .panel-button:hover,
+#panel.transparent-panel .panel-button:hover {
+  color: rgba(255, 255, 255, 0.7) !important;
+  background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+#panel.light-panel .panel-button:active, #panel.light-panel .panel-button:checked, #panel.light-panel .panel-button:focus,
+#panel.dark-panel .panel-button:active,
+#panel.dark-panel .panel-button:checked,
+#panel.dark-panel .panel-button:focus,
+#panel.transparent-panel .panel-button:active,
+#panel.transparent-panel .panel-button:checked,
+#panel.transparent-panel .panel-button:focus {
+  color: rgba(255, 255, 255, 0.85) !important;
+  background-color: rgba(255, 255, 255, 0.3) !important;
+}
+
+#panel.light-panel .panel-button:hover.clock-display .clock, #panel.light-panel .panel-button:active.clock-display .clock, #panel.light-panel .panel-button:overview.clock-display .clock, #panel.light-panel .panel-button:focus.clock-display .clock, #panel.light-panel .panel-button:checked.clock-display .clock,
+#panel.dark-panel .panel-button:hover.clock-display .clock,
+#panel.dark-panel .panel-button:active.clock-display .clock,
+#panel.dark-panel .panel-button:overview.clock-display .clock,
+#panel.dark-panel .panel-button:focus.clock-display .clock,
+#panel.dark-panel .panel-button:checked.clock-display .clock,
+#panel.transparent-panel .panel-button:hover.clock-display .clock,
+#panel.transparent-panel .panel-button:active.clock-display .clock,
+#panel.transparent-panel .panel-button:overview.clock-display .clock,
+#panel.transparent-panel .panel-button:focus.clock-display .clock,
+#panel.transparent-panel .panel-button:checked.clock-display .clock {
+  color: rgba(255, 255, 255, 0.85) !important;
+}
+
+.overview-components-transparent .search-entry,
+.overview-components-light .search-entry,
+.overview-components-dark .search-entry {
+  caret-color: rgba(255, 255, 255, 0.75) !important;
+}
+
+.overview-components-transparent .search-entry .search-entry-icon,
+.overview-components-light .search-entry .search-entry-icon,
+.overview-components-dark .search-entry .search-entry-icon {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.overview-components-transparent .search-entry StLabel.hint-text,
+.overview-components-light .search-entry StLabel.hint-text,
+.overview-components-dark .search-entry StLabel.hint-text {
+  color: rgba(255, 255, 255, 0.35) !important;
+}
+
+.arcmenu-menu {
+  border-image: none !important;
+  border-radius: 3px !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+}
+
+.arcmenu-menu .popup-menu-content {
+  padding: 6px !important;
+  margin: 6px !important;
+  border: none !important;
+  background-color: rgba(255, 255, 255, 0.97);
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.1) !important;
+  border-radius: 3px !important;
+}

--- a/src/gnome-shell/shell-48-0/gnome-shell.scss
+++ b/src/gnome-shell/shell-48-0/gnome-shell.scss
@@ -1,0 +1,10 @@
+$variant: 'light';
+$laptop: 'false';
+$panel: 'dark';
+
+@import '../sass/variables';
+@import '../sass/colors';
+@import '../sass/drawing';
+@import '../sass/common-40-0';
+@import '../sass/widgets-48-0';
+@import '../sass/extensions-46-0';


### PR DESCRIPTION
This should provide a provisional fix to #200. The details might still need some tweaking but at least nothing should be overlapping and the quick settings menu is usable.