### PR TITLE
Match ArcMenu hover with Dash to Panel

### DIFF
--- a/src/gnome-shell/sass/_extensions-40-0.scss
+++ b/src/gnome-shell/sass/_extensions-40-0.scss
@@ -342,6 +342,23 @@
   }
 
   .panel-button { color: $panel_secondary_fg_color !important; }
+
+  @if $panel_style == 'compact' {
+    &#panel .arcmenu-panel-menu.panel-button {
+      border: none !important;
+      border-radius: 0 !important;
+      box-shadow: none !important;
+      margin: 0 !important;
+
+      // Match Dash to Panel's .dtp-container interaction states in both
+      // light and dark shell variants.
+      &:hover,
+      &:focus { background-color: rgba(238, 238, 236, 0.1) !important; }
+
+      &:active,
+      &:checked { background-color: rgba(238, 238, 236, 0.18) !important; }
+    }
+  }
 }
 
 //

--- a/src/gnome-shell/sass/_extensions-46-0.scss
+++ b/src/gnome-shell/sass/_extensions-46-0.scss
@@ -361,6 +361,23 @@
   }
 
   .panel-button { color: $panel_secondary_fg_color !important; }
+
+  @if $panel_style == 'compact' {
+    &#panel .arcmenu-panel-menu.panel-button {
+      border: none !important;
+      border-radius: 0 !important;
+      box-shadow: none !important;
+      margin: 0 !important;
+
+      // Match Dash to Panel's .dtp-container interaction states in both
+      // light and dark shell variants.
+      &:hover,
+      &:focus { background-color: rgba(238, 238, 236, 0.1) !important; }
+
+      &:active,
+      &:checked { background-color: rgba(238, 238, 236, 0.18) !important; }
+    }
+  }
 }
 
 //


### PR DESCRIPTION
Remove ArcMenu's rounded panel-button treatment on compact Dash to Panel layouts and reuse Dash to Panel's hover and active colors across light and dark shell variants. Preserve floating panel styling.