### PR TITLE
Gnome weather fix

### DIFF
--- a/src/_sass/gtk/apps/_gnome-40.0.scss
+++ b/src/_sass/gtk/apps/_gnome-40.0.scss
@@ -149,7 +149,7 @@ navigation-view-page > toolbarview > scrolledwindow > viewport > clamp {
 
 $weather_thermometer_high_color: $yellow-700;
 $weather_thermometer_low_color: $blue-700;
-$weather_forecast_color: #ae7b03;
+$weather_forecast_color: if($variant == 'light', #ae7b03, #fdd835);
 
 #places-label {
   font-weight: bold;

--- a/src/gtk/4.0/gtk-Dark-compact.css
+++ b/src/gtk/4.0/gtk-Dark-compact.css
@@ -5253,7 +5253,7 @@ navigation-view-page > toolbarview > scrolledwindow > viewport > clamp > box > b
 
 .forecast-temperature-label {
   font-weight: bold;
-  color: #ae7b03;
+  color: #fdd835;
 }
 
 WeatherThermometer {

--- a/src/gtk/4.0/gtk-Dark.css
+++ b/src/gtk/4.0/gtk-Dark.css
@@ -5253,7 +5253,7 @@ navigation-view-page > toolbarview > scrolledwindow > viewport > clamp > box > b
 
 .forecast-temperature-label {
   font-weight: bold;
-  color: #ae7b03;
+  color: #fdd835;
 }
 
 WeatherThermometer {


### PR DESCRIPTION
Fixes #222

Before:
<img width="1087" height="664" alt="old" src="https://github.com/user-attachments/assets/96b5fb76-dad4-4f76-9ece-2f290d9d8d00" />

After:
<img width="1087" height="664" alt="new" src="https://github.com/user-attachments/assets/657fc0c1-a5f9-41c8-a4bf-d07d0e4733e4" />

Does not break light mode, only fixes dark mode.