### PR TITLE
Fix notebook and list colors use `$base` color instead of `$background` one

### DIFF
--- a/src/_sass/gtk/_common-3.20.scss
+++ b/src/_sass/gtk/_common-3.20.scss
@@ -2201,7 +2201,7 @@ notebook {
   frame > paned > & > header,
   &.frame > header { background-color: $base-alt; }
 
-  &, &.frame {
+  &.frame {
     background-color: $base;
     border-radius: $corner-radius;
   }
@@ -3258,7 +3258,7 @@ separator {
 
 list {
   border-color: $divider;
-  background-color: $base;
+  background-color: $background;
 
   row { padding: $space-size / 2 $space-size; }
 

--- a/src/_sass/gtk/_common-4.0.scss
+++ b/src/_sass/gtk/_common-4.0.scss
@@ -2395,7 +2395,7 @@ notebook {
   frame > paned > & > header,
   &.frame > header { background-color: $base-alt; }
 
-  &, &.frame {
+  &.frame {
     background-color: $base;
     border-radius: $corner-radius;
   }
@@ -3519,7 +3519,7 @@ separator {
 listview,
 list {
   border-color: $divider;
-  background-color: $base;
+  background-color: $background;
   color: $text;
   box-shadow: none;
 

--- a/src/gtk/3.0/gtk-Dark-compact.css
+++ b/src/gtk/3.0/gtk-Dark-compact.css
@@ -2395,7 +2395,7 @@ frame > paned > notebook > header, notebook.frame > header {
   background-color: #303030;
 }
 
-notebook, notebook.frame {
+notebook.frame {
   background-color: #2B2B2B;
   border-radius: 2px;
 }
@@ -3572,7 +3572,7 @@ window.background.csd > box.vertical > overlay > stack > box.vertical > box.hori
 
 list {
   border-color: rgba(255, 255, 255, 0.12);
-  background-color: #2B2B2B;
+  background-color: #333333;
 }
 
 list row {

--- a/src/gtk/3.0/gtk-Dark.css
+++ b/src/gtk/3.0/gtk-Dark.css
@@ -2395,7 +2395,7 @@ frame > paned > notebook > header, notebook.frame > header {
   background-color: #303030;
 }
 
-notebook, notebook.frame {
+notebook.frame {
   background-color: #2B2B2B;
   border-radius: 2px;
 }
@@ -3572,7 +3572,7 @@ window.background.csd > box.vertical > overlay > stack > box.vertical > box.hori
 
 list {
   border-color: rgba(255, 255, 255, 0.12);
-  background-color: #2B2B2B;
+  background-color: #333333;
 }
 
 list row {

--- a/src/gtk/3.0/gtk-Light-compact.css
+++ b/src/gtk/3.0/gtk-Light-compact.css
@@ -2395,7 +2395,7 @@ frame > paned > notebook > header, notebook.frame > header {
   background-color: #FAFAFA;
 }
 
-notebook, notebook.frame {
+notebook.frame {
   background-color: #FFFFFF;
   border-radius: 2px;
 }
@@ -3572,7 +3572,7 @@ window.background.csd > box.vertical > overlay > stack > box.vertical > box.hori
 
 list {
   border-color: rgba(0, 0, 0, 0.12);
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
 }
 
 list row {

--- a/src/gtk/3.0/gtk-Light.css
+++ b/src/gtk/3.0/gtk-Light.css
@@ -2395,7 +2395,7 @@ frame > paned > notebook > header, notebook.frame > header {
   background-color: #FAFAFA;
 }
 
-notebook, notebook.frame {
+notebook.frame {
   background-color: #FFFFFF;
   border-radius: 2px;
 }
@@ -3572,7 +3572,7 @@ window.background.csd > box.vertical > overlay > stack > box.vertical > box.hori
 
 list {
   border-color: rgba(0, 0, 0, 0.12);
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
 }
 
 list row {

--- a/src/gtk/3.0/gtk-compact.css
+++ b/src/gtk/3.0/gtk-compact.css
@@ -2396,7 +2396,7 @@ frame > paned > notebook > header, notebook.frame > header {
   background-color: #FAFAFA;
 }
 
-notebook, notebook.frame {
+notebook.frame {
   background-color: #FFFFFF;
   border-radius: 2px;
 }
@@ -3573,7 +3573,7 @@ window.background.csd > box.vertical > overlay > stack > box.vertical > box.hori
 
 list {
   border-color: rgba(0, 0, 0, 0.12);
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
 }
 
 list row {

--- a/src/gtk/3.0/gtk.css
+++ b/src/gtk/3.0/gtk.css
@@ -2396,7 +2396,7 @@ frame > paned > notebook > header, notebook.frame > header {
   background-color: #FAFAFA;
 }
 
-notebook, notebook.frame {
+notebook.frame {
   background-color: #FFFFFF;
   border-radius: 2px;
 }
@@ -3573,7 +3573,7 @@ window.background.csd > box.vertical > overlay > stack > box.vertical > box.hori
 
 list {
   border-color: rgba(0, 0, 0, 0.12);
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
 }
 
 list row {

--- a/src/gtk/4.0/gtk-Dark-compact.css
+++ b/src/gtk/4.0/gtk-Dark-compact.css
@@ -2730,7 +2730,7 @@ frame > paned > notebook > header, notebook.frame > header {
   background-color: #303030;
 }
 
-notebook, notebook.frame {
+notebook.frame {
   background-color: #2B2B2B;
   border-radius: 2px;
 }
@@ -3991,7 +3991,7 @@ stacksidebar separator.horizontal, button.font separator, button.file separator 
 listview,
 list {
   border-color: rgba(255, 255, 255, 0.12);
-  background-color: #2B2B2B;
+  background-color: #333333;
   color: white;
   box-shadow: none;
 }

--- a/src/gtk/4.0/gtk-Dark.css
+++ b/src/gtk/4.0/gtk-Dark.css
@@ -2730,7 +2730,7 @@ frame > paned > notebook > header, notebook.frame > header {
   background-color: #303030;
 }
 
-notebook, notebook.frame {
+notebook.frame {
   background-color: #2B2B2B;
   border-radius: 2px;
 }
@@ -3991,7 +3991,7 @@ stacksidebar separator.horizontal, button.font separator, button.file separator 
 listview,
 list {
   border-color: rgba(255, 255, 255, 0.12);
-  background-color: #2B2B2B;
+  background-color: #333333;
   color: white;
   box-shadow: none;
 }

--- a/src/gtk/4.0/gtk-Light-compact.css
+++ b/src/gtk/4.0/gtk-Light-compact.css
@@ -2730,7 +2730,7 @@ frame > paned > notebook > header, notebook.frame > header {
   background-color: #FAFAFA;
 }
 
-notebook, notebook.frame {
+notebook.frame {
   background-color: #FFFFFF;
   border-radius: 2px;
 }
@@ -3991,7 +3991,7 @@ stacksidebar separator.horizontal, button.font separator, button.file separator 
 listview,
 list {
   border-color: rgba(0, 0, 0, 0.12);
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
   color: rgba(0, 0, 0, 0.87);
   box-shadow: none;
 }

--- a/src/gtk/4.0/gtk-Light.css
+++ b/src/gtk/4.0/gtk-Light.css
@@ -2730,7 +2730,7 @@ frame > paned > notebook > header, notebook.frame > header {
   background-color: #FAFAFA;
 }
 
-notebook, notebook.frame {
+notebook.frame {
   background-color: #FFFFFF;
   border-radius: 2px;
 }
@@ -3991,7 +3991,7 @@ stacksidebar separator.horizontal, button.font separator, button.file separator 
 listview,
 list {
   border-color: rgba(0, 0, 0, 0.12);
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
   color: rgba(0, 0, 0, 0.87);
   box-shadow: none;
 }

--- a/src/gtk/4.0/gtk-compact.css
+++ b/src/gtk/4.0/gtk-compact.css
@@ -2731,7 +2731,7 @@ frame > paned > notebook > header, notebook.frame > header {
   background-color: #FAFAFA;
 }
 
-notebook, notebook.frame {
+notebook.frame {
   background-color: #FFFFFF;
   border-radius: 2px;
 }
@@ -3992,7 +3992,7 @@ stacksidebar separator.horizontal, button.font separator, button.file separator 
 listview,
 list {
   border-color: rgba(0, 0, 0, 0.12);
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
   color: rgba(0, 0, 0, 0.87);
   box-shadow: none;
 }

--- a/src/gtk/4.0/gtk.css
+++ b/src/gtk/4.0/gtk.css
@@ -2731,7 +2731,7 @@ frame > paned > notebook > header, notebook.frame > header {
   background-color: #FAFAFA;
 }
 
-notebook, notebook.frame {
+notebook.frame {
   background-color: #FFFFFF;
   border-radius: 2px;
 }
@@ -3992,7 +3992,7 @@ stacksidebar separator.horizontal, button.font separator, button.file separator 
 listview,
 list {
   border-color: rgba(0, 0, 0, 0.12);
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
   color: rgba(0, 0, 0, 0.87);
   box-shadow: none;
 }


### PR DESCRIPTION
Before continue, I need to mention that issue in GNOME Authenticator was caused by list color, while in SoundConverter it was notebook color. To avoid issues later, I fixed two issues in both GTK3 and GTK4 variants, does not seem to break anything, unlike my previous PR #208 that I have closed because of that.

### Before
![2025-06-09 19-00-15](https://github.com/user-attachments/assets/b37fc006-c900-49cb-a389-931075a7479a)
*GNOME Authenticator (GTK4/Libadwaita)*

![2025-06-09 18-59-53](https://github.com/user-attachments/assets/0fd1c3f1-f9ec-4f07-90cd-c7797e2bd6ab)
*SoundConverter (GTK3)*

### After
![2025-06-09 18-55-01](https://github.com/user-attachments/assets/e7bb3a5d-e577-4dd3-8926-5d241ee0a921)
*GNOME Authenticator (GTK4/Libadwaita)*

![2025-06-09 18-55-28](https://github.com/user-attachments/assets/80057f52-a35d-4366-b3fd-31c3719d87ca)
*SoundConverter (GTK3)*