### PR TITLE
Fix wrong colors were used for GtkNotebook and GtkListBox causing issues in some apps.

### DIFF
--- a/src/_sass/gtk/_common-3.20.scss
+++ b/src/_sass/gtk/_common-3.20.scss
@@ -2184,7 +2184,7 @@ $tab-radius: $corner-radius;
 
   &:checked {
     transition: $transition;
-    background-color: $base;
+    background-color: $background;
     background-clip: padding-box;
     border-color: $solid-border;
     color: $text;
@@ -2202,7 +2202,7 @@ notebook {
   &.frame > header { background-color: $base-alt; }
 
   &, &.frame {
-    background-color: $base;
+    background-color: $background;
     border-radius: $corner-radius;
   }
 
@@ -3258,7 +3258,7 @@ separator {
 
 list {
   border-color: $divider;
-  background-color: $base;
+  background-color: $background;
 
   row { padding: $space-size / 2 $space-size; }
 

--- a/src/_sass/gtk/_common-4.0.scss
+++ b/src/_sass/gtk/_common-4.0.scss
@@ -2380,7 +2380,7 @@ $tab-radius: $corner-radius;
     box-shadow: none;
 
     &, &:hover {
-      background-color: $base;
+      background-color: $background;
     }
 
     &:disabled { color: $text-disabled; }
@@ -2396,7 +2396,7 @@ notebook {
   &.frame > header { background-color: $base-alt; }
 
   &, &.frame {
-    background-color: $base;
+    background-color: $background;
     border-radius: $corner-radius;
   }
 
@@ -3519,7 +3519,7 @@ separator {
 listview,
 list {
   border-color: $divider;
-  background-color: $base;
+  background-color: $background;
   color: $text;
   box-shadow: none;
 

--- a/src/gtk/3.0/gtk-Dark-compact.css
+++ b/src/gtk/3.0/gtk-Dark-compact.css
@@ -2377,7 +2377,7 @@ tabbox > tab:disabled, notebook > header tab:disabled {
 
 tabbox > tab:checked, notebook > header tab:checked {
   transition: all 75ms cubic-bezier(0, 0, 0.2, 1);
-  background-color: #2B2B2B;
+  background-color: #333333;
   background-clip: padding-box;
   border-color: #4d4d4d;
   color: white;
@@ -2396,7 +2396,7 @@ frame > paned > notebook > header, notebook.frame > header {
 }
 
 notebook, notebook.frame {
-  background-color: #2B2B2B;
+  background-color: #333333;
   border-radius: 2px;
 }
 
@@ -3572,7 +3572,7 @@ window.background.csd > box.vertical > overlay > stack > box.vertical > box.hori
 
 list {
   border-color: rgba(255, 255, 255, 0.12);
-  background-color: #2B2B2B;
+  background-color: #333333;
 }
 
 list row {

--- a/src/gtk/3.0/gtk-Dark.css
+++ b/src/gtk/3.0/gtk-Dark.css
@@ -2377,7 +2377,7 @@ tabbox > tab:disabled, notebook > header tab:disabled {
 
 tabbox > tab:checked, notebook > header tab:checked {
   transition: all 75ms cubic-bezier(0, 0, 0.2, 1);
-  background-color: #2B2B2B;
+  background-color: #333333;
   background-clip: padding-box;
   border-color: #4d4d4d;
   color: white;
@@ -2396,7 +2396,7 @@ frame > paned > notebook > header, notebook.frame > header {
 }
 
 notebook, notebook.frame {
-  background-color: #2B2B2B;
+  background-color: #333333;
   border-radius: 2px;
 }
 
@@ -3572,7 +3572,7 @@ window.background.csd > box.vertical > overlay > stack > box.vertical > box.hori
 
 list {
   border-color: rgba(255, 255, 255, 0.12);
-  background-color: #2B2B2B;
+  background-color: #333333;
 }
 
 list row {

--- a/src/gtk/3.0/gtk-Light-compact.css
+++ b/src/gtk/3.0/gtk-Light-compact.css
@@ -2377,7 +2377,7 @@ tabbox > tab:disabled, notebook > header tab:disabled {
 
 tabbox > tab:checked, notebook > header tab:checked {
   transition: all 75ms cubic-bezier(0, 0, 0.2, 1);
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
   background-clip: padding-box;
   border-color: #d9d9d9;
   color: rgba(0, 0, 0, 0.87);
@@ -2396,7 +2396,7 @@ frame > paned > notebook > header, notebook.frame > header {
 }
 
 notebook, notebook.frame {
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
   border-radius: 2px;
 }
 
@@ -3572,7 +3572,7 @@ window.background.csd > box.vertical > overlay > stack > box.vertical > box.hori
 
 list {
   border-color: rgba(0, 0, 0, 0.12);
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
 }
 
 list row {

--- a/src/gtk/3.0/gtk-Light.css
+++ b/src/gtk/3.0/gtk-Light.css
@@ -2377,7 +2377,7 @@ tabbox > tab:disabled, notebook > header tab:disabled {
 
 tabbox > tab:checked, notebook > header tab:checked {
   transition: all 75ms cubic-bezier(0, 0, 0.2, 1);
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
   background-clip: padding-box;
   border-color: #d9d9d9;
   color: rgba(0, 0, 0, 0.87);
@@ -2396,7 +2396,7 @@ frame > paned > notebook > header, notebook.frame > header {
 }
 
 notebook, notebook.frame {
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
   border-radius: 2px;
 }
 
@@ -3572,7 +3572,7 @@ window.background.csd > box.vertical > overlay > stack > box.vertical > box.hori
 
 list {
   border-color: rgba(0, 0, 0, 0.12);
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
 }
 
 list row {

--- a/src/gtk/3.0/gtk-compact.css
+++ b/src/gtk/3.0/gtk-compact.css
@@ -2378,7 +2378,7 @@ tabbox > tab:disabled, notebook > header tab:disabled {
 
 tabbox > tab:checked, notebook > header tab:checked {
   transition: all 75ms cubic-bezier(0, 0, 0.2, 1);
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
   background-clip: padding-box;
   border-color: #d9d9d9;
   color: rgba(0, 0, 0, 0.87);
@@ -2397,7 +2397,7 @@ frame > paned > notebook > header, notebook.frame > header {
 }
 
 notebook, notebook.frame {
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
   border-radius: 2px;
 }
 
@@ -3573,7 +3573,7 @@ window.background.csd > box.vertical > overlay > stack > box.vertical > box.hori
 
 list {
   border-color: rgba(0, 0, 0, 0.12);
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
 }
 
 list row {

--- a/src/gtk/3.0/gtk.css
+++ b/src/gtk/3.0/gtk.css
@@ -2378,7 +2378,7 @@ tabbox > tab:disabled, notebook > header tab:disabled {
 
 tabbox > tab:checked, notebook > header tab:checked {
   transition: all 75ms cubic-bezier(0, 0, 0.2, 1);
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
   background-clip: padding-box;
   border-color: #d9d9d9;
   color: rgba(0, 0, 0, 0.87);
@@ -2397,7 +2397,7 @@ frame > paned > notebook > header, notebook.frame > header {
 }
 
 notebook, notebook.frame {
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
   border-radius: 2px;
 }
 
@@ -3573,7 +3573,7 @@ window.background.csd > box.vertical > overlay > stack > box.vertical > box.hori
 
 list {
   border-color: rgba(0, 0, 0, 0.12);
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
 }
 
 list row {

--- a/src/gtk/4.0/gtk-Dark-compact.css
+++ b/src/gtk/4.0/gtk-Dark-compact.css
@@ -2715,7 +2715,7 @@ tabbar tabbox tab:checked, notebook > header tab:checked, tabbar tabbox tab:sele
 }
 
 tabbar tabbox tab:checked, notebook > header tab:checked, notebook > header tab:checked:hover, tabbar tabbox tab:selected, notebook > header tab:selected, notebook > header tab:selected:hover {
-  background-color: #2B2B2B;
+  background-color: #333333;
 }
 
 tabbar tabbox tab:checked:disabled, notebook > header tab:checked:disabled, tabbar tabbox tab:selected:disabled, notebook > header tab:selected:disabled {
@@ -2731,7 +2731,7 @@ frame > paned > notebook > header, notebook.frame > header {
 }
 
 notebook, notebook.frame {
-  background-color: #2B2B2B;
+  background-color: #333333;
   border-radius: 2px;
 }
 
@@ -3991,7 +3991,7 @@ stacksidebar separator.horizontal, button.font separator, button.file separator 
 listview,
 list {
   border-color: rgba(255, 255, 255, 0.12);
-  background-color: #2B2B2B;
+  background-color: #333333;
   color: white;
   box-shadow: none;
 }

--- a/src/gtk/4.0/gtk-Dark.css
+++ b/src/gtk/4.0/gtk-Dark.css
@@ -2715,7 +2715,7 @@ tabbar tabbox tab:checked, notebook > header tab:checked, tabbar tabbox tab:sele
 }
 
 tabbar tabbox tab:checked, notebook > header tab:checked, notebook > header tab:checked:hover, tabbar tabbox tab:selected, notebook > header tab:selected, notebook > header tab:selected:hover {
-  background-color: #2B2B2B;
+  background-color: #333333;
 }
 
 tabbar tabbox tab:checked:disabled, notebook > header tab:checked:disabled, tabbar tabbox tab:selected:disabled, notebook > header tab:selected:disabled {
@@ -2731,7 +2731,7 @@ frame > paned > notebook > header, notebook.frame > header {
 }
 
 notebook, notebook.frame {
-  background-color: #2B2B2B;
+  background-color: #333333;
   border-radius: 2px;
 }
 
@@ -3991,7 +3991,7 @@ stacksidebar separator.horizontal, button.font separator, button.file separator 
 listview,
 list {
   border-color: rgba(255, 255, 255, 0.12);
-  background-color: #2B2B2B;
+  background-color: #333333;
   color: white;
   box-shadow: none;
 }

--- a/src/gtk/4.0/gtk-Light-compact.css
+++ b/src/gtk/4.0/gtk-Light-compact.css
@@ -2715,7 +2715,7 @@ tabbar tabbox tab:checked, notebook > header tab:checked, tabbar tabbox tab:sele
 }
 
 tabbar tabbox tab:checked, notebook > header tab:checked, notebook > header tab:checked:hover, tabbar tabbox tab:selected, notebook > header tab:selected, notebook > header tab:selected:hover {
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
 }
 
 tabbar tabbox tab:checked:disabled, notebook > header tab:checked:disabled, tabbar tabbox tab:selected:disabled, notebook > header tab:selected:disabled {
@@ -2731,7 +2731,7 @@ frame > paned > notebook > header, notebook.frame > header {
 }
 
 notebook, notebook.frame {
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
   border-radius: 2px;
 }
 
@@ -3991,7 +3991,7 @@ stacksidebar separator.horizontal, button.font separator, button.file separator 
 listview,
 list {
   border-color: rgba(0, 0, 0, 0.12);
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
   color: rgba(0, 0, 0, 0.87);
   box-shadow: none;
 }

--- a/src/gtk/4.0/gtk-Light.css
+++ b/src/gtk/4.0/gtk-Light.css
@@ -2715,7 +2715,7 @@ tabbar tabbox tab:checked, notebook > header tab:checked, tabbar tabbox tab:sele
 }
 
 tabbar tabbox tab:checked, notebook > header tab:checked, notebook > header tab:checked:hover, tabbar tabbox tab:selected, notebook > header tab:selected, notebook > header tab:selected:hover {
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
 }
 
 tabbar tabbox tab:checked:disabled, notebook > header tab:checked:disabled, tabbar tabbox tab:selected:disabled, notebook > header tab:selected:disabled {
@@ -2731,7 +2731,7 @@ frame > paned > notebook > header, notebook.frame > header {
 }
 
 notebook, notebook.frame {
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
   border-radius: 2px;
 }
 
@@ -3991,7 +3991,7 @@ stacksidebar separator.horizontal, button.font separator, button.file separator 
 listview,
 list {
   border-color: rgba(0, 0, 0, 0.12);
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
   color: rgba(0, 0, 0, 0.87);
   box-shadow: none;
 }

--- a/src/gtk/4.0/gtk-compact.css
+++ b/src/gtk/4.0/gtk-compact.css
@@ -2716,7 +2716,7 @@ tabbar tabbox tab:checked, notebook > header tab:checked, tabbar tabbox tab:sele
 }
 
 tabbar tabbox tab:checked, notebook > header tab:checked, notebook > header tab:checked:hover, tabbar tabbox tab:selected, notebook > header tab:selected, notebook > header tab:selected:hover {
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
 }
 
 tabbar tabbox tab:checked:disabled, notebook > header tab:checked:disabled, tabbar tabbox tab:selected:disabled, notebook > header tab:selected:disabled {
@@ -2732,7 +2732,7 @@ frame > paned > notebook > header, notebook.frame > header {
 }
 
 notebook, notebook.frame {
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
   border-radius: 2px;
 }
 
@@ -3992,7 +3992,7 @@ stacksidebar separator.horizontal, button.font separator, button.file separator 
 listview,
 list {
   border-color: rgba(0, 0, 0, 0.12);
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
   color: rgba(0, 0, 0, 0.87);
   box-shadow: none;
 }

--- a/src/gtk/4.0/gtk.css
+++ b/src/gtk/4.0/gtk.css
@@ -2716,7 +2716,7 @@ tabbar tabbox tab:checked, notebook > header tab:checked, tabbar tabbox tab:sele
 }
 
 tabbar tabbox tab:checked, notebook > header tab:checked, notebook > header tab:checked:hover, tabbar tabbox tab:selected, notebook > header tab:selected, notebook > header tab:selected:hover {
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
 }
 
 tabbar tabbox tab:checked:disabled, notebook > header tab:checked:disabled, tabbar tabbox tab:selected:disabled, notebook > header tab:selected:disabled {
@@ -2732,7 +2732,7 @@ frame > paned > notebook > header, notebook.frame > header {
 }
 
 notebook, notebook.frame {
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
   border-radius: 2px;
 }
 
@@ -3992,7 +3992,7 @@ stacksidebar separator.horizontal, button.font separator, button.file separator 
 listview,
 list {
   border-color: rgba(0, 0, 0, 0.12);
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
   color: rgba(0, 0, 0, 0.87);
   box-shadow: none;
 }


### PR DESCRIPTION
Nevermind, this change causes color mismatch between tabs and notebooks in apps like LibreOffice and GPick.

~~No idea what to tell about that, base color was misused in this case, and background one should be used instead.~~
~~P.S.: Sorry for such spam with images, but I need to show an issue.~~

~~# Issues with apps, before and after~~
~~### Before~~
![2025-06-09 13-38-24](https://github.com/user-attachments/assets/54b9aaed-b405-46a3-b12d-e767e5b66cc3)
~~*GNOME Authenticator (GTK4/Libadwaita)*~~

![2025-06-09 13-38-58](https://github.com/user-attachments/assets/d856fc88-897d-4615-a1e6-483cd7afd28c)
~~*SoundConverter settings page (GTK3)*~~

~~### After~~
![2025-06-09 13-44-09](https://github.com/user-attachments/assets/09534e65-5a5d-4ddc-b5e1-bce89e2fa71e)
~~*GNOME Authenticator (GTK4/Libadwaita)*~~

![2025-06-09 13-44-25](https://github.com/user-attachments/assets/1ce4caf0-fe38-411e-a4a4-7b337a7f460d)
~~*SoundConverter settings page (GTK3)*~~

~~# GTK3 and GTK4 Widgets Factories, before and after~~
~~### Before~~
![2025-06-09 13-41-20](https://github.com/user-attachments/assets/a5fb368a-4805-468d-bfcb-39b9b243eb5e)
~~*GTK3 Widgets Factory*~~

![2025-06-09 13-42-23](https://github.com/user-attachments/assets/19233e2d-09d0-46b9-a73f-7a0602e1c27a)
~~*GTK4 Widgets Factory*~~

~~### After~~
![2025-06-09 13-44-50](https://github.com/user-attachments/assets/5e6cc456-6e62-4be1-bdf3-5a1b1b97ec94)
~~*GTK3 Widgets Factory*~~

![2025-06-09 13-45-09](https://github.com/user-attachments/assets/7a387b03-643d-4037-b2fb-e9062d92e79d)
~~*GTK4 Widgets Factory*~~