### PR TITLE
GTK3 tweaks and fixes.

### DIFF
--- a/src/_sass/gtk/_common-3.20.scss
+++ b/src/_sass/gtk/_common-3.20.scss
@@ -2580,14 +2580,17 @@ $tab-radius: $corner-radius;
   }
 }
 
-notebook {
+frame notebook:not(.frame) {
+  background-color: $base;
+}
 
-  frame > paned > & > header,
+notebook {
+  frame > paned > &.frame > header,
   &.frame > header {
     background-color: $base-alt;
   }
 
-  &, &.frame {
+  &.frame {
     background-color: $base;
     border-radius: $corner-radius;
   }
@@ -2605,6 +2608,11 @@ notebook {
         border-radius: $corner-radius;
       }
     }
+  }
+
+  // in the hope 1st child of 'notebook' is 'header' and 2nd one - 'stack'
+  &:not(.frame):nth-child(1) > stack:nth-child(2) {
+    background-color: $base;
   }
 
   &:focus tab:checked {
@@ -3677,13 +3685,17 @@ actionbar > revealer > box {
 }
 
 scrolledwindow {
+  &.frame {
+    // just transparent without this
+    background-color: $base;
+  }
+
   viewport.frame {
     // avoid double borders when viewport inside scrolled window
     border: none;
   }
 
   stack &.frame {
-
     // border-radius: $corner-radius;
     viewport.frame list {
       border: none;
@@ -4795,51 +4807,64 @@ stackswitcher {
   min-height: 0;
   padding: 0 $space-size;
   // margin: $space-size 0;
-  border-radius: $corner-radius;
-  background-color: $overlay-normal;
 
   &.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action) {
     margin: 0;
-    background-color: transparent;
+    background-color: gtkalpha($text, 0.05);
     background-image: none;
-    border: none;
     animation: none;
     box-shadow: none;
     transition: box-shadow $ripple-fade-in-duration $ease-out;
-
-    &, &:first-child, &:last-child {
-      border-radius: 0;
-    }
 
     &.text-button {
       min-width: 100px;
     }
 
+    &:first-child {
+      border-left: $space-size solid gtkalpha($text, 0.05);
+      border-top-left-radius: $corner-radius;
+      border-bottom-left-radius: $corner-radius;
+    }
+
+    &:last-child {
+      border-right: $space-size solid gtkalpha($text, 0.05);
+      border-top-right-radius: $corner-radius;
+      border-bottom-right-radius: $corner-radius;
+    }
+
     &:focus {
       box-shadow: inset 0 -2px $overlay-focus;
-      background-color: transparent;
       background-image: none;
+      background-color: gtkalpha($text, 0.05);
     }
 
     &:hover {
       box-shadow: inset 0 -2px gtkalpha(currentColor, 0.3);
-      background-color: transparent;
       background-image: none;
+      background-color: gtkalpha($text, 0.05);
     }
 
     &:active {
       box-shadow: inset 0 -2px gtkalpha($primary, 0.65);
-      background-color: transparent;
       background-image: none;
       transition: box-shadow $ripple-fade-in-duration $ease-out;
+      background-color: gtkalpha($text, 0.05);
     }
 
     &:checked {
       box-shadow: inset 0 -2px $primary;
-      background-color: transparent;
       background-image: none;
       color: $text;
       transition: box-shadow $ripple-fade-in-duration $ease-out;
+      background-color: gtkalpha($text, 0.05);
+
+      &:first-child {
+        border-left: $space-size solid transparent;
+      }
+
+      &:last-child {
+        border-right: $space-size solid transparent;
+      }
     }
   }
 

--- a/src/_sass/gtk/apps/_misc.scss
+++ b/src/_sass/gtk/apps/_misc.scss
@@ -321,6 +321,20 @@ window.background:not(.csd) {
   }
 }
 
+#DialogNotebook > viewport.frame {
+  border: 1px solid $border;
+  border-radius: $corner-radius;
+}
+
+#DockedDialogNotebook {
+  button.close-button {
+    background-color: transparent;
+  }
+  header {
+    background-color: $base-alt;
+  }
+}
+
 
 /***********
  * Synapse *
@@ -395,7 +409,8 @@ window.background:not(.solid-csd):not(.csd) {
     // FIXME: Breaks DroidCam style and does not change anything in LibreOffice
     /*
     background-color: $titlebar;
-    box-shadow: inset 0 -1px $divider;*/
+    box-shadow: inset 0 -1px $divider;
+    */
 
     > button.flat.small-button {
       // 'close' button
@@ -403,9 +418,12 @@ window.background:not(.solid-csd):not(.csd) {
       border-radius: $circular-radius;
     }
 
+    // FIXME: Breaks DroidCam style and does not change anything in LibreOffice
+    /*
     &:backdrop {
       background-color: $titlebar-backdrop;
     }
+    */
   }
 
   // for 'Notebookbar' toolbar
@@ -437,16 +455,6 @@ window.background:not(.solid-csd):not(.csd) {
       label { color: on($primary); }
     }
   }
-}
-
-
-/************
- * DroidCam *
- ************/
-window.background > grid.horizontal > grid.horizontal {
-  // fixes radio/checkbox button backgrounds
-  box-shadow: none;
-  background-color: transparent;
 }
 
 
@@ -485,4 +493,98 @@ frame > widget > box.vertical > notebook > stack {
 box.dialog-vbox.vertical > box.horizontal > list {
   // border right after list in settings window
   border-right: 1px solid $border;
+}
+#lutris > stack:nth-child(2) > box.horizontal:nth-child(1) > box.vertical:nth-child(2) > revealer:nth-last-child(1) > box.horizontal {
+  // panel with "Play" button and other stuff that appears after click on game title
+  border-top: 1px solid $border;
+}
+
+
+/***********
+ * Brasero *
+ ***********/
+// FIXME: App is broken, rules work only if set as "GTK_STYLE_PROVIDER_PRIORITY_USER" (either CSS in "~/.config/gtk-3.0/gtk.css" or in GTK Inspector)
+window.background > box.vertical:nth-child(2) > notebook:nth-child(2) > stack:nth-child(1) > box.vertical:nth-child(2) > paned.horizontal:nth-child(2) > box.vertical > box.vertical:nth-child(1) > notebook:nth-child(2) > stack:nth-child(1) > frame:nth-child(1) > widget:nth-child(2) {
+  // fix white background in "New Project"
+  background-color: $base;
+}
+
+
+/*********
+ * Gpick *
+ *********/
+window.background > box.vertical:nth-child(2) > paned.horizontal:nth-child(2) > notebook.frame:nth-child(1) > stack:nth-child(2) > box.vertical:nth-child(3) > box.horizontal:nth-child(1) > widget:nth-child(1) > toolbar.horizontal:nth-child(1) {
+  // "New palette" tab, layout selection
+  background-color: transparent;
+}
+
+
+/***************
+ * Filechooser *
+ ***************/
+dialog > box > filechooser {
+  // add border to the bottom because it is absent in case file picker does not expect any file extension
+  // FIXME: Causes border above "Ok"/"Cancel" buttons when file extension is expected
+  border-bottom: 1px solid $border;
+}
+
+
+/*******
+ * Xed *
+ *******/
+window.background.xed-window > overlay:nth-child(2) > box.vertical:nth-child(1) > box.horizontal.xed-searchbar:nth-child(4) {
+  // search bar border, visible when search bar is hidden
+  border-top: 1px solid $border;
+}
+
+
+/*****************
+ * GNOME Drawing *
+ *****************/
+window.background > box.vertical:nth-child(2) > box.vertical.primary-toolbar:nth-child(1) {
+  // toolbar background
+  background-color: $titlebar;
+  &:backdrop {
+    background-color: $titlebar-backdrop;
+  }
+
+  // elements background on this toolbar
+  > box:nth-child(1) > toolbar.horizontal:nth-child(1) {
+    background-color: $titlebar;
+    &:backdrop {
+      background-color: $titlebar-backdrop;
+    }
+  }
+}
+
+
+/********
+ * Meld *
+ ********/
+// FIXME: App is broken, rules work only if set as "GTK_STYLE_PROVIDER_PRIORITY_USER" (either CSS in "~/.config/gtk-3.0/gtk.css" or in GTK Inspector)
+#meldapp.background.csd {
+  &, & > box.vertical:nth-child(3) > notebook.meld-notebook:nth-child(1) > stack:nth-child(2) {
+    // it has tabs and background color should match them
+    background-color: $base;
+  }
+}
+
+
+/*******************
+ * NVIDIA Settings *
+ *******************/
+// "Application Profiles" section
+window.background > box.vertical > paned.horizontal:nth-child(1) > box.horizontal:nth-child(3) > box.vertical:nth-child(1) > notebook.frame:nth-child(4) > stack:nth-child(2) > box.vertical > toolbar.horizontal:nth-child(1) {
+  // toolbar background and bottom border in "Rules/Profiles" table
+  background-color: $titlebar-backdrop;
+  border-bottom: 1px solid $border;
+}
+
+
+/*****************************************************
+ * Cinnamon "System Settings > Keyboard > Shortcuts" *
+ *****************************************************/
+window.background > box.vertical:nth-child(2) > stack:nth-child(2) > scrolledwindow:nth-child(2) > viewport:nth-last-child(3) > box.vertical:nth-child(1) > stack:nth-child(1) > box.vertical:nth-child(2) > box.vertical:nth-child(1) > box.horizontal:nth-child(1) > paned.horizontal:nth-child(1) > separator.wide:nth-child(2) {
+  // fix separator between "Categories" and "Keyboard shortcuts" tables has left and right borders
+  background-image: none;
 }

--- a/src/_sass/gtk/apps/_nemo.scss
+++ b/src/_sass/gtk/apps/_nemo.scss
@@ -98,3 +98,8 @@
 .nemo-desktop.nemo-canvas-item {
   @extend %desktop-canvas-item;
 }
+
+// Fix solid color background displayed over wallpaper if theme is applied as "~/.config/gtk-3.0/{assets,gtk.css}"
+.nemo-desktop-window {
+  opacity: 0;
+}

--- a/src/gtk/3.0/gtk-Dark-compact.css
+++ b/src/gtk/3.0/gtk-Dark-compact.css
@@ -2408,11 +2408,15 @@ tabbox > tab:checked.reorderable-page, notebook > header tab:checked.reorderable
   background-color: #2B2B2B;
 }
 
-frame > paned > notebook > header, notebook.frame > header {
+frame notebook:not(.frame) {
+  background-color: #2B2B2B;
+}
+
+frame > paned > notebook.frame > header, notebook.frame > header {
   background-color: #303030;
 }
 
-notebook, notebook.frame {
+notebook.frame {
   background-color: #2B2B2B;
   border-radius: 2px;
 }
@@ -2424,6 +2428,10 @@ notebook.frame frame > border {
 
 notebook.frame frame > list row.activatable {
   border-radius: 2px;
+}
+
+notebook:not(.frame):nth-child(1) > stack:nth-child(2) {
+  background-color: #2B2B2B;
 }
 
 notebook:focus tab:checked {
@@ -3466,6 +3474,10 @@ actionbar > revealer > box {
   border-radius: 0 0 3px 3px;
 }
 
+scrolledwindow.frame {
+  background-color: #2B2B2B;
+}
+
 scrolledwindow viewport.frame {
   border: none;
 }
@@ -4344,53 +4356,66 @@ cursor-handle.insertion-cursor:dir(ltr), cursor-handle.insertion-cursor:dir(rtl)
 stackswitcher {
   min-height: 0;
   padding: 0 4px;
-  border-radius: 2px;
-  background-color: alpha(currentColor, 0.05);
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action) {
   margin: 0;
-  background-color: transparent;
+  background-color: alpha(white, 0.05);
   background-image: none;
-  border: none;
   animation: none;
   box-shadow: none;
   transition: box-shadow 225ms cubic-bezier(0, 0, 0.2, 1);
-}
-
-stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action), stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):first-child, stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):last-child {
-  border-radius: 0;
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action).text-button {
   min-width: 100px;
 }
 
+stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):first-child {
+  border-left: 4px solid alpha(white, 0.05);
+  border-top-left-radius: 2px;
+  border-bottom-left-radius: 2px;
+}
+
+stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):last-child {
+  border-right: 4px solid alpha(white, 0.05);
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
+}
+
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):focus {
   box-shadow: inset 0 -2px alpha(currentColor, 0.08);
-  background-color: transparent;
   background-image: none;
+  background-color: alpha(white, 0.05);
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):hover {
   box-shadow: inset 0 -2px alpha(currentColor, 0.3);
-  background-color: transparent;
   background-image: none;
+  background-color: alpha(white, 0.05);
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):active {
   box-shadow: inset 0 -2px alpha(#3281EA, 0.65);
-  background-color: transparent;
   background-image: none;
   transition: box-shadow 225ms cubic-bezier(0, 0, 0.2, 1);
+  background-color: alpha(white, 0.05);
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):checked {
   box-shadow: inset 0 -2px #3281EA;
-  background-color: transparent;
   background-image: none;
   color: white;
   transition: box-shadow 225ms cubic-bezier(0, 0, 0.2, 1);
+  background-color: alpha(white, 0.05);
+}
+
+stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):checked:first-child {
+  border-left: 4px solid transparent;
+}
+
+stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):checked:last-child {
+  border-right: 4px solid transparent;
 }
 
 stackswitcher button.text-button {
@@ -6458,6 +6483,19 @@ window.background:not(.csd) > window > menu menuitem {
   padding: 8px 4px;
 }
 
+#DialogNotebook > viewport.frame {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 2px;
+}
+
+#DockedDialogNotebook button.close-button {
+  background-color: transparent;
+}
+
+#DockedDialogNotebook header {
+  background-color: #303030;
+}
+
 /***********
  * Synapse *
  ***********/
@@ -6509,16 +6547,18 @@ entry.search > window.background > frame > border {
 window.background:not(.solid-csd):not(.csd) > grid.horizontal > grid.horizontal {
   /*
     background-color: $titlebar;
-    box-shadow: inset 0 -1px $divider;*/
+    box-shadow: inset 0 -1px $divider;
+    */
+  /*
+    &:backdrop {
+      background-color: $titlebar-backdrop;
+    }
+    */
 }
 
 window.background:not(.solid-csd):not(.csd) > grid.horizontal > grid.horizontal > button.flat.small-button {
   border: none;
   border-radius: 9999px;
-}
-
-window.background:not(.solid-csd):not(.csd) > grid.horizontal > grid.horizontal:backdrop {
-  background-color: #2C2C2C;
 }
 
 window.background:not(.solid-csd):not(.csd) > notebook:not(.frame) {
@@ -6550,14 +6590,6 @@ window.background:not(.solid-csd):not(.csd) > notebook:not(.frame) > stack {
   color: white;
 }
 
-/************
- * DroidCam *
- ************/
-window.background > grid.horizontal > grid.horizontal {
-  box-shadow: none;
-  background-color: transparent;
-}
-
 /******************
  * SoundConverter *
  ******************/
@@ -6583,6 +6615,79 @@ frame > widget > box.vertical > notebook > stack {
  **********/
 box.dialog-vbox.vertical > box.horizontal > list {
   border-right: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+#lutris > stack:nth-child(2) > box.horizontal:nth-child(1) > box.vertical:nth-child(2) > revealer:nth-last-child(1) > box.horizontal {
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+/***********
+ * Brasero *
+ ***********/
+window.background > box.vertical:nth-child(2) > notebook:nth-child(2) > stack:nth-child(1) > box.vertical:nth-child(2) > paned.horizontal:nth-child(2) > box.vertical > box.vertical:nth-child(1) > notebook:nth-child(2) > stack:nth-child(1) > frame:nth-child(1) > widget:nth-child(2) {
+  background-color: #2B2B2B;
+}
+
+/*********
+ * Gpick *
+ *********/
+window.background > box.vertical:nth-child(2) > paned.horizontal:nth-child(2) > notebook.frame:nth-child(1) > stack:nth-child(2) > box.vertical:nth-child(3) > box.horizontal:nth-child(1) > widget:nth-child(1) > toolbar.horizontal:nth-child(1) {
+  background-color: transparent;
+}
+
+/***************
+ * Filechooser *
+ ***************/
+dialog > box > filechooser {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+/*******
+ * Xed *
+ *******/
+window.background.xed-window > overlay:nth-child(2) > box.vertical:nth-child(1) > box.horizontal.xed-searchbar:nth-child(4) {
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+/*****************
+ * GNOME Drawing *
+ *****************/
+window.background > box.vertical:nth-child(2) > box.vertical.primary-toolbar:nth-child(1) {
+  background-color: #202020;
+}
+
+window.background > box.vertical:nth-child(2) > box.vertical.primary-toolbar:nth-child(1):backdrop {
+  background-color: #2C2C2C;
+}
+
+window.background > box.vertical:nth-child(2) > box.vertical.primary-toolbar:nth-child(1) > box:nth-child(1) > toolbar.horizontal:nth-child(1) {
+  background-color: #202020;
+}
+
+window.background > box.vertical:nth-child(2) > box.vertical.primary-toolbar:nth-child(1) > box:nth-child(1) > toolbar.horizontal:nth-child(1):backdrop {
+  background-color: #2C2C2C;
+}
+
+/********
+ * Meld *
+ ********/
+#meldapp.background.csd, #meldapp.background.csd > box.vertical:nth-child(3) > notebook.meld-notebook:nth-child(1) > stack:nth-child(2) {
+  background-color: #2B2B2B;
+}
+
+/*******************
+ * NVIDIA Settings *
+ *******************/
+window.background > box.vertical > paned.horizontal:nth-child(1) > box.horizontal:nth-child(3) > box.vertical:nth-child(1) > notebook.frame:nth-child(4) > stack:nth-child(2) > box.vertical > toolbar.horizontal:nth-child(1) {
+  background-color: #2C2C2C;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+/*****************************************************
+ * Cinnamon "System Settings > Keyboard > Shortcuts" *
+ *****************************************************/
+window.background > box.vertical:nth-child(2) > stack:nth-child(2) > scrolledwindow:nth-child(2) > viewport:nth-last-child(3) > box.vertical:nth-child(1) > stack:nth-child(1) > box.vertical:nth-child(2) > box.vertical:nth-child(1) > box.horizontal:nth-child(1) > paned.horizontal:nth-child(1) > separator.wide:nth-child(2) {
+  background-image: none;
 }
 
 /*********
@@ -8305,6 +8410,10 @@ window.background.csd.thunar scrolledwindow.frame.sidebar.shortcuts-pane {
   -NemoPlacesTreeView-disk-full-bar-radius: 0;
   -NemoPlacesTreeView-disk-full-bottom-padding: 1px;
   -NemoPlacesTreeView-disk-full-max-length: 80px;
+}
+
+.nemo-desktop-window {
+  opacity: 0;
 }
 
 /* GTK NAMED COLORS

--- a/src/gtk/3.0/gtk-Dark.css
+++ b/src/gtk/3.0/gtk-Dark.css
@@ -2408,11 +2408,15 @@ tabbox > tab:checked.reorderable-page, notebook > header tab:checked.reorderable
   background-color: #2B2B2B;
 }
 
-frame > paned > notebook > header, notebook.frame > header {
+frame notebook:not(.frame) {
+  background-color: #2B2B2B;
+}
+
+frame > paned > notebook.frame > header, notebook.frame > header {
   background-color: #303030;
 }
 
-notebook, notebook.frame {
+notebook.frame {
   background-color: #2B2B2B;
   border-radius: 2px;
 }
@@ -2424,6 +2428,10 @@ notebook.frame frame > border {
 
 notebook.frame frame > list row.activatable {
   border-radius: 2px;
+}
+
+notebook:not(.frame):nth-child(1) > stack:nth-child(2) {
+  background-color: #2B2B2B;
 }
 
 notebook:focus tab:checked {
@@ -3466,6 +3474,10 @@ actionbar > revealer > box {
   border-radius: 0 0 3px 3px;
 }
 
+scrolledwindow.frame {
+  background-color: #2B2B2B;
+}
+
 scrolledwindow viewport.frame {
   border: none;
 }
@@ -4344,53 +4356,66 @@ cursor-handle.insertion-cursor:dir(ltr), cursor-handle.insertion-cursor:dir(rtl)
 stackswitcher {
   min-height: 0;
   padding: 0 6px;
-  border-radius: 2px;
-  background-color: alpha(currentColor, 0.05);
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action) {
   margin: 0;
-  background-color: transparent;
+  background-color: alpha(white, 0.05);
   background-image: none;
-  border: none;
   animation: none;
   box-shadow: none;
   transition: box-shadow 225ms cubic-bezier(0, 0, 0.2, 1);
-}
-
-stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action), stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):first-child, stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):last-child {
-  border-radius: 0;
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action).text-button {
   min-width: 100px;
 }
 
+stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):first-child {
+  border-left: 6px solid alpha(white, 0.05);
+  border-top-left-radius: 2px;
+  border-bottom-left-radius: 2px;
+}
+
+stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):last-child {
+  border-right: 6px solid alpha(white, 0.05);
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
+}
+
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):focus {
   box-shadow: inset 0 -2px alpha(currentColor, 0.08);
-  background-color: transparent;
   background-image: none;
+  background-color: alpha(white, 0.05);
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):hover {
   box-shadow: inset 0 -2px alpha(currentColor, 0.3);
-  background-color: transparent;
   background-image: none;
+  background-color: alpha(white, 0.05);
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):active {
   box-shadow: inset 0 -2px alpha(#3281EA, 0.65);
-  background-color: transparent;
   background-image: none;
   transition: box-shadow 225ms cubic-bezier(0, 0, 0.2, 1);
+  background-color: alpha(white, 0.05);
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):checked {
   box-shadow: inset 0 -2px #3281EA;
-  background-color: transparent;
   background-image: none;
   color: white;
   transition: box-shadow 225ms cubic-bezier(0, 0, 0.2, 1);
+  background-color: alpha(white, 0.05);
+}
+
+stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):checked:first-child {
+  border-left: 6px solid transparent;
+}
+
+stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):checked:last-child {
+  border-right: 6px solid transparent;
 }
 
 stackswitcher button.text-button {
@@ -6458,6 +6483,19 @@ window.background:not(.csd) > window > menu menuitem {
   padding: 8px 4px;
 }
 
+#DialogNotebook > viewport.frame {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 2px;
+}
+
+#DockedDialogNotebook button.close-button {
+  background-color: transparent;
+}
+
+#DockedDialogNotebook header {
+  background-color: #303030;
+}
+
 /***********
  * Synapse *
  ***********/
@@ -6509,16 +6547,18 @@ entry.search > window.background > frame > border {
 window.background:not(.solid-csd):not(.csd) > grid.horizontal > grid.horizontal {
   /*
     background-color: $titlebar;
-    box-shadow: inset 0 -1px $divider;*/
+    box-shadow: inset 0 -1px $divider;
+    */
+  /*
+    &:backdrop {
+      background-color: $titlebar-backdrop;
+    }
+    */
 }
 
 window.background:not(.solid-csd):not(.csd) > grid.horizontal > grid.horizontal > button.flat.small-button {
   border: none;
   border-radius: 9999px;
-}
-
-window.background:not(.solid-csd):not(.csd) > grid.horizontal > grid.horizontal:backdrop {
-  background-color: #2C2C2C;
 }
 
 window.background:not(.solid-csd):not(.csd) > notebook:not(.frame) {
@@ -6550,14 +6590,6 @@ window.background:not(.solid-csd):not(.csd) > notebook:not(.frame) > stack {
   color: white;
 }
 
-/************
- * DroidCam *
- ************/
-window.background > grid.horizontal > grid.horizontal {
-  box-shadow: none;
-  background-color: transparent;
-}
-
 /******************
  * SoundConverter *
  ******************/
@@ -6583,6 +6615,79 @@ frame > widget > box.vertical > notebook > stack {
  **********/
 box.dialog-vbox.vertical > box.horizontal > list {
   border-right: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+#lutris > stack:nth-child(2) > box.horizontal:nth-child(1) > box.vertical:nth-child(2) > revealer:nth-last-child(1) > box.horizontal {
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+/***********
+ * Brasero *
+ ***********/
+window.background > box.vertical:nth-child(2) > notebook:nth-child(2) > stack:nth-child(1) > box.vertical:nth-child(2) > paned.horizontal:nth-child(2) > box.vertical > box.vertical:nth-child(1) > notebook:nth-child(2) > stack:nth-child(1) > frame:nth-child(1) > widget:nth-child(2) {
+  background-color: #2B2B2B;
+}
+
+/*********
+ * Gpick *
+ *********/
+window.background > box.vertical:nth-child(2) > paned.horizontal:nth-child(2) > notebook.frame:nth-child(1) > stack:nth-child(2) > box.vertical:nth-child(3) > box.horizontal:nth-child(1) > widget:nth-child(1) > toolbar.horizontal:nth-child(1) {
+  background-color: transparent;
+}
+
+/***************
+ * Filechooser *
+ ***************/
+dialog > box > filechooser {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+/*******
+ * Xed *
+ *******/
+window.background.xed-window > overlay:nth-child(2) > box.vertical:nth-child(1) > box.horizontal.xed-searchbar:nth-child(4) {
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+/*****************
+ * GNOME Drawing *
+ *****************/
+window.background > box.vertical:nth-child(2) > box.vertical.primary-toolbar:nth-child(1) {
+  background-color: #202020;
+}
+
+window.background > box.vertical:nth-child(2) > box.vertical.primary-toolbar:nth-child(1):backdrop {
+  background-color: #2C2C2C;
+}
+
+window.background > box.vertical:nth-child(2) > box.vertical.primary-toolbar:nth-child(1) > box:nth-child(1) > toolbar.horizontal:nth-child(1) {
+  background-color: #202020;
+}
+
+window.background > box.vertical:nth-child(2) > box.vertical.primary-toolbar:nth-child(1) > box:nth-child(1) > toolbar.horizontal:nth-child(1):backdrop {
+  background-color: #2C2C2C;
+}
+
+/********
+ * Meld *
+ ********/
+#meldapp.background.csd, #meldapp.background.csd > box.vertical:nth-child(3) > notebook.meld-notebook:nth-child(1) > stack:nth-child(2) {
+  background-color: #2B2B2B;
+}
+
+/*******************
+ * NVIDIA Settings *
+ *******************/
+window.background > box.vertical > paned.horizontal:nth-child(1) > box.horizontal:nth-child(3) > box.vertical:nth-child(1) > notebook.frame:nth-child(4) > stack:nth-child(2) > box.vertical > toolbar.horizontal:nth-child(1) {
+  background-color: #2C2C2C;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+/*****************************************************
+ * Cinnamon "System Settings > Keyboard > Shortcuts" *
+ *****************************************************/
+window.background > box.vertical:nth-child(2) > stack:nth-child(2) > scrolledwindow:nth-child(2) > viewport:nth-last-child(3) > box.vertical:nth-child(1) > stack:nth-child(1) > box.vertical:nth-child(2) > box.vertical:nth-child(1) > box.horizontal:nth-child(1) > paned.horizontal:nth-child(1) > separator.wide:nth-child(2) {
+  background-image: none;
 }
 
 /*********
@@ -8305,6 +8410,10 @@ window.background.csd.thunar scrolledwindow.frame.sidebar.shortcuts-pane {
   -NemoPlacesTreeView-disk-full-bar-radius: 0;
   -NemoPlacesTreeView-disk-full-bottom-padding: 1px;
   -NemoPlacesTreeView-disk-full-max-length: 80px;
+}
+
+.nemo-desktop-window {
+  opacity: 0;
 }
 
 /* GTK NAMED COLORS

--- a/src/gtk/3.0/gtk-Light-compact.css
+++ b/src/gtk/3.0/gtk-Light-compact.css
@@ -2408,11 +2408,15 @@ tabbox > tab:checked.reorderable-page, notebook > header tab:checked.reorderable
   background-color: #FFFFFF;
 }
 
-frame > paned > notebook > header, notebook.frame > header {
+frame notebook:not(.frame) {
+  background-color: #FFFFFF;
+}
+
+frame > paned > notebook.frame > header, notebook.frame > header {
   background-color: #FAFAFA;
 }
 
-notebook, notebook.frame {
+notebook.frame {
   background-color: #FFFFFF;
   border-radius: 2px;
 }
@@ -2424,6 +2428,10 @@ notebook.frame frame > border {
 
 notebook.frame frame > list row.activatable {
   border-radius: 2px;
+}
+
+notebook:not(.frame):nth-child(1) > stack:nth-child(2) {
+  background-color: #FFFFFF;
 }
 
 notebook:focus tab:checked {
@@ -3466,6 +3474,10 @@ actionbar > revealer > box {
   border-radius: 0 0 3px 3px;
 }
 
+scrolledwindow.frame {
+  background-color: #FFFFFF;
+}
+
 scrolledwindow viewport.frame {
   border: none;
 }
@@ -4344,53 +4356,66 @@ cursor-handle.insertion-cursor:dir(ltr), cursor-handle.insertion-cursor:dir(rtl)
 stackswitcher {
   min-height: 0;
   padding: 0 4px;
-  border-radius: 2px;
-  background-color: alpha(currentColor, 0.05);
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action) {
   margin: 0;
-  background-color: transparent;
+  background-color: alpha(rgba(0, 0, 0, 0.87), 0.05);
   background-image: none;
-  border: none;
   animation: none;
   box-shadow: none;
   transition: box-shadow 225ms cubic-bezier(0, 0, 0.2, 1);
-}
-
-stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action), stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):first-child, stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):last-child {
-  border-radius: 0;
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action).text-button {
   min-width: 100px;
 }
 
+stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):first-child {
+  border-left: 4px solid alpha(rgba(0, 0, 0, 0.87), 0.05);
+  border-top-left-radius: 2px;
+  border-bottom-left-radius: 2px;
+}
+
+stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):last-child {
+  border-right: 4px solid alpha(rgba(0, 0, 0, 0.87), 0.05);
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
+}
+
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):focus {
   box-shadow: inset 0 -2px alpha(currentColor, 0.08);
-  background-color: transparent;
   background-image: none;
+  background-color: alpha(rgba(0, 0, 0, 0.87), 0.05);
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):hover {
   box-shadow: inset 0 -2px alpha(currentColor, 0.3);
-  background-color: transparent;
   background-image: none;
+  background-color: alpha(rgba(0, 0, 0, 0.87), 0.05);
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):active {
   box-shadow: inset 0 -2px alpha(#1A73E8, 0.65);
-  background-color: transparent;
   background-image: none;
   transition: box-shadow 225ms cubic-bezier(0, 0, 0.2, 1);
+  background-color: alpha(rgba(0, 0, 0, 0.87), 0.05);
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):checked {
   box-shadow: inset 0 -2px #1A73E8;
-  background-color: transparent;
   background-image: none;
   color: rgba(0, 0, 0, 0.87);
   transition: box-shadow 225ms cubic-bezier(0, 0, 0.2, 1);
+  background-color: alpha(rgba(0, 0, 0, 0.87), 0.05);
+}
+
+stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):checked:first-child {
+  border-left: 4px solid transparent;
+}
+
+stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):checked:last-child {
+  border-right: 4px solid transparent;
 }
 
 stackswitcher button.text-button {
@@ -6458,6 +6483,19 @@ window.background:not(.csd) > window > menu menuitem {
   padding: 8px 4px;
 }
 
+#DialogNotebook > viewport.frame {
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 2px;
+}
+
+#DockedDialogNotebook button.close-button {
+  background-color: transparent;
+}
+
+#DockedDialogNotebook header {
+  background-color: #FAFAFA;
+}
+
 /***********
  * Synapse *
  ***********/
@@ -6509,16 +6547,18 @@ entry.search > window.background > frame > border {
 window.background:not(.solid-csd):not(.csd) > grid.horizontal > grid.horizontal {
   /*
     background-color: $titlebar;
-    box-shadow: inset 0 -1px $divider;*/
+    box-shadow: inset 0 -1px $divider;
+    */
+  /*
+    &:backdrop {
+      background-color: $titlebar-backdrop;
+    }
+    */
 }
 
 window.background:not(.solid-csd):not(.csd) > grid.horizontal > grid.horizontal > button.flat.small-button {
   border: none;
   border-radius: 9999px;
-}
-
-window.background:not(.solid-csd):not(.csd) > grid.horizontal > grid.horizontal:backdrop {
-  background-color: #F2F2F2;
 }
 
 window.background:not(.solid-csd):not(.csd) > notebook:not(.frame) {
@@ -6550,14 +6590,6 @@ window.background:not(.solid-csd):not(.csd) > notebook:not(.frame) > stack {
   color: white;
 }
 
-/************
- * DroidCam *
- ************/
-window.background > grid.horizontal > grid.horizontal {
-  box-shadow: none;
-  background-color: transparent;
-}
-
 /******************
  * SoundConverter *
  ******************/
@@ -6583,6 +6615,79 @@ frame > widget > box.vertical > notebook > stack {
  **********/
 box.dialog-vbox.vertical > box.horizontal > list {
   border-right: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+#lutris > stack:nth-child(2) > box.horizontal:nth-child(1) > box.vertical:nth-child(2) > revealer:nth-last-child(1) > box.horizontal {
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+/***********
+ * Brasero *
+ ***********/
+window.background > box.vertical:nth-child(2) > notebook:nth-child(2) > stack:nth-child(1) > box.vertical:nth-child(2) > paned.horizontal:nth-child(2) > box.vertical > box.vertical:nth-child(1) > notebook:nth-child(2) > stack:nth-child(1) > frame:nth-child(1) > widget:nth-child(2) {
+  background-color: #FFFFFF;
+}
+
+/*********
+ * Gpick *
+ *********/
+window.background > box.vertical:nth-child(2) > paned.horizontal:nth-child(2) > notebook.frame:nth-child(1) > stack:nth-child(2) > box.vertical:nth-child(3) > box.horizontal:nth-child(1) > widget:nth-child(1) > toolbar.horizontal:nth-child(1) {
+  background-color: transparent;
+}
+
+/***************
+ * Filechooser *
+ ***************/
+dialog > box > filechooser {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+/*******
+ * Xed *
+ *******/
+window.background.xed-window > overlay:nth-child(2) > box.vertical:nth-child(1) > box.horizontal.xed-searchbar:nth-child(4) {
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+/*****************
+ * GNOME Drawing *
+ *****************/
+window.background > box.vertical:nth-child(2) > box.vertical.primary-toolbar:nth-child(1) {
+  background-color: #F7F7F7;
+}
+
+window.background > box.vertical:nth-child(2) > box.vertical.primary-toolbar:nth-child(1):backdrop {
+  background-color: #F2F2F2;
+}
+
+window.background > box.vertical:nth-child(2) > box.vertical.primary-toolbar:nth-child(1) > box:nth-child(1) > toolbar.horizontal:nth-child(1) {
+  background-color: #F7F7F7;
+}
+
+window.background > box.vertical:nth-child(2) > box.vertical.primary-toolbar:nth-child(1) > box:nth-child(1) > toolbar.horizontal:nth-child(1):backdrop {
+  background-color: #F2F2F2;
+}
+
+/********
+ * Meld *
+ ********/
+#meldapp.background.csd, #meldapp.background.csd > box.vertical:nth-child(3) > notebook.meld-notebook:nth-child(1) > stack:nth-child(2) {
+  background-color: #FFFFFF;
+}
+
+/*******************
+ * NVIDIA Settings *
+ *******************/
+window.background > box.vertical > paned.horizontal:nth-child(1) > box.horizontal:nth-child(3) > box.vertical:nth-child(1) > notebook.frame:nth-child(4) > stack:nth-child(2) > box.vertical > toolbar.horizontal:nth-child(1) {
+  background-color: #F2F2F2;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+/*****************************************************
+ * Cinnamon "System Settings > Keyboard > Shortcuts" *
+ *****************************************************/
+window.background > box.vertical:nth-child(2) > stack:nth-child(2) > scrolledwindow:nth-child(2) > viewport:nth-last-child(3) > box.vertical:nth-child(1) > stack:nth-child(1) > box.vertical:nth-child(2) > box.vertical:nth-child(1) > box.horizontal:nth-child(1) > paned.horizontal:nth-child(1) > separator.wide:nth-child(2) {
+  background-image: none;
 }
 
 /*********
@@ -8293,6 +8398,10 @@ window.background.csd.thunar scrolledwindow.frame.sidebar.shortcuts-pane {
   -NemoPlacesTreeView-disk-full-bar-radius: 0;
   -NemoPlacesTreeView-disk-full-bottom-padding: 1px;
   -NemoPlacesTreeView-disk-full-max-length: 80px;
+}
+
+.nemo-desktop-window {
+  opacity: 0;
 }
 
 /* GTK NAMED COLORS

--- a/src/gtk/3.0/gtk-Light.css
+++ b/src/gtk/3.0/gtk-Light.css
@@ -2408,11 +2408,15 @@ tabbox > tab:checked.reorderable-page, notebook > header tab:checked.reorderable
   background-color: #FFFFFF;
 }
 
-frame > paned > notebook > header, notebook.frame > header {
+frame notebook:not(.frame) {
+  background-color: #FFFFFF;
+}
+
+frame > paned > notebook.frame > header, notebook.frame > header {
   background-color: #FAFAFA;
 }
 
-notebook, notebook.frame {
+notebook.frame {
   background-color: #FFFFFF;
   border-radius: 2px;
 }
@@ -2424,6 +2428,10 @@ notebook.frame frame > border {
 
 notebook.frame frame > list row.activatable {
   border-radius: 2px;
+}
+
+notebook:not(.frame):nth-child(1) > stack:nth-child(2) {
+  background-color: #FFFFFF;
 }
 
 notebook:focus tab:checked {
@@ -3466,6 +3474,10 @@ actionbar > revealer > box {
   border-radius: 0 0 3px 3px;
 }
 
+scrolledwindow.frame {
+  background-color: #FFFFFF;
+}
+
 scrolledwindow viewport.frame {
   border: none;
 }
@@ -4344,53 +4356,66 @@ cursor-handle.insertion-cursor:dir(ltr), cursor-handle.insertion-cursor:dir(rtl)
 stackswitcher {
   min-height: 0;
   padding: 0 6px;
-  border-radius: 2px;
-  background-color: alpha(currentColor, 0.05);
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action) {
   margin: 0;
-  background-color: transparent;
+  background-color: alpha(rgba(0, 0, 0, 0.87), 0.05);
   background-image: none;
-  border: none;
   animation: none;
   box-shadow: none;
   transition: box-shadow 225ms cubic-bezier(0, 0, 0.2, 1);
-}
-
-stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action), stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):first-child, stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):last-child {
-  border-radius: 0;
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action).text-button {
   min-width: 100px;
 }
 
+stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):first-child {
+  border-left: 6px solid alpha(rgba(0, 0, 0, 0.87), 0.05);
+  border-top-left-radius: 2px;
+  border-bottom-left-radius: 2px;
+}
+
+stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):last-child {
+  border-right: 6px solid alpha(rgba(0, 0, 0, 0.87), 0.05);
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
+}
+
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):focus {
   box-shadow: inset 0 -2px alpha(currentColor, 0.08);
-  background-color: transparent;
   background-image: none;
+  background-color: alpha(rgba(0, 0, 0, 0.87), 0.05);
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):hover {
   box-shadow: inset 0 -2px alpha(currentColor, 0.3);
-  background-color: transparent;
   background-image: none;
+  background-color: alpha(rgba(0, 0, 0, 0.87), 0.05);
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):active {
   box-shadow: inset 0 -2px alpha(#1A73E8, 0.65);
-  background-color: transparent;
   background-image: none;
   transition: box-shadow 225ms cubic-bezier(0, 0, 0.2, 1);
+  background-color: alpha(rgba(0, 0, 0, 0.87), 0.05);
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):checked {
   box-shadow: inset 0 -2px #1A73E8;
-  background-color: transparent;
   background-image: none;
   color: rgba(0, 0, 0, 0.87);
   transition: box-shadow 225ms cubic-bezier(0, 0, 0.2, 1);
+  background-color: alpha(rgba(0, 0, 0, 0.87), 0.05);
+}
+
+stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):checked:first-child {
+  border-left: 6px solid transparent;
+}
+
+stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):checked:last-child {
+  border-right: 6px solid transparent;
 }
 
 stackswitcher button.text-button {
@@ -6458,6 +6483,19 @@ window.background:not(.csd) > window > menu menuitem {
   padding: 8px 4px;
 }
 
+#DialogNotebook > viewport.frame {
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 2px;
+}
+
+#DockedDialogNotebook button.close-button {
+  background-color: transparent;
+}
+
+#DockedDialogNotebook header {
+  background-color: #FAFAFA;
+}
+
 /***********
  * Synapse *
  ***********/
@@ -6509,16 +6547,18 @@ entry.search > window.background > frame > border {
 window.background:not(.solid-csd):not(.csd) > grid.horizontal > grid.horizontal {
   /*
     background-color: $titlebar;
-    box-shadow: inset 0 -1px $divider;*/
+    box-shadow: inset 0 -1px $divider;
+    */
+  /*
+    &:backdrop {
+      background-color: $titlebar-backdrop;
+    }
+    */
 }
 
 window.background:not(.solid-csd):not(.csd) > grid.horizontal > grid.horizontal > button.flat.small-button {
   border: none;
   border-radius: 9999px;
-}
-
-window.background:not(.solid-csd):not(.csd) > grid.horizontal > grid.horizontal:backdrop {
-  background-color: #F2F2F2;
 }
 
 window.background:not(.solid-csd):not(.csd) > notebook:not(.frame) {
@@ -6550,14 +6590,6 @@ window.background:not(.solid-csd):not(.csd) > notebook:not(.frame) > stack {
   color: white;
 }
 
-/************
- * DroidCam *
- ************/
-window.background > grid.horizontal > grid.horizontal {
-  box-shadow: none;
-  background-color: transparent;
-}
-
 /******************
  * SoundConverter *
  ******************/
@@ -6583,6 +6615,79 @@ frame > widget > box.vertical > notebook > stack {
  **********/
 box.dialog-vbox.vertical > box.horizontal > list {
   border-right: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+#lutris > stack:nth-child(2) > box.horizontal:nth-child(1) > box.vertical:nth-child(2) > revealer:nth-last-child(1) > box.horizontal {
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+/***********
+ * Brasero *
+ ***********/
+window.background > box.vertical:nth-child(2) > notebook:nth-child(2) > stack:nth-child(1) > box.vertical:nth-child(2) > paned.horizontal:nth-child(2) > box.vertical > box.vertical:nth-child(1) > notebook:nth-child(2) > stack:nth-child(1) > frame:nth-child(1) > widget:nth-child(2) {
+  background-color: #FFFFFF;
+}
+
+/*********
+ * Gpick *
+ *********/
+window.background > box.vertical:nth-child(2) > paned.horizontal:nth-child(2) > notebook.frame:nth-child(1) > stack:nth-child(2) > box.vertical:nth-child(3) > box.horizontal:nth-child(1) > widget:nth-child(1) > toolbar.horizontal:nth-child(1) {
+  background-color: transparent;
+}
+
+/***************
+ * Filechooser *
+ ***************/
+dialog > box > filechooser {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+/*******
+ * Xed *
+ *******/
+window.background.xed-window > overlay:nth-child(2) > box.vertical:nth-child(1) > box.horizontal.xed-searchbar:nth-child(4) {
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+/*****************
+ * GNOME Drawing *
+ *****************/
+window.background > box.vertical:nth-child(2) > box.vertical.primary-toolbar:nth-child(1) {
+  background-color: #F7F7F7;
+}
+
+window.background > box.vertical:nth-child(2) > box.vertical.primary-toolbar:nth-child(1):backdrop {
+  background-color: #F2F2F2;
+}
+
+window.background > box.vertical:nth-child(2) > box.vertical.primary-toolbar:nth-child(1) > box:nth-child(1) > toolbar.horizontal:nth-child(1) {
+  background-color: #F7F7F7;
+}
+
+window.background > box.vertical:nth-child(2) > box.vertical.primary-toolbar:nth-child(1) > box:nth-child(1) > toolbar.horizontal:nth-child(1):backdrop {
+  background-color: #F2F2F2;
+}
+
+/********
+ * Meld *
+ ********/
+#meldapp.background.csd, #meldapp.background.csd > box.vertical:nth-child(3) > notebook.meld-notebook:nth-child(1) > stack:nth-child(2) {
+  background-color: #FFFFFF;
+}
+
+/*******************
+ * NVIDIA Settings *
+ *******************/
+window.background > box.vertical > paned.horizontal:nth-child(1) > box.horizontal:nth-child(3) > box.vertical:nth-child(1) > notebook.frame:nth-child(4) > stack:nth-child(2) > box.vertical > toolbar.horizontal:nth-child(1) {
+  background-color: #F2F2F2;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+/*****************************************************
+ * Cinnamon "System Settings > Keyboard > Shortcuts" *
+ *****************************************************/
+window.background > box.vertical:nth-child(2) > stack:nth-child(2) > scrolledwindow:nth-child(2) > viewport:nth-last-child(3) > box.vertical:nth-child(1) > stack:nth-child(1) > box.vertical:nth-child(2) > box.vertical:nth-child(1) > box.horizontal:nth-child(1) > paned.horizontal:nth-child(1) > separator.wide:nth-child(2) {
+  background-image: none;
 }
 
 /*********
@@ -8293,6 +8398,10 @@ window.background.csd.thunar scrolledwindow.frame.sidebar.shortcuts-pane {
   -NemoPlacesTreeView-disk-full-bar-radius: 0;
   -NemoPlacesTreeView-disk-full-bottom-padding: 1px;
   -NemoPlacesTreeView-disk-full-max-length: 80px;
+}
+
+.nemo-desktop-window {
+  opacity: 0;
 }
 
 /* GTK NAMED COLORS

--- a/src/gtk/3.0/gtk-compact.css
+++ b/src/gtk/3.0/gtk-compact.css
@@ -2409,11 +2409,15 @@ tabbox > tab:checked.reorderable-page, notebook > header tab:checked.reorderable
   background-color: #FFFFFF;
 }
 
-frame > paned > notebook > header, notebook.frame > header {
+frame notebook:not(.frame) {
+  background-color: #FFFFFF;
+}
+
+frame > paned > notebook.frame > header, notebook.frame > header {
   background-color: #FAFAFA;
 }
 
-notebook, notebook.frame {
+notebook.frame {
   background-color: #FFFFFF;
   border-radius: 2px;
 }
@@ -2425,6 +2429,10 @@ notebook.frame frame > border {
 
 notebook.frame frame > list row.activatable {
   border-radius: 2px;
+}
+
+notebook:not(.frame):nth-child(1) > stack:nth-child(2) {
+  background-color: #FFFFFF;
 }
 
 notebook:focus tab:checked {
@@ -3467,6 +3475,10 @@ actionbar > revealer > box {
   border-radius: 0 0 3px 3px;
 }
 
+scrolledwindow.frame {
+  background-color: #FFFFFF;
+}
+
 scrolledwindow viewport.frame {
   border: none;
 }
@@ -4345,53 +4357,66 @@ cursor-handle.insertion-cursor:dir(ltr), cursor-handle.insertion-cursor:dir(rtl)
 stackswitcher {
   min-height: 0;
   padding: 0 4px;
-  border-radius: 2px;
-  background-color: alpha(currentColor, 0.05);
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action) {
   margin: 0;
-  background-color: transparent;
+  background-color: alpha(rgba(0, 0, 0, 0.87), 0.05);
   background-image: none;
-  border: none;
   animation: none;
   box-shadow: none;
   transition: box-shadow 225ms cubic-bezier(0, 0, 0.2, 1);
-}
-
-stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action), stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):first-child, stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):last-child {
-  border-radius: 0;
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action).text-button {
   min-width: 100px;
 }
 
+stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):first-child {
+  border-left: 4px solid alpha(rgba(0, 0, 0, 0.87), 0.05);
+  border-top-left-radius: 2px;
+  border-bottom-left-radius: 2px;
+}
+
+stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):last-child {
+  border-right: 4px solid alpha(rgba(0, 0, 0, 0.87), 0.05);
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
+}
+
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):focus {
   box-shadow: inset 0 -2px alpha(currentColor, 0.08);
-  background-color: transparent;
   background-image: none;
+  background-color: alpha(rgba(0, 0, 0, 0.87), 0.05);
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):hover {
   box-shadow: inset 0 -2px alpha(currentColor, 0.3);
-  background-color: transparent;
   background-image: none;
+  background-color: alpha(rgba(0, 0, 0, 0.87), 0.05);
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):active {
   box-shadow: inset 0 -2px alpha(#1A73E8, 0.65);
-  background-color: transparent;
   background-image: none;
   transition: box-shadow 225ms cubic-bezier(0, 0, 0.2, 1);
+  background-color: alpha(rgba(0, 0, 0, 0.87), 0.05);
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):checked {
   box-shadow: inset 0 -2px #1A73E8;
-  background-color: transparent;
   background-image: none;
   color: rgba(0, 0, 0, 0.87);
   transition: box-shadow 225ms cubic-bezier(0, 0, 0.2, 1);
+  background-color: alpha(rgba(0, 0, 0, 0.87), 0.05);
+}
+
+stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):checked:first-child {
+  border-left: 4px solid transparent;
+}
+
+stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):checked:last-child {
+  border-right: 4px solid transparent;
 }
 
 stackswitcher button.text-button {
@@ -6463,6 +6488,19 @@ window.background:not(.csd) > window > menu menuitem {
   padding: 8px 4px;
 }
 
+#DialogNotebook > viewport.frame {
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 2px;
+}
+
+#DockedDialogNotebook button.close-button {
+  background-color: transparent;
+}
+
+#DockedDialogNotebook header {
+  background-color: #FAFAFA;
+}
+
 /***********
  * Synapse *
  ***********/
@@ -6514,16 +6552,18 @@ entry.search > window.background > frame > border {
 window.background:not(.solid-csd):not(.csd) > grid.horizontal > grid.horizontal {
   /*
     background-color: $titlebar;
-    box-shadow: inset 0 -1px $divider;*/
+    box-shadow: inset 0 -1px $divider;
+    */
+  /*
+    &:backdrop {
+      background-color: $titlebar-backdrop;
+    }
+    */
 }
 
 window.background:not(.solid-csd):not(.csd) > grid.horizontal > grid.horizontal > button.flat.small-button {
   border: none;
   border-radius: 9999px;
-}
-
-window.background:not(.solid-csd):not(.csd) > grid.horizontal > grid.horizontal:backdrop {
-  background-color: #3c3c3c;
 }
 
 window.background:not(.solid-csd):not(.csd) > notebook:not(.frame) {
@@ -6555,14 +6595,6 @@ window.background:not(.solid-csd):not(.csd) > notebook:not(.frame) > stack {
   color: white;
 }
 
-/************
- * DroidCam *
- ************/
-window.background > grid.horizontal > grid.horizontal {
-  box-shadow: none;
-  background-color: transparent;
-}
-
 /******************
  * SoundConverter *
  ******************/
@@ -6588,6 +6620,79 @@ frame > widget > box.vertical > notebook > stack {
  **********/
 box.dialog-vbox.vertical > box.horizontal > list {
   border-right: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+#lutris > stack:nth-child(2) > box.horizontal:nth-child(1) > box.vertical:nth-child(2) > revealer:nth-last-child(1) > box.horizontal {
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+/***********
+ * Brasero *
+ ***********/
+window.background > box.vertical:nth-child(2) > notebook:nth-child(2) > stack:nth-child(1) > box.vertical:nth-child(2) > paned.horizontal:nth-child(2) > box.vertical > box.vertical:nth-child(1) > notebook:nth-child(2) > stack:nth-child(1) > frame:nth-child(1) > widget:nth-child(2) {
+  background-color: #FFFFFF;
+}
+
+/*********
+ * Gpick *
+ *********/
+window.background > box.vertical:nth-child(2) > paned.horizontal:nth-child(2) > notebook.frame:nth-child(1) > stack:nth-child(2) > box.vertical:nth-child(3) > box.horizontal:nth-child(1) > widget:nth-child(1) > toolbar.horizontal:nth-child(1) {
+  background-color: transparent;
+}
+
+/***************
+ * Filechooser *
+ ***************/
+dialog > box > filechooser {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+/*******
+ * Xed *
+ *******/
+window.background.xed-window > overlay:nth-child(2) > box.vertical:nth-child(1) > box.horizontal.xed-searchbar:nth-child(4) {
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+/*****************
+ * GNOME Drawing *
+ *****************/
+window.background > box.vertical:nth-child(2) > box.vertical.primary-toolbar:nth-child(1) {
+  background-color: #2C2C2C;
+}
+
+window.background > box.vertical:nth-child(2) > box.vertical.primary-toolbar:nth-child(1):backdrop {
+  background-color: #3c3c3c;
+}
+
+window.background > box.vertical:nth-child(2) > box.vertical.primary-toolbar:nth-child(1) > box:nth-child(1) > toolbar.horizontal:nth-child(1) {
+  background-color: #2C2C2C;
+}
+
+window.background > box.vertical:nth-child(2) > box.vertical.primary-toolbar:nth-child(1) > box:nth-child(1) > toolbar.horizontal:nth-child(1):backdrop {
+  background-color: #3c3c3c;
+}
+
+/********
+ * Meld *
+ ********/
+#meldapp.background.csd, #meldapp.background.csd > box.vertical:nth-child(3) > notebook.meld-notebook:nth-child(1) > stack:nth-child(2) {
+  background-color: #FFFFFF;
+}
+
+/*******************
+ * NVIDIA Settings *
+ *******************/
+window.background > box.vertical > paned.horizontal:nth-child(1) > box.horizontal:nth-child(3) > box.vertical:nth-child(1) > notebook.frame:nth-child(4) > stack:nth-child(2) > box.vertical > toolbar.horizontal:nth-child(1) {
+  background-color: #3c3c3c;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+/*****************************************************
+ * Cinnamon "System Settings > Keyboard > Shortcuts" *
+ *****************************************************/
+window.background > box.vertical:nth-child(2) > stack:nth-child(2) > scrolledwindow:nth-child(2) > viewport:nth-last-child(3) > box.vertical:nth-child(1) > stack:nth-child(1) > box.vertical:nth-child(2) > box.vertical:nth-child(1) > box.horizontal:nth-child(1) > paned.horizontal:nth-child(1) > separator.wide:nth-child(2) {
+  background-image: none;
 }
 
 /*********
@@ -8310,6 +8415,10 @@ window.background.csd.thunar scrolledwindow.frame.sidebar.shortcuts-pane {
   -NemoPlacesTreeView-disk-full-bar-radius: 0;
   -NemoPlacesTreeView-disk-full-bottom-padding: 1px;
   -NemoPlacesTreeView-disk-full-max-length: 80px;
+}
+
+.nemo-desktop-window {
+  opacity: 0;
 }
 
 /* GTK NAMED COLORS

--- a/src/gtk/3.0/gtk.css
+++ b/src/gtk/3.0/gtk.css
@@ -2409,11 +2409,15 @@ tabbox > tab:checked.reorderable-page, notebook > header tab:checked.reorderable
   background-color: #FFFFFF;
 }
 
-frame > paned > notebook > header, notebook.frame > header {
+frame notebook:not(.frame) {
+  background-color: #FFFFFF;
+}
+
+frame > paned > notebook.frame > header, notebook.frame > header {
   background-color: #FAFAFA;
 }
 
-notebook, notebook.frame {
+notebook.frame {
   background-color: #FFFFFF;
   border-radius: 2px;
 }
@@ -2425,6 +2429,10 @@ notebook.frame frame > border {
 
 notebook.frame frame > list row.activatable {
   border-radius: 2px;
+}
+
+notebook:not(.frame):nth-child(1) > stack:nth-child(2) {
+  background-color: #FFFFFF;
 }
 
 notebook:focus tab:checked {
@@ -3467,6 +3475,10 @@ actionbar > revealer > box {
   border-radius: 0 0 3px 3px;
 }
 
+scrolledwindow.frame {
+  background-color: #FFFFFF;
+}
+
 scrolledwindow viewport.frame {
   border: none;
 }
@@ -4345,53 +4357,66 @@ cursor-handle.insertion-cursor:dir(ltr), cursor-handle.insertion-cursor:dir(rtl)
 stackswitcher {
   min-height: 0;
   padding: 0 6px;
-  border-radius: 2px;
-  background-color: alpha(currentColor, 0.05);
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action) {
   margin: 0;
-  background-color: transparent;
+  background-color: alpha(rgba(0, 0, 0, 0.87), 0.05);
   background-image: none;
-  border: none;
   animation: none;
   box-shadow: none;
   transition: box-shadow 225ms cubic-bezier(0, 0, 0.2, 1);
-}
-
-stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action), stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):first-child, stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):last-child {
-  border-radius: 0;
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action).text-button {
   min-width: 100px;
 }
 
+stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):first-child {
+  border-left: 6px solid alpha(rgba(0, 0, 0, 0.87), 0.05);
+  border-top-left-radius: 2px;
+  border-bottom-left-radius: 2px;
+}
+
+stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):last-child {
+  border-right: 6px solid alpha(rgba(0, 0, 0, 0.87), 0.05);
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
+}
+
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):focus {
   box-shadow: inset 0 -2px alpha(currentColor, 0.08);
-  background-color: transparent;
   background-image: none;
+  background-color: alpha(rgba(0, 0, 0, 0.87), 0.05);
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):hover {
   box-shadow: inset 0 -2px alpha(currentColor, 0.3);
-  background-color: transparent;
   background-image: none;
+  background-color: alpha(rgba(0, 0, 0, 0.87), 0.05);
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):active {
   box-shadow: inset 0 -2px alpha(#1A73E8, 0.65);
-  background-color: transparent;
   background-image: none;
   transition: box-shadow 225ms cubic-bezier(0, 0, 0.2, 1);
+  background-color: alpha(rgba(0, 0, 0, 0.87), 0.05);
 }
 
 stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):checked {
   box-shadow: inset 0 -2px #1A73E8;
-  background-color: transparent;
   background-image: none;
   color: rgba(0, 0, 0, 0.87);
   transition: box-shadow 225ms cubic-bezier(0, 0, 0.2, 1);
+  background-color: alpha(rgba(0, 0, 0, 0.87), 0.05);
+}
+
+stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):checked:first-child {
+  border-left: 6px solid transparent;
+}
+
+stackswitcher.linked:not(.vertical) > button:not(.suggested-action):not(.destructive-action):checked:last-child {
+  border-right: 6px solid transparent;
 }
 
 stackswitcher button.text-button {
@@ -6463,6 +6488,19 @@ window.background:not(.csd) > window > menu menuitem {
   padding: 8px 4px;
 }
 
+#DialogNotebook > viewport.frame {
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 2px;
+}
+
+#DockedDialogNotebook button.close-button {
+  background-color: transparent;
+}
+
+#DockedDialogNotebook header {
+  background-color: #FAFAFA;
+}
+
 /***********
  * Synapse *
  ***********/
@@ -6514,16 +6552,18 @@ entry.search > window.background > frame > border {
 window.background:not(.solid-csd):not(.csd) > grid.horizontal > grid.horizontal {
   /*
     background-color: $titlebar;
-    box-shadow: inset 0 -1px $divider;*/
+    box-shadow: inset 0 -1px $divider;
+    */
+  /*
+    &:backdrop {
+      background-color: $titlebar-backdrop;
+    }
+    */
 }
 
 window.background:not(.solid-csd):not(.csd) > grid.horizontal > grid.horizontal > button.flat.small-button {
   border: none;
   border-radius: 9999px;
-}
-
-window.background:not(.solid-csd):not(.csd) > grid.horizontal > grid.horizontal:backdrop {
-  background-color: #3c3c3c;
 }
 
 window.background:not(.solid-csd):not(.csd) > notebook:not(.frame) {
@@ -6555,14 +6595,6 @@ window.background:not(.solid-csd):not(.csd) > notebook:not(.frame) > stack {
   color: white;
 }
 
-/************
- * DroidCam *
- ************/
-window.background > grid.horizontal > grid.horizontal {
-  box-shadow: none;
-  background-color: transparent;
-}
-
 /******************
  * SoundConverter *
  ******************/
@@ -6588,6 +6620,79 @@ frame > widget > box.vertical > notebook > stack {
  **********/
 box.dialog-vbox.vertical > box.horizontal > list {
   border-right: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+#lutris > stack:nth-child(2) > box.horizontal:nth-child(1) > box.vertical:nth-child(2) > revealer:nth-last-child(1) > box.horizontal {
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+/***********
+ * Brasero *
+ ***********/
+window.background > box.vertical:nth-child(2) > notebook:nth-child(2) > stack:nth-child(1) > box.vertical:nth-child(2) > paned.horizontal:nth-child(2) > box.vertical > box.vertical:nth-child(1) > notebook:nth-child(2) > stack:nth-child(1) > frame:nth-child(1) > widget:nth-child(2) {
+  background-color: #FFFFFF;
+}
+
+/*********
+ * Gpick *
+ *********/
+window.background > box.vertical:nth-child(2) > paned.horizontal:nth-child(2) > notebook.frame:nth-child(1) > stack:nth-child(2) > box.vertical:nth-child(3) > box.horizontal:nth-child(1) > widget:nth-child(1) > toolbar.horizontal:nth-child(1) {
+  background-color: transparent;
+}
+
+/***************
+ * Filechooser *
+ ***************/
+dialog > box > filechooser {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+/*******
+ * Xed *
+ *******/
+window.background.xed-window > overlay:nth-child(2) > box.vertical:nth-child(1) > box.horizontal.xed-searchbar:nth-child(4) {
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+/*****************
+ * GNOME Drawing *
+ *****************/
+window.background > box.vertical:nth-child(2) > box.vertical.primary-toolbar:nth-child(1) {
+  background-color: #2C2C2C;
+}
+
+window.background > box.vertical:nth-child(2) > box.vertical.primary-toolbar:nth-child(1):backdrop {
+  background-color: #3c3c3c;
+}
+
+window.background > box.vertical:nth-child(2) > box.vertical.primary-toolbar:nth-child(1) > box:nth-child(1) > toolbar.horizontal:nth-child(1) {
+  background-color: #2C2C2C;
+}
+
+window.background > box.vertical:nth-child(2) > box.vertical.primary-toolbar:nth-child(1) > box:nth-child(1) > toolbar.horizontal:nth-child(1):backdrop {
+  background-color: #3c3c3c;
+}
+
+/********
+ * Meld *
+ ********/
+#meldapp.background.csd, #meldapp.background.csd > box.vertical:nth-child(3) > notebook.meld-notebook:nth-child(1) > stack:nth-child(2) {
+  background-color: #FFFFFF;
+}
+
+/*******************
+ * NVIDIA Settings *
+ *******************/
+window.background > box.vertical > paned.horizontal:nth-child(1) > box.horizontal:nth-child(3) > box.vertical:nth-child(1) > notebook.frame:nth-child(4) > stack:nth-child(2) > box.vertical > toolbar.horizontal:nth-child(1) {
+  background-color: #3c3c3c;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+/*****************************************************
+ * Cinnamon "System Settings > Keyboard > Shortcuts" *
+ *****************************************************/
+window.background > box.vertical:nth-child(2) > stack:nth-child(2) > scrolledwindow:nth-child(2) > viewport:nth-last-child(3) > box.vertical:nth-child(1) > stack:nth-child(1) > box.vertical:nth-child(2) > box.vertical:nth-child(1) > box.horizontal:nth-child(1) > paned.horizontal:nth-child(1) > separator.wide:nth-child(2) {
+  background-image: none;
 }
 
 /*********
@@ -8310,6 +8415,10 @@ window.background.csd.thunar scrolledwindow.frame.sidebar.shortcuts-pane {
   -NemoPlacesTreeView-disk-full-bar-radius: 0;
   -NemoPlacesTreeView-disk-full-bottom-padding: 1px;
   -NemoPlacesTreeView-disk-full-max-length: 80px;
+}
+
+.nemo-desktop-window {
+  opacity: 0;
 }
 
 /* GTK NAMED COLORS


### PR DESCRIPTION
1.  `notebook` used `$base` color on top of background (elements with `$background` color) even if there was no frame. This issue noticeable in gThumb's settings window, in Cinnamon's network settings and everywhere where `notebook` is used without frame. Also, I've set `$base` color for `scrolledwindow`, because it was just transparent, and that was not noticeable because of `$base` color of `notebook`, on top of which `scrolledwindow` is often placed.
2. Reworked `stackswitcher` theming, now it is transparent and I achieved exactly the same decorations just by theming buttons there, including rounded left and right borders (for first and last childs respectively). I think this is needed only ~~because of~~ for Cinnamon, because this issue is not noticeable anywhere except in "System Settings > Thunderbolt" and in dialog windows with applets settings. No idea why they decided to put blank stackswitchers there, but now those are not visible if there is no any button. P.S.: using `$text` color instead of `currentColor` is necessary in this case to prevent overlapping of alpha channels.
3. On Cinnamon desktop, in case theme's CSS is placed under `~/.config/gtk-3.0`, wallpaper just becomes overlapped with `$background` color, so I've made `.nemo-desktop-window` transparent.
4. Removed no longer needed fix for DroidCam. Issue was caused by tweaks aimed at LibreOffice, but those do not seem to change anything there, so I commented following:
```scss
    // FIXME: Breaks DroidCam style and does not change anything in LibreOffice
    /*
    background-color: $titlebar;
    box-shadow: inset 0 -1px $divider;*/
    box-shadow: inset 0 -1px $divider;
    */

    > button.flat.small-button {
      // 'close' button
      border: none;
      border-radius: $circular-radius;
    }

    // FIXME: Breaks DroidCam style and does not change anything in LibreOffice
    /*
    &:backdrop {
      background-color: $titlebar-backdrop;
    }
    */
```
5. Fixed missing bottom border in file chooser window if there is no expected file extension.
6. Fixed issue with Cinnamon "System Settings > Keyboard > Shortcuts", there was displayed ugly separator with right and left borders between "Categories" and "Keyboard shortcuts"+"Keyboard bindings" (last one under first one) pages (`viewport.frame`'s).
7. Added tweaks for Gpick, Xed, GNOME Drawing, NVIDIA Settings and Lutris (another one) to make those look better. Fixes for Brasero and Meld do not work at all, except cases when those are specified as overrides in GTK Inspector or in case theme's CSS is placed under `~/.config/gtk-3.0`. No idea why that happens, but I've kept these fixes in `_misc.css` just in case.

With all these changes, I did not notice any regression **on my system**, in `gtk3-widget-factory` everything is fine too.

UPD: Settings window in SoundConverter is still affected, added workaround for it back (force push).