### PR TITLE
Tweak the prompt-dialog-info-label color to prevent unreadable text

### DIFF
--- a/src/gnome-shell/sass/widgets/_dialogs-47.scss
+++ b/src/gnome-shell/sass/widgets/_dialogs-47.scss
@@ -185,6 +185,11 @@
   color: $warning_color;
 }
 
+.prompt-dialog-info-label {
+  color: $primary_color;
+  background-color: transparentize($fg_color, 0.9);
+}
+
 /* Polkit Dialog */
 .polkit-dialog-user-layout {
   text-align: center;


### PR DESCRIPTION
Previously, no color was defined for `.prompt-dialog-info-label`, causing text to be by default a light color and unreadable in non-dark themes. This makes text darker in non-dark themes.

(The CSS files need to be manually updated)