### PR TITLE
Add missing Libadwaita named colors

### DIFF
--- a/src/_sass/gtk/_libadwaita-colors-public.scss
+++ b/src/_sass/gtk/_libadwaita-colors-public.scss
@@ -1,0 +1,101 @@
+// apps rely on some named colors to be exported
+/* LIBADWAITA NAMED COLORS
+   -----------------------
+       use responsibly!    */
+
+// Sass thinks we're using the colors in the variables as strings and may shoot
+// warning, it's innocuous and can be defeated by using "" + $var
+/*
+important/interactive/active widget accent colors */
+@define-color accent_color #{"" + $primary};
+@define-color accent_bg_color #{"" + $primary};
+@define-color accent_fg_color #{"" + on($primary)};
+
+/*
+dangerous action colors */
+@define-color destructive_color #{"" + $error};
+@define-color destructive_bg_color #{"" + $error};
+@define-color destructive_fg_color #{"" + on($error)};
+
+/*
+success colors */
+// @define-color success_color #{"" + $success};
+@define-color success_bg_color #{"" + $success};
+@define-color success_fg_color #{"" + on($success)};
+
+/*
+warning colors */
+// @define-color warning_color #{"" + $warning};
+@define-color warning_bg_color #{"" + $warning};
+@define-color warning_fg_color #{"" + on($warning)};
+
+/*
+error colors */
+// @define-color error_color #{"" + $error};
+@define-color error_bg_color #{"" + $error};
+@define-color error_fg_color #{"" + on($error)};
+
+/*
+window colors */
+@define-color window_bg_color #{"" + $background};
+@define-color window_fg_color #{"" + $text};
+
+/*
+view colors */
+@define-color view_bg_color #{"" + $base};
+@define-color view_fg_color #{"" + $text};
+
+/*
+headerbar colors */
+@define-color headerbar_bg_color #{"" + $titlebar};
+@define-color headerbar_fg_color #{"" + $titlebar-text};
+@define-color headerbar_border_color #{"" + $divider};
+@define-color headerbar_backdrop_color #{"" + $titlebar-backdrop};
+@define-color headerbar_shade_color #{"" + darken($titlebar, 6%)};
+@define-color headerbar_darker_shade_color #{"" + darken($titlebar, 12%)};
+
+/*
+sidebar colors */
+@define-color sidebar_bg_color #{"" + $base};
+@define-color sidebar_fg_color #{"" + $text};
+@define-color sidebar_backdrop_color #{"" + $base-alt};
+@define-color sidebar_border_color #{"" + $divider};
+@define-color sidebar_shade_color #{"" + darken($base, 6%)};
+
+/*
+secondary sidebar colors */
+@define-color secondary_sidebar_bg_color #{"" + $base-alt};
+@define-color secondary_sidebar_fg_color #{"" + $text};
+@define-color secondary_sidebar_backdrop_color #{"" + darken($base-alt, 4%)};
+@define-color secondary_sidebar_border_color #{"" + $divider};
+@define-color secondary_sidebar_shade_color #{"" + darken($base-alt, 8%)};
+
+/*
+card and boxes list colors */
+@define-color card_bg_color #{"" + $base};
+@define-color card_fg_color #{"" + $text};
+@define-color card_shade_color #{"" + darken($base, 6%)};
+
+/*
+tab overview colors */
+@define-color thumbnail_bg_color #{"" + $base-alt};
+@define-color thumbnail_fg_color #{"" + $text};
+
+/*
+dialog colors */
+@define-color dialog_bg_color #{"" + $base};
+@define-color dialog_fg_color #{"" + $text};
+
+/*
+three dots menu colors */
+@define-color popover_bg_color #{"" + $base};
+@define-color popover_fg_color #{"" + $text};
+@define-color popover_shade_color #{"" + darken($base, 6%)};
+
+/*
+scroll undershoot and transition color */
+@define-color shade_color #{"" + rgba(black, 0.06)};
+
+/*
+scroll bar outine color */
+@define-color scrollbar_outline_color #{"" + rgba($text, 0.1)};

--- a/src/gtk/4.0/gtk-Dark-compact.css
+++ b/src/gtk/4.0/gtk-Dark-compact.css
@@ -7916,3 +7916,83 @@ FIXME this is really an API */
 @define-color BLACK_500 #393634;
 @define-color BLACK_700 #33302F;
 @define-color BLACK_900 #2B2928;
+
+/* LIBADWAITA NAMED COLORS
+   -----------------------
+       use responsibly!    */
+/*
+important/interactive/active widget accent colors */
+@define-color accent_color #3281EA;
+@define-color accent_bg_color #3281EA;
+@define-color accent_fg_color white;
+/*
+dangerous action colors */
+@define-color destructive_color #F28B82;
+@define-color destructive_bg_color #F28B82;
+@define-color destructive_fg_color rgba(0, 0, 0, 0.87);
+/*
+success colors */
+@define-color success_bg_color #81C995;
+@define-color success_fg_color rgba(0, 0, 0, 0.87);
+/*
+warning colors */
+@define-color warning_bg_color #FDD633;
+@define-color warning_fg_color rgba(0, 0, 0, 0.87);
+/*
+error colors */
+@define-color error_bg_color #F28B82;
+@define-color error_fg_color rgba(0, 0, 0, 0.87);
+/*
+window colors */
+@define-color window_bg_color #333333;
+@define-color window_fg_color white;
+/*
+view colors */
+@define-color view_bg_color #2B2B2B;
+@define-color view_fg_color white;
+/*
+headerbar colors */
+@define-color headerbar_bg_color #202020;
+@define-color headerbar_fg_color white;
+@define-color headerbar_border_color rgba(255, 255, 255, 0.12);
+@define-color headerbar_backdrop_color #2C2C2C;
+@define-color headerbar_shade_color #111111;
+@define-color headerbar_darker_shade_color #010101;
+/*
+sidebar colors */
+@define-color sidebar_bg_color #2B2B2B;
+@define-color sidebar_fg_color white;
+@define-color sidebar_backdrop_color #303030;
+@define-color sidebar_border_color rgba(255, 255, 255, 0.12);
+@define-color sidebar_shade_color #1c1c1c;
+/*
+secondary sidebar colors */
+@define-color secondary_sidebar_bg_color #303030;
+@define-color secondary_sidebar_fg_color white;
+@define-color secondary_sidebar_backdrop_color #262626;
+@define-color secondary_sidebar_border_color rgba(255, 255, 255, 0.12);
+@define-color secondary_sidebar_shade_color #1c1c1c;
+/*
+card and boxes list colors */
+@define-color card_bg_color #2B2B2B;
+@define-color card_fg_color white;
+@define-color card_shade_color #1c1c1c;
+/*
+tab overview colors */
+@define-color thumbnail_bg_color #303030;
+@define-color thumbnail_fg_color white;
+/*
+dialog colors */
+@define-color dialog_bg_color #2B2B2B;
+@define-color dialog_fg_color white;
+/*
+three dots menu colors */
+@define-color popover_bg_color #2B2B2B;
+@define-color popover_fg_color white;
+@define-color popover_shade_color #1c1c1c;
+/*
+scroll undershoot and transition color */
+@define-color shade_color rgba(0, 0, 0, 0.06);
+/*
+scroll bar outine color */
+@define-color scrollbar_outline_color rgba(255, 255, 255, 0.1);

--- a/src/gtk/4.0/gtk-Dark-compact.scss
+++ b/src/gtk/4.0/gtk-Dark-compact.scss
@@ -8,3 +8,4 @@ $compact: 'true';
 @import '../../_sass/gtk/common-4.0';
 @import '../../_sass/gtk/apps-4.0';
 @import '../../_sass/gtk/colors-public';
+@import '../../_sass/gtk/libadwaita-colors-public';

--- a/src/gtk/4.0/gtk-Dark.css
+++ b/src/gtk/4.0/gtk-Dark.css
@@ -7916,3 +7916,83 @@ FIXME this is really an API */
 @define-color BLACK_500 #393634;
 @define-color BLACK_700 #33302F;
 @define-color BLACK_900 #2B2928;
+
+/* LIBADWAITA NAMED COLORS
+   -----------------------
+       use responsibly!    */
+/*
+important/interactive/active widget accent colors */
+@define-color accent_color #3281EA;
+@define-color accent_bg_color #3281EA;
+@define-color accent_fg_color white;
+/*
+dangerous action colors */
+@define-color destructive_color #F28B82;
+@define-color destructive_bg_color #F28B82;
+@define-color destructive_fg_color rgba(0, 0, 0, 0.87);
+/*
+success colors */
+@define-color success_bg_color #81C995;
+@define-color success_fg_color rgba(0, 0, 0, 0.87);
+/*
+warning colors */
+@define-color warning_bg_color #FDD633;
+@define-color warning_fg_color rgba(0, 0, 0, 0.87);
+/*
+error colors */
+@define-color error_bg_color #F28B82;
+@define-color error_fg_color rgba(0, 0, 0, 0.87);
+/*
+window colors */
+@define-color window_bg_color #333333;
+@define-color window_fg_color white;
+/*
+view colors */
+@define-color view_bg_color #2B2B2B;
+@define-color view_fg_color white;
+/*
+headerbar colors */
+@define-color headerbar_bg_color #202020;
+@define-color headerbar_fg_color white;
+@define-color headerbar_border_color rgba(255, 255, 255, 0.12);
+@define-color headerbar_backdrop_color #2C2C2C;
+@define-color headerbar_shade_color #111111;
+@define-color headerbar_darker_shade_color #010101;
+/*
+sidebar colors */
+@define-color sidebar_bg_color #2B2B2B;
+@define-color sidebar_fg_color white;
+@define-color sidebar_backdrop_color #303030;
+@define-color sidebar_border_color rgba(255, 255, 255, 0.12);
+@define-color sidebar_shade_color #1c1c1c;
+/*
+secondary sidebar colors */
+@define-color secondary_sidebar_bg_color #303030;
+@define-color secondary_sidebar_fg_color white;
+@define-color secondary_sidebar_backdrop_color #262626;
+@define-color secondary_sidebar_border_color rgba(255, 255, 255, 0.12);
+@define-color secondary_sidebar_shade_color #1c1c1c;
+/*
+card and boxes list colors */
+@define-color card_bg_color #2B2B2B;
+@define-color card_fg_color white;
+@define-color card_shade_color #1c1c1c;
+/*
+tab overview colors */
+@define-color thumbnail_bg_color #303030;
+@define-color thumbnail_fg_color white;
+/*
+dialog colors */
+@define-color dialog_bg_color #2B2B2B;
+@define-color dialog_fg_color white;
+/*
+three dots menu colors */
+@define-color popover_bg_color #2B2B2B;
+@define-color popover_fg_color white;
+@define-color popover_shade_color #1c1c1c;
+/*
+scroll undershoot and transition color */
+@define-color shade_color rgba(0, 0, 0, 0.06);
+/*
+scroll bar outine color */
+@define-color scrollbar_outline_color rgba(255, 255, 255, 0.1);

--- a/src/gtk/4.0/gtk-Dark.scss
+++ b/src/gtk/4.0/gtk-Dark.scss
@@ -8,3 +8,4 @@ $compact: 'false';
 @import '../../_sass/gtk/common-4.0';
 @import '../../_sass/gtk/apps-4.0';
 @import '../../_sass/gtk/colors-public';
+@import '../../_sass/gtk/libadwaita-colors-public';

--- a/src/gtk/4.0/gtk-Light-compact.css
+++ b/src/gtk/4.0/gtk-Light-compact.css
@@ -7916,3 +7916,83 @@ FIXME this is really an API */
 @define-color BLACK_500 #393634;
 @define-color BLACK_700 #33302F;
 @define-color BLACK_900 #2B2928;
+
+/* LIBADWAITA NAMED COLORS
+   -----------------------
+       use responsibly!    */
+/*
+important/interactive/active widget accent colors */
+@define-color accent_color #1A73E8;
+@define-color accent_bg_color #1A73E8;
+@define-color accent_fg_color white;
+/*
+dangerous action colors */
+@define-color destructive_color #D93025;
+@define-color destructive_bg_color #D93025;
+@define-color destructive_fg_color white;
+/*
+success colors */
+@define-color success_bg_color #0F9D58;
+@define-color success_fg_color white;
+/*
+warning colors */
+@define-color warning_bg_color #F4B400;
+@define-color warning_fg_color rgba(0, 0, 0, 0.87);
+/*
+error colors */
+@define-color error_bg_color #D93025;
+@define-color error_fg_color white;
+/*
+window colors */
+@define-color window_bg_color #F2F2F2;
+@define-color window_fg_color rgba(0, 0, 0, 0.87);
+/*
+view colors */
+@define-color view_bg_color #FFFFFF;
+@define-color view_fg_color rgba(0, 0, 0, 0.87);
+/*
+headerbar colors */
+@define-color headerbar_bg_color #F7F7F7;
+@define-color headerbar_fg_color rgba(0, 0, 0, 0.87);
+@define-color headerbar_border_color rgba(0, 0, 0, 0.12);
+@define-color headerbar_backdrop_color #F2F2F2;
+@define-color headerbar_shade_color #e8e8e8;
+@define-color headerbar_darker_shade_color #d8d8d8;
+/*
+sidebar colors */
+@define-color sidebar_bg_color #FFFFFF;
+@define-color sidebar_fg_color rgba(0, 0, 0, 0.87);
+@define-color sidebar_backdrop_color #FAFAFA;
+@define-color sidebar_border_color rgba(0, 0, 0, 0.12);
+@define-color sidebar_shade_color #f0f0f0;
+/*
+secondary sidebar colors */
+@define-color secondary_sidebar_bg_color #FAFAFA;
+@define-color secondary_sidebar_fg_color rgba(0, 0, 0, 0.87);
+@define-color secondary_sidebar_backdrop_color #f0f0f0;
+@define-color secondary_sidebar_border_color rgba(0, 0, 0, 0.12);
+@define-color secondary_sidebar_shade_color #e6e6e6;
+/*
+card and boxes list colors */
+@define-color card_bg_color #FFFFFF;
+@define-color card_fg_color rgba(0, 0, 0, 0.87);
+@define-color card_shade_color #f0f0f0;
+/*
+tab overview colors */
+@define-color thumbnail_bg_color #FAFAFA;
+@define-color thumbnail_fg_color rgba(0, 0, 0, 0.87);
+/*
+dialog colors */
+@define-color dialog_bg_color #FFFFFF;
+@define-color dialog_fg_color rgba(0, 0, 0, 0.87);
+/*
+three dots menu colors */
+@define-color popover_bg_color #FFFFFF;
+@define-color popover_fg_color rgba(0, 0, 0, 0.87);
+@define-color popover_shade_color #f0f0f0;
+/*
+scroll undershoot and transition color */
+@define-color shade_color rgba(0, 0, 0, 0.06);
+/*
+scroll bar outine color */
+@define-color scrollbar_outline_color rgba(0, 0, 0, 0.1);

--- a/src/gtk/4.0/gtk-Light-compact.scss
+++ b/src/gtk/4.0/gtk-Light-compact.scss
@@ -8,3 +8,4 @@ $compact: 'true';
 @import '../../_sass/gtk/common-4.0';
 @import '../../_sass/gtk/apps-4.0';
 @import '../../_sass/gtk/colors-public';
+@import '../../_sass/gtk/libadwaita-colors-public';

--- a/src/gtk/4.0/gtk-Light.css
+++ b/src/gtk/4.0/gtk-Light.css
@@ -7916,3 +7916,83 @@ FIXME this is really an API */
 @define-color BLACK_500 #393634;
 @define-color BLACK_700 #33302F;
 @define-color BLACK_900 #2B2928;
+
+/* LIBADWAITA NAMED COLORS
+   -----------------------
+       use responsibly!    */
+/*
+important/interactive/active widget accent colors */
+@define-color accent_color #1A73E8;
+@define-color accent_bg_color #1A73E8;
+@define-color accent_fg_color white;
+/*
+dangerous action colors */
+@define-color destructive_color #D93025;
+@define-color destructive_bg_color #D93025;
+@define-color destructive_fg_color white;
+/*
+success colors */
+@define-color success_bg_color #0F9D58;
+@define-color success_fg_color white;
+/*
+warning colors */
+@define-color warning_bg_color #F4B400;
+@define-color warning_fg_color rgba(0, 0, 0, 0.87);
+/*
+error colors */
+@define-color error_bg_color #D93025;
+@define-color error_fg_color white;
+/*
+window colors */
+@define-color window_bg_color #F2F2F2;
+@define-color window_fg_color rgba(0, 0, 0, 0.87);
+/*
+view colors */
+@define-color view_bg_color #FFFFFF;
+@define-color view_fg_color rgba(0, 0, 0, 0.87);
+/*
+headerbar colors */
+@define-color headerbar_bg_color #F7F7F7;
+@define-color headerbar_fg_color rgba(0, 0, 0, 0.87);
+@define-color headerbar_border_color rgba(0, 0, 0, 0.12);
+@define-color headerbar_backdrop_color #F2F2F2;
+@define-color headerbar_shade_color #e8e8e8;
+@define-color headerbar_darker_shade_color #d8d8d8;
+/*
+sidebar colors */
+@define-color sidebar_bg_color #FFFFFF;
+@define-color sidebar_fg_color rgba(0, 0, 0, 0.87);
+@define-color sidebar_backdrop_color #FAFAFA;
+@define-color sidebar_border_color rgba(0, 0, 0, 0.12);
+@define-color sidebar_shade_color #f0f0f0;
+/*
+secondary sidebar colors */
+@define-color secondary_sidebar_bg_color #FAFAFA;
+@define-color secondary_sidebar_fg_color rgba(0, 0, 0, 0.87);
+@define-color secondary_sidebar_backdrop_color #f0f0f0;
+@define-color secondary_sidebar_border_color rgba(0, 0, 0, 0.12);
+@define-color secondary_sidebar_shade_color #e6e6e6;
+/*
+card and boxes list colors */
+@define-color card_bg_color #FFFFFF;
+@define-color card_fg_color rgba(0, 0, 0, 0.87);
+@define-color card_shade_color #f0f0f0;
+/*
+tab overview colors */
+@define-color thumbnail_bg_color #FAFAFA;
+@define-color thumbnail_fg_color rgba(0, 0, 0, 0.87);
+/*
+dialog colors */
+@define-color dialog_bg_color #FFFFFF;
+@define-color dialog_fg_color rgba(0, 0, 0, 0.87);
+/*
+three dots menu colors */
+@define-color popover_bg_color #FFFFFF;
+@define-color popover_fg_color rgba(0, 0, 0, 0.87);
+@define-color popover_shade_color #f0f0f0;
+/*
+scroll undershoot and transition color */
+@define-color shade_color rgba(0, 0, 0, 0.06);
+/*
+scroll bar outine color */
+@define-color scrollbar_outline_color rgba(0, 0, 0, 0.1);

--- a/src/gtk/4.0/gtk-Light.scss
+++ b/src/gtk/4.0/gtk-Light.scss
@@ -8,3 +8,4 @@ $compact: 'false';
 @import '../../_sass/gtk/common-4.0';
 @import '../../_sass/gtk/apps-4.0';
 @import '../../_sass/gtk/colors-public';
+@import '../../_sass/gtk/libadwaita-colors-public';

--- a/src/gtk/4.0/gtk-compact.css
+++ b/src/gtk/4.0/gtk-compact.css
@@ -7917,3 +7917,83 @@ FIXME this is really an API */
 @define-color BLACK_500 #393634;
 @define-color BLACK_700 #33302F;
 @define-color BLACK_900 #2B2928;
+
+/* LIBADWAITA NAMED COLORS
+   -----------------------
+       use responsibly!    */
+/*
+important/interactive/active widget accent colors */
+@define-color accent_color #1A73E8;
+@define-color accent_bg_color #1A73E8;
+@define-color accent_fg_color white;
+/*
+dangerous action colors */
+@define-color destructive_color #D93025;
+@define-color destructive_bg_color #D93025;
+@define-color destructive_fg_color white;
+/*
+success colors */
+@define-color success_bg_color #0F9D58;
+@define-color success_fg_color white;
+/*
+warning colors */
+@define-color warning_bg_color #F4B400;
+@define-color warning_fg_color rgba(0, 0, 0, 0.87);
+/*
+error colors */
+@define-color error_bg_color #D93025;
+@define-color error_fg_color white;
+/*
+window colors */
+@define-color window_bg_color #F2F2F2;
+@define-color window_fg_color rgba(0, 0, 0, 0.87);
+/*
+view colors */
+@define-color view_bg_color #FFFFFF;
+@define-color view_fg_color rgba(0, 0, 0, 0.87);
+/*
+headerbar colors */
+@define-color headerbar_bg_color #2C2C2C;
+@define-color headerbar_fg_color white;
+@define-color headerbar_border_color rgba(0, 0, 0, 0.12);
+@define-color headerbar_backdrop_color #3c3c3c;
+@define-color headerbar_shade_color #1d1d1d;
+@define-color headerbar_darker_shade_color #0d0d0d;
+/*
+sidebar colors */
+@define-color sidebar_bg_color #FFFFFF;
+@define-color sidebar_fg_color rgba(0, 0, 0, 0.87);
+@define-color sidebar_backdrop_color #FAFAFA;
+@define-color sidebar_border_color rgba(0, 0, 0, 0.12);
+@define-color sidebar_shade_color #f0f0f0;
+/*
+secondary sidebar colors */
+@define-color secondary_sidebar_bg_color #FAFAFA;
+@define-color secondary_sidebar_fg_color rgba(0, 0, 0, 0.87);
+@define-color secondary_sidebar_backdrop_color #f0f0f0;
+@define-color secondary_sidebar_border_color rgba(0, 0, 0, 0.12);
+@define-color secondary_sidebar_shade_color #e6e6e6;
+/*
+card and boxes list colors */
+@define-color card_bg_color #FFFFFF;
+@define-color card_fg_color rgba(0, 0, 0, 0.87);
+@define-color card_shade_color #f0f0f0;
+/*
+tab overview colors */
+@define-color thumbnail_bg_color #FAFAFA;
+@define-color thumbnail_fg_color rgba(0, 0, 0, 0.87);
+/*
+dialog colors */
+@define-color dialog_bg_color #FFFFFF;
+@define-color dialog_fg_color rgba(0, 0, 0, 0.87);
+/*
+three dots menu colors */
+@define-color popover_bg_color #FFFFFF;
+@define-color popover_fg_color rgba(0, 0, 0, 0.87);
+@define-color popover_shade_color #f0f0f0;
+/*
+scroll undershoot and transition color */
+@define-color shade_color rgba(0, 0, 0, 0.06);
+/*
+scroll bar outine color */
+@define-color scrollbar_outline_color rgba(0, 0, 0, 0.1);

--- a/src/gtk/4.0/gtk-compact.scss
+++ b/src/gtk/4.0/gtk-compact.scss
@@ -8,3 +8,4 @@ $compact: 'true';
 @import '../../_sass/gtk/common-4.0';
 @import '../../_sass/gtk/apps-4.0';
 @import '../../_sass/gtk/colors-public';
+@import '../../_sass/gtk/libadwaita-colors-public';

--- a/src/gtk/4.0/gtk.css
+++ b/src/gtk/4.0/gtk.css
@@ -7917,3 +7917,83 @@ FIXME this is really an API */
 @define-color BLACK_500 #393634;
 @define-color BLACK_700 #33302F;
 @define-color BLACK_900 #2B2928;
+
+/* LIBADWAITA NAMED COLORS
+   -----------------------
+       use responsibly!    */
+/*
+important/interactive/active widget accent colors */
+@define-color accent_color #1A73E8;
+@define-color accent_bg_color #1A73E8;
+@define-color accent_fg_color white;
+/*
+dangerous action colors */
+@define-color destructive_color #D93025;
+@define-color destructive_bg_color #D93025;
+@define-color destructive_fg_color white;
+/*
+success colors */
+@define-color success_bg_color #0F9D58;
+@define-color success_fg_color white;
+/*
+warning colors */
+@define-color warning_bg_color #F4B400;
+@define-color warning_fg_color rgba(0, 0, 0, 0.87);
+/*
+error colors */
+@define-color error_bg_color #D93025;
+@define-color error_fg_color white;
+/*
+window colors */
+@define-color window_bg_color #F2F2F2;
+@define-color window_fg_color rgba(0, 0, 0, 0.87);
+/*
+view colors */
+@define-color view_bg_color #FFFFFF;
+@define-color view_fg_color rgba(0, 0, 0, 0.87);
+/*
+headerbar colors */
+@define-color headerbar_bg_color #2C2C2C;
+@define-color headerbar_fg_color white;
+@define-color headerbar_border_color rgba(0, 0, 0, 0.12);
+@define-color headerbar_backdrop_color #3c3c3c;
+@define-color headerbar_shade_color #1d1d1d;
+@define-color headerbar_darker_shade_color #0d0d0d;
+/*
+sidebar colors */
+@define-color sidebar_bg_color #FFFFFF;
+@define-color sidebar_fg_color rgba(0, 0, 0, 0.87);
+@define-color sidebar_backdrop_color #FAFAFA;
+@define-color sidebar_border_color rgba(0, 0, 0, 0.12);
+@define-color sidebar_shade_color #f0f0f0;
+/*
+secondary sidebar colors */
+@define-color secondary_sidebar_bg_color #FAFAFA;
+@define-color secondary_sidebar_fg_color rgba(0, 0, 0, 0.87);
+@define-color secondary_sidebar_backdrop_color #f0f0f0;
+@define-color secondary_sidebar_border_color rgba(0, 0, 0, 0.12);
+@define-color secondary_sidebar_shade_color #e6e6e6;
+/*
+card and boxes list colors */
+@define-color card_bg_color #FFFFFF;
+@define-color card_fg_color rgba(0, 0, 0, 0.87);
+@define-color card_shade_color #f0f0f0;
+/*
+tab overview colors */
+@define-color thumbnail_bg_color #FAFAFA;
+@define-color thumbnail_fg_color rgba(0, 0, 0, 0.87);
+/*
+dialog colors */
+@define-color dialog_bg_color #FFFFFF;
+@define-color dialog_fg_color rgba(0, 0, 0, 0.87);
+/*
+three dots menu colors */
+@define-color popover_bg_color #FFFFFF;
+@define-color popover_fg_color rgba(0, 0, 0, 0.87);
+@define-color popover_shade_color #f0f0f0;
+/*
+scroll undershoot and transition color */
+@define-color shade_color rgba(0, 0, 0, 0.06);
+/*
+scroll bar outine color */
+@define-color scrollbar_outline_color rgba(0, 0, 0, 0.1);

--- a/src/gtk/4.0/gtk.scss
+++ b/src/gtk/4.0/gtk.scss
@@ -8,3 +8,4 @@ $compact: 'false';
 @import '../../_sass/gtk/common-4.0';
 @import '../../_sass/gtk/apps-4.0';
 @import '../../_sass/gtk/colors-public';
+@import '../../_sass/gtk/libadwaita-colors-public';


### PR DESCRIPTION
That should fix issue with mixed Adwaita and Fluent theme colors caused by missing specifications of named colors in GTK4 CSS of Fluent theme. Both colors of light and dark variants of Fluent theme partially match Adwaita ones, that is why it seems to look good *in GNOME*. If that does not look like real issue, then just look at Fluent Dark theme outside of GNOME.

![2025-06-07 17-55-46](https://github.com/user-attachments/assets/41700f08-e7da-45f4-a895-29077594cc4a)
*GNOME System Monitor on Cinnamon DE*

As you can see, font is black and graphs are white. I have installed theme properly, by putting `Fluent-Dark-compact/gtk-4.0/gtk.css` into `~/.config/gtk-4.0/gtk.css`.
Also this issue exists in GNOME Calculator and file pickers created by Libadwaita apps (sidebar separator is just white), I bet there is much more apps suffering from that.

That is why I added missing named colors respecting [Libadwaita's named colors documentation](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.5/named-colors.html), even ones that could be safely ignored. As a result, everything looks good now.

![2025-06-07 17-56-43](https://github.com/user-attachments/assets/75463dd8-43d3-458c-b6eb-fcc0d38dc3fe)